### PR TITLE
BI-2636: Use newer macos distro for signing

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -79,7 +79,7 @@ buildvariants:
       - name: "integration_tests_atlas"
       - name: "integration_tests_local"
       - name: "sign_dmg"
-        run_on: osx-1010-compass
+        run_on: macos-1014-codesign
 
 tasks:
   - name: "build"


### PR DESCRIPTION
Patch with passing macos sign task: https://spruce.mongodb.com/task/mongo_odbc_driver_macos_sign_dmg_patch_c6e5a27c4390b9f64c3ee49c588325bbb0c70754_60da09fc32f41738eec06686_21_06_28_17_45_18/files?execution=0