### PR TITLE
BI-2537: rewrite dep in libssl

### DIFF
--- a/mongodb-odbc-driver/bin/create-dmg.sh
+++ b/mongodb-odbc-driver/bin/create-dmg.sh
@@ -26,6 +26,8 @@
     cp "$BREW_OPENSSL_PATH/libssl.1.0.0.dylib"  ./
     cp "$BREW_OPENSSL_PATH/libcrypto.1.0.0.dylib"  ./
 
+    install_name_tool -change "$BREW_OPENSSL_PATH/libcrypto.1.0.0.dylib" "@loader_path/libcrypto.1.0.0.dylib" ./libssl.1.0.0.dylib
+
     sh ./build-dmg.sh
 
     # clear PKG_DIR


### PR DESCRIPTION
This appears to be all the change we need. I tested this pretty extensively with tableau to make sure none of my installed ssl were being used be accident, like what was happening before, by renaming them.