### PR TITLE
SQL-619: Add sanitizer tests

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -118,6 +118,48 @@ functions:
           ${prepare_shell}
           cargo test
 
+  "install unix odbc":
+    - command: shell.exec
+      type: system
+      params:
+        shell: bash
+        working_dir: mongo-odbc-driver
+        script: |
+          ${prepare_shell}
+          dir="$PWD"
+          mkdir -p unixodbc/install
+          cd unixodbc
+          echo "downloading unixODBC"
+          unixODBC_dir=unixODBC-2.3.6
+          curl -O "http://noexpire.s3.amazonaws.com/sqlproxy/binary/linux/unixODBC-2.3.6.tar.gz" \
+            --silent \
+            --fail \
+            --max-time 60 \
+            --retry 5 \
+            --retry-delay 0
+          tar xf "$unixODBC_dir.tar.gz"
+          cd "$unixODBC_dir"
+          ./configure --prefix="$dir/unixodbc/install" --with-pic
+          make
+          make install
+
+
+  "run asan tests":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongo-odbc-driver
+        script: |
+          ${prepare_shell}
+          dir="$PWD"
+          ~/.cargo/bin/rustup default nightly
+          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
+          export LD_LIBRARY_PATH="$dir/unixodbc/install/lib"
+          export LIBRARY_PATH="$dir/unixodbc/install/lib"
+          export RUSTFLAGS="-Z sanitizer=address"
+          cargo test --target x86_64-unknown-linux-gnu
+
 pre:
   - func: "fetch source"
   - func: "generate expansions"
@@ -144,6 +186,12 @@ tasks:
       - func: "install rust toolchain"
       - func: "run rust tests"
 
+  - name: asan
+    commands:
+      - func: "install rust toolchain"
+      - func: "install unix odbc"
+      - func: "run asan tests"
+
 buildvariants:
 
   - name: static-analysis
@@ -166,3 +214,9 @@ buildvariants:
     tasks:
       - name: compile
       - name: test-rust
+
+  - name: ubuntu1804
+    display_name: Ubuntu Sanitizers
+    run_on: [ ubuntu1804-test ]
+    tasks:
+      - name: asan

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -41,6 +41,7 @@ functions:
             set -o errexit
             export PATH="$PATH"
             export CARGO_NET_GIT_FETCH_WITH_CLI="$CARGO_NET_GIT_FETCH_WITH_CLI"
+            export UNIX_ODBC_PATH="$PWD/unixodbc/install"
             git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
           EOT
     - command: expansions.update
@@ -126,8 +127,7 @@ functions:
         working_dir: mongo-odbc-driver
         script: |
           ${prepare_shell}
-          dir="$PWD"
-          mkdir -p unixodbc/install
+          mkdir -p "$UNIX_ODBC_PATH"
           cd unixodbc
           echo "downloading unixODBC"
           unixODBC_dir=unixODBC-2.3.6
@@ -139,7 +139,7 @@ functions:
             --retry-delay 0
           tar xf "$unixODBC_dir.tar.gz"
           cd "$unixODBC_dir"
-          ./configure --prefix="$dir/unixodbc/install" --with-pic
+          ./configure --prefix="$UNIX_ODBC_PATH" --with-pic
           make
           make install
 
@@ -152,11 +152,10 @@ functions:
         working_dir: mongo-odbc-driver
         script: |
           ${prepare_shell}
-          dir="$PWD"
           ~/.cargo/bin/rustup default nightly
           ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
-          export LD_LIBRARY_PATH="$dir/unixodbc/install/lib"
-          export LIBRARY_PATH="$dir/unixodbc/install/lib"
+          export LD_LIBRARY_PATH="$UNIX_ODBC_PATH/lib"
+          export LIBRARY_PATH="$UNIX_ODBC_PATH/lib"
           export RUSTFLAGS="-Z sanitizer=address"
           cargo test --target x86_64-unknown-linux-gnu
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -215,8 +215,8 @@ buildvariants:
       - name: compile
       - name: test-rust
 
-  - name: ubuntu1804
-    display_name: Ubuntu Sanitizers
-    run_on: [ ubuntu1804-test ]
+  - name: ubuntu2004
+    display_name: Ubuntu 20.04
+    run_on: [ ubuntu2004-large ]
     tasks:
       - name: asan


### PR DESCRIPTION
This is based off SQL-616 Because I needed code to test. It won't be merged until 616 is merged, so that we can have a clean gitlog. So the only changes that matter here are in evergreen.yml