### PR TITLE
BI-2039: Use new cluster for atlas connect tests

### DIFF
--- a/mongodb-odbc-driver/bin/run-atlas-integration-tests.sh
+++ b/mongodb-odbc-driver/bin/run-atlas-integration-tests.sh
@@ -17,7 +17,7 @@
             platform="32-bit"
         fi
 
-        echo 'running atlas prod connection tests...'
+        echo 'running atlas connection tests...'
 
         # 32-bit powershell is configured to disallow scripts by default.
         # This invocation allows us to temporarily bypass that restriction.
@@ -36,30 +36,12 @@
             -Password "$BIC_PROD_PASSWORD" \
             -Version $(< "$SCRIPT_DIR/VERSION.txt")
 
-        echo 'running atlas dev connection tests...'
-
-        "$POWERSHELL" \
-            -ExecutionPolicy ByPass \
-            -NoProfile \
-            -NoLogo \
-            -NonInteractive \
-            -File "$SCRIPT_DIR/run-windows-integration-tests.ps1" \
-            -Atlas \
-            -Platform "$platform" \
-            -Server "$BIC_DEV_SERVER" \
-            -Port "${BIC_DEV_PORT:-27015}" \
-            -User "$BIC_DEV_USER" \
-            -Password "$BIC_DEV_PASSWORD" \
-            -Version $(< VERSION.txt)
-
-        echo 'integration tests passed'
-
     elif [ "macos" = "$PLATFORM" ]; then
         if ! hash iodbctestw &> /dev/null; then
             echo 'building iODBC'
             "$SCRIPT_DIR"/build-iodbc.sh
         fi
-        echo 'running atlas prod connection tests...'
+        echo 'running atlas connection tests...'
 
         "$SCRIPT_DIR"/run-unix-integration-tests.sh \
             "iodbctestw" \
@@ -69,24 +51,13 @@
             "$BIC_PROD_PORT" \
             "$BIC_PROD_USER" \
             "$BIC_PROD_PASSWORD"
-
-        echo 'running atlas dev connection tests...'
-
-        "$SCRIPT_DIR"/run-unix-integration-tests.sh \
-            "iodbctestw" \
-            "DSN=" \
-            "atlas" \
-            "$BIC_DEV_SERVER" \
-            "$BIC_DEV_PORT" \
-            "$BIC_DEV_USER" \
-            "$BIC_DEV_PASSWORD"
     else
         iusql_bin="$BUILD_DIR"/install/bin/iusql
         if [ ! -f "$iusql_bin" ]; then
             echo 'building unixODBC'
             "$SCRIPT_DIR"/build-unixodbc.sh
         fi
-        echo 'running atlas prod connection tests...'
+        echo 'running atlas connection tests...'
 
         "$SCRIPT_DIR"/run-unix-integration-tests.sh \
             "$iusql_bin" \
@@ -96,17 +67,6 @@
             "$BIC_PROD_PORT" \
             "$BIC_PROD_USER" \
             "$BIC_PROD_PASSWORD"
-
-        echo 'running atlas dev connection tests...'
-
-        "$SCRIPT_DIR"/run-unix-integration-tests.sh \
-            "$iusql_bin" \
-            "" \
-            "atlas" \
-            "$BIC_DEV_SERVER" \
-            "$BIC_DEV_PORT" \
-            "$BIC_DEV_USER" \
-            "$BIC_DEV_PASSWORD"
     fi
 ) > $LOG_FILE 2>&1
 

--- a/mongodb-odbc-driver/bin/run-atlas-integration-tests.sh
+++ b/mongodb-odbc-driver/bin/run-atlas-integration-tests.sh
@@ -34,7 +34,7 @@
             -Port "${BIC_PROD_PORT:-27015}" \
             -User "$BIC_PROD_USER" \
             -Password "$BIC_PROD_PASSWORD" \
-            -Version $(< VERSION.txt)
+            -Version $(< "$SCRIPT_DIR/VERSION.txt")
 
         echo 'running atlas dev connection tests...'
 

--- a/mongodb-odbc-driver/bin/run-local-integration-tests.sh
+++ b/mongodb-odbc-driver/bin/run-local-integration-tests.sh
@@ -39,7 +39,7 @@
             -Port '3307' \
             -User 'user_not_used' \
             -Password 'password_not_used' \
-            -Version $(< VERSION.txt) \
+            -Version $(< "$SCRIPT_DIR/VERSION.txt") \
             -DB 'information_schema'
 
         echo 'integration tests passed'

--- a/mongodb-odbc-driver/bin/run-unix-integration-tests.sh
+++ b/mongodb-odbc-driver/bin/run-unix-integration-tests.sh
@@ -14,7 +14,7 @@ BIC_PORT="$2";
 BIC_USER="$3";
 BIC_PASSWORD="$4";
 
-db=H1B-Visa-Applications
+db=test
 if [ "$CASE" = "local" ]; then
 db=information_schema
 fi
@@ -56,9 +56,7 @@ EOS
 
 function test_connect_success {
     testname=$1; shift
-    query="select agent_attorney_city\
-          from year2015\
-          where _id = '572cbdd9d2fc210e7ce696ec'"
+    query="select message from greeting where _id = '5c64a48d1c9d44000046008d'"
     if [ "$CASE" = "local" ]; then
         query="select CATALOG_NAME from\
             information_schema.schemata\
@@ -70,9 +68,7 @@ function test_connect_success {
 	set +o errexit
         out="$(echo "$query" | "$TEST_BIN" "$BIN_ARG_PREFIX""$dsn")"
 	set -o errexit
-        # idodbctest has poorly formatted output, just check to make
-        # sure that the attorney city of AUSTIN is present for this _id.
-        if [ "$CASE" = "atlas" ] && [[ $out = *"MINNEAPOLIS"* ]]; then
+        if [ "$CASE" = "atlas" ] && [[ $out = *"Hello, world!"* ]]; then
             continue
         elif [ "$CASE" = "local" ] && [[ $out = *"def"* ]]; then
             continue
@@ -95,9 +91,7 @@ function test_connect_failure {
     # Thus, checking for specific errors
     # like on Windows is not possible. This is only a problem with iodbctest,
     # but we do not have another means to test this.
-    query="select _id\
-          from year2015\
-          where _id = '572cbdd9d2fc210e7ce696ec'"
+    query="select message from greeting where _id = '5c64a48d1c9d44000046008d'"
     if [ "$CASE" = "local" ]; then
         query="select CATALOG_NAME from\
             information_schema.schemata\

--- a/mongodb-odbc-driver/bin/run-windows-integration-tests.ps1
+++ b/mongodb-odbc-driver/bin/run-windows-integration-tests.ps1
@@ -16,7 +16,7 @@
    [switch]$Local,
    [switch]$LocalSSL,
    [string]$Version,
-   [string]$DB = 'H1B-Visa-Applications'
+   [string]$DB = 'test'
  )
 
 Set-strictmode -version latest
@@ -129,19 +129,13 @@ function Test-Query {
        [string]$Dsn
     )
     if ($Atlas) {
-        $query = "select * from year2015 where _id = '572cbdd9d2fc210e7ce696ec'"
+        $query = "select * from greeting where _id = '5c64a48d1c9d44000046008d'"
         $ds = Query-ODBC -Dsn $Dsn -Query $query
-        if ($ds._id -ne "572cbdd9d2fc210e7ce696ec") {
-               throw "Data not as expected, got _id: $($ds._id), expected '572cbdd9d2fc210e7ce696ec'"
+        if ($ds._id -ne "5c64a48d1c9d44000046008d") {
+               throw "Data not as expected, got _id: $($ds._id), expected '5c64a48d1c9d44000046008d'"
         }
-        if ( $ds.agent_attorney_city -ne "MINNEAPOLIS" ) {
-               throw "Data not as expected, got agent_attorney_city: $($ds.agent_attorney_city), expected 'MINNEAPOLIS'"
-        }
-        if ( $ds.agent_attorney_state  -ne "MN" ) {
-               throw "Data not as expected, got agent_attorney_state: $($ds.agent_attorney_state), expected 'MN'"
-        }
-        if ( $ds.job_title -ne "MECHANICAL ENGINEER") {
-               throw "Data not as expected, got job_title: $($ds.job_title), expected 'MECHANICAL ENGINEER'"
+        if ( $ds.message -ne "Hello, world!" ) {
+               throw "Data not as expected, got message: $($ds.message), expected 'Hello, world!'"
         }
     } else {
         $query = "select * from information_schema.schemata where schema_name = 'mysql'"


### PR DESCRIPTION
This is a fairly straightforward update, similar to the one just made in 10gen/sqlproxy. Most of the variables were changed in the evg project config.

This patch also fixes atlas connection tests that were failing on windows due to an incorrect invocation.