### PR TITLE
SQL-990: Properly handle the ODBC URI format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1074,7 @@ dependencies = [
  "num-traits",
  "odbc-api",
  "odbc-sys",
+ "regex",
  "serde",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -1509,6 +1519,23 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "resolv-conf"

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -15,6 +15,7 @@ chrono = "0.4.11"
 lazy_static = "1.4.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
+regex = "1.6.0"
 constants = { path = "../constants" }
 mongo-odbc-core = { path = "../core" }
 

--- a/odbc/src/api/driver_connect_tests.rs
+++ b/odbc/src/api/driver_connect_tests.rs
@@ -94,7 +94,7 @@ mod unit {
             driver_completion = DriverConnectOption::NoPrompt,
             expected_sql_state = UNABLE_TO_CONNECT,
             expected_sql_return = SqlReturn::ERROR,
-            expected_error_message = "[MongoDB][API] Invalid Uri: One of [\"user\", \"uid\"] is required for a valid Mongo ODBC Uri"
+            expected_error_message = "[MongoDB][API] Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri"
         );
     test_connection_diagnostics! (
             missing_pwd_in_connection_string,
@@ -102,7 +102,7 @@ mod unit {
             driver_completion = DriverConnectOption::NoPrompt,
             expected_sql_state = UNABLE_TO_CONNECT,
             expected_sql_return = SqlReturn::ERROR,
-            expected_error_message = "[MongoDB][API] Invalid Uri: One of [\"pwd\", \"password\"] is required for a valid Mongo ODBC Uri"
+            expected_error_message = "[MongoDB][API] Invalid Uri: One of [\"password\", \"pwd\"] is required for a valid Mongo ODBC Uri"
         );
     test_connection_diagnostics!(
         missing_driver_in_connection_string,

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -36,7 +36,7 @@ pub struct ODBCUri<'a>(HashMap<String, &'a str>);
 impl<'a> ODBCUri<'a> {
     pub fn new(odbc_uri: &'a str) -> Result<ODBCUri<'a>> {
         if odbc_uri.is_empty() {
-            return Err(ODBCError::InvalidUriFormat(NOT_EMPTY_ERROR.to_string()));
+            return Err(ODBCError::InvalidUriFormat(EMPTY_URI_ERROR.to_string()));
         }
         let mut input = odbc_uri;
         let mut ret = ODBCUri(HashMap::new());

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -90,7 +90,9 @@ impl<'a> ODBCUri<'a> {
             })?);
         match rest.len() {
             0 => unreachable!(),
+            // Just the "}" remaining
             1 => return Ok((value, None)),
+            // Just "};" remaining
             2 if rest.chars().nth(1).unwrap() == ';' => return Ok((value, None)),
             _ => (),
         }

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -42,10 +42,9 @@ impl<'a> ODBCUri<'a> {
         let mut ret = ODBCUri(HashMap::new());
         while let Some((keyword, value, rest)) = ODBCUri::get_next_attribute(input)? {
             // if attributes are repeated, the first is the one that is kept.
-            if ret.0.contains_key(&keyword) {
-                continue;
+            if !ret.0.contains_key(&keyword) {
+                ret.0.insert(keyword, value);
             }
-            ret.0.insert(keyword, value);
             if rest.is_none() {
                 return Ok(ret);
             }
@@ -372,6 +371,18 @@ mod unit {
             let expected =
                 ODBCUri(map! {"driver".to_string() => "Foo", "server".to_string() => "bAr"});
             assert_eq!(expected, ODBCUri::new("Driver=Foo;SERVER=bAr").unwrap());
+        }
+
+        #[test]
+        fn repeated_attribute_selects_first() {
+            use crate::map;
+            use crate::odbc_uri::ODBCUri;
+            let expected =
+                ODBCUri(map! {"driver".to_string() => "Foo", "server".to_string() => "bAr"});
+            assert_eq!(
+                expected,
+                ODBCUri::new("Driver=Foo;SERVER=bAr;Driver=F").unwrap()
+            );
         }
 
         #[test]

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -42,9 +42,7 @@ impl<'a> ODBCUri<'a> {
         let mut ret = ODBCUri(HashMap::new());
         while let Some((keyword, value, rest)) = ODBCUri::get_next_attribute(input)? {
             // if attributes are repeated, the first is the one that is kept.
-            if !ret.0.contains_key(&keyword) {
-                ret.0.insert(keyword, value);
-            }
+            ret.0.entry(keyword).or_insert(value);
             if rest.is_none() {
                 return Ok(ret);
             }

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -41,9 +41,6 @@ impl<'a> ODBCUri<'a> {
         let mut input = odbc_uri;
         let mut ret = ODBCUri(HashMap::new());
         while let Some((keyword, value, rest)) = ODBCUri::get_next_attribute(input)? {
-            if keyword.is_empty() {
-                return Ok(ret);
-            }
             ret.0.insert(keyword, value);
             if rest.is_none() {
                 return Ok(ret);

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -91,7 +91,6 @@ impl<'a> ODBCUri<'a> {
             input.split_at(input.find('}').ok_or_else(|| {
                 ODBCError::InvalidUriFormat(MISSING_CLOSING_BRACE_ERROR.to_string())
             })?);
-        println!("\t{}\n\t{}", value, rest);
         match rest.len() {
             0 => unreachable!(),
             1 => return Ok((value, None)),

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -4,7 +4,7 @@ use regex::{RegexSet, RegexSetBuilder};
 use std::collections::HashMap;
 
 const EMPTY_URI_ERROR: &str = "URI must not be empty";
-const EQUAL_ERROR: &str = "all URI attributes must be of the form keyword=value";
+const INVALID_ATTR_FORMAT_ERROR: &str = "all URI attributes must be of the form keyword=value";
 const MISSING_CLOSING_BRACE_ERROR: &str = "attribute value beginning with '{' must end with '}'";
 
 const USER: &[&str] = &["uid", "user"];

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -41,6 +41,10 @@ impl<'a> ODBCUri<'a> {
         let mut input = odbc_uri;
         let mut ret = ODBCUri(HashMap::new());
         while let Some((keyword, value, rest)) = ODBCUri::get_next_attribute(input)? {
+            // if attributes are repeated, the first is the one that is kept.
+            if ret.0.contains_key(&keyword) {
+                continue;
+            }
             ret.0.insert(keyword, value);
             if rest.is_none() {
                 return Ok(ret);

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use regex::{RegexSet, RegexSetBuilder};
 use std::collections::HashMap;
 
-const NOT_EMPTY_ERROR: &str = "URI must not be empty";
+const EMPTY_URI_ERROR: &str = "URI must not be empty";
 const EQUAL_ERROR: &str = "all URI attributes must be of the form keyword=value";
 const MISSING_CLOSING_BRACE_ERROR: &str = "attribute value beginning with '{' must end with '}'";
 

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -1,15 +1,36 @@
 use crate::errors::{ODBCError, Result};
+use lazy_static::lazy_static;
+use regex::{RegexSet, RegexSetBuilder};
 use std::collections::HashMap;
 
 // TODO SQL-990: These errors will probably change.
-const NOT_EMPTY_ERROR: &str = "uri must not be empty";
-const EQUAL_ERROR: &str = "all uri atttributes must be of the form key=value";
+const NOT_EMPTY_ERROR: &str = "URI must not be empty";
+const EQUAL_ERROR: &str = "all URI attributes must be of the form keyword=value";
+const MISSING_CLOSING_BRACE_ERROR: &str = "attribute value beginning with '{' must end with '}'";
 
 // TODO SQL-990: Audit these mandatory attributes
-const USER: &[&str] = &["user", "uid"];
-const PWD: &[&str] = &["pwd", "password"];
+const USER: &[&str] = &["uid", "user"];
+const PWD: &[&str] = &["password", "pwd"];
 const SERVER: &[&str] = &["server"];
-const SSL: &[&str] = &["ssl"];
+const SSL: &[&str] = &["ssl", "tls"];
+
+lazy_static! {
+    static ref KEYWORDS: RegexSet = RegexSetBuilder::new(&[
+        "^AUTH_SRC$",
+        "^DRIVER$",
+        "^DSN$",
+        "^PASSWORD$",
+        "^PWD$",
+        "^SERVER$",
+        "^SSL$",
+        "^TLS$",
+        "^USER$",
+        "^UID$",
+    ])
+    .case_insensitive(true)
+    .build()
+    .unwrap();
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ODBCUri<'a>(HashMap<String, &'a str>);
@@ -19,23 +40,79 @@ impl<'a> ODBCUri<'a> {
         if odbc_uri.is_empty() {
             return Err(ODBCError::InvalidUriFormat(NOT_EMPTY_ERROR.to_string()));
         }
-        // TODO SQL-990: Support the actual ODBC spec with regards to special characters in attributes
-        // the algorithm will most likely need to be a state machine over each character in the
-        // odbc_uri string.
-        odbc_uri
-            .split(';')
-            .filter(|attr| !attr.is_empty())
-            .map(|attr| {
-                // now split each attribute pair on '='
-                let mut sp = attr.split('=').collect::<Vec<_>>();
-                if sp.len() != 2 {
-                    return Err(ODBCError::InvalidUriFormat(EQUAL_ERROR.to_string()));
-                }
-                // ODBC attribute keys are case insensitive, so we lowercase the keys
-                Ok((sp.remove(0).to_lowercase(), sp.remove(0)))
-            })
-            .collect::<Result<HashMap<_, _>>>()
-            .map(ODBCUri)
+        let mut input = odbc_uri;
+        let mut ret = ODBCUri(HashMap::new());
+        while let Some((keyword, value, rest)) = ODBCUri::get_next_attribute(input)? {
+            if keyword.is_empty() {
+                return Ok(ret);
+            }
+            ret.0.insert(keyword, value);
+            if rest.is_none() {
+                return Ok(ret);
+            }
+            input = rest.unwrap();
+        }
+        Ok(ret)
+    }
+
+    fn get_next_attribute(odbc_uri: &'a str) -> Result<Option<(String, &'a str, Option<&'a str>)>> {
+        // clean up any extra semi-colons
+        let index = odbc_uri.find(|c| c != ';');
+        // these are just trailing semis on the URI
+        if index.is_none() {
+            return Ok(None);
+        }
+        let odbc_uri = odbc_uri.get(index.unwrap()..).unwrap();
+        // find the first '=' sign, '=' does not appear in any keywords, so this is safe.
+        let (keyword, rest) = odbc_uri.split_at(
+            odbc_uri
+                .find('=')
+                .ok_or(ODBCError::InvalidUriFormat(EQUAL_ERROR.to_string()))?,
+        );
+        // remove the leading '=' sign.
+        let rest = rest.get(1..).unwrap();
+        if !KEYWORDS.is_match(keyword) {
+            return Err(ODBCError::InvalidUriFormat(format!(
+                "'{}' is not a valid URI keyword",
+                keyword
+            )));
+        }
+        let (value, rest) = if rest.chars().nth(0).unwrap() == '{' {
+            let rest = rest.get(1..).ok_or_else(|| {
+                ODBCError::InvalidUriFormat(MISSING_CLOSING_BRACE_ERROR.to_string())
+            })?;
+            ODBCUri::handle_braced_value(rest)?
+        } else {
+            ODBCUri::handle_unbraced_value(rest)?
+        };
+        Ok(Some((keyword.to_lowercase(), value, rest)))
+    }
+
+    fn handle_braced_value(input: &'a str) -> Result<(&'a str, Option<&'a str>)> {
+        let (value, rest) =
+            input.split_at(input.find('}').ok_or_else(|| {
+                ODBCError::InvalidUriFormat(MISSING_CLOSING_BRACE_ERROR.to_string())
+            })?);
+        println!("\t{}\n\t{}", value, rest);
+        match rest.len() {
+            0 => unreachable!(),
+            1 => return Ok((value, None)),
+            2 if rest.chars().nth(1).unwrap() == ';' => return Ok((value, None)),
+            _ => (),
+        }
+        Ok((value, rest.get(2..)))
+    }
+
+    fn handle_unbraced_value(input: &'a str) -> Result<(&'a str, Option<&'a str>)> {
+        let index = input.find(";");
+        if index.is_none() {
+            return Ok((input, None));
+        }
+        let (value, rest) = input.split_at(index.unwrap());
+        if rest.len() == 1 {
+            return Ok((value, None));
+        }
+        Ok((value, rest.get(1..)))
     }
 
     // remove will remove the first value with a given one of the names passed, assuming all names
@@ -101,6 +178,158 @@ impl<'a> ODBCUri<'a> {
 }
 
 mod unit {
+    mod get_next_attribute {
+        #[test]
+        fn get_unbraced() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("driver".to_string(), "foo", None),
+                ODBCUri::get_next_attribute("DRIVER=foo").unwrap().unwrap(),
+            );
+        }
+
+        #[test]
+        fn get_braced() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("driver".to_string(), "fo[]=o", None),
+                ODBCUri::get_next_attribute("DRIVER={fo[]=o}")
+                    .unwrap()
+                    .unwrap(),
+            );
+        }
+
+        #[test]
+        fn get_unbraced_with_rest() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("driver".to_string(), "foo", Some("UID=stuff")),
+                ODBCUri::get_next_attribute("DRIVER=foo;UID=stuff")
+                    .unwrap()
+                    .unwrap(),
+            );
+        }
+
+        #[test]
+        fn get_braced_with_rest() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("driver".to_string(), "fo[]=o", Some("UID=stuff")),
+                ODBCUri::get_next_attribute("DRIVER={fo[]=o};UID=stuff")
+                    .unwrap()
+                    .unwrap(),
+            );
+        }
+
+        #[test]
+        fn get_with_non_keyword_in_keyword_position_is_error() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                "[MongoDB][API] Invalid Uri: 'stuff' is not a valid URI keyword",
+                format!(
+                    "{}",
+                    ODBCUri::get_next_attribute("stuff=stuff;").unwrap_err()
+                )
+            );
+        }
+    }
+
+    mod handle_braced_value {
+        #[test]
+        fn no_closing_brace_is_error() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                "[MongoDB][API] Invalid Uri: attribute value beginning with '{' must end with '}'",
+                format!(
+                    "{}",
+                    ODBCUri::handle_braced_value("stuff;stuff").unwrap_err()
+                )
+            );
+        }
+
+        #[test]
+        fn ends_with_brace() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", None),
+                ODBCUri::handle_braced_value("stuff}").unwrap()
+            );
+        }
+
+        #[test]
+        fn ends_with_semi() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", None),
+                ODBCUri::handle_braced_value("stuff};").unwrap()
+            );
+        }
+
+        #[test]
+        fn has_rest() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", Some("DRIVER=foo")),
+                ODBCUri::handle_braced_value("stuff};DRIVER=foo").unwrap()
+            );
+        }
+
+        #[test]
+        fn ends_with_brace_special_chars() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stu%=[]ff", None),
+                ODBCUri::handle_braced_value("stu%=[]ff}").unwrap()
+            );
+        }
+
+        #[test]
+        fn ends_with_semi_special_chars() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stu%=[]ff", None),
+                ODBCUri::handle_braced_value("stu%=[]ff};").unwrap()
+            );
+        }
+
+        #[test]
+        fn has_rest_special_chars() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stu%=[]ff", Some("DRIVER=foo")),
+                ODBCUri::handle_braced_value("stu%=[]ff};DRIVER=foo").unwrap()
+            );
+        }
+    }
+
+    mod handle_unbraced_value {
+        #[test]
+        fn ends_with_empty() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", None),
+                ODBCUri::handle_unbraced_value("stuff").unwrap()
+            );
+        }
+
+        #[test]
+        fn ends_with_semi() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", None),
+                ODBCUri::handle_unbraced_value("stuff;").unwrap()
+            );
+        }
+
+        #[test]
+        fn has_rest() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                ("stuff", Some("DRIVER=foo")),
+                ODBCUri::handle_unbraced_value("stuff;DRIVER=foo").unwrap()
+            );
+        }
+    }
     // TODO SQL-990: Add more tests to cover the ODBC spec with regards to special characters.
     mod new {
         #[test]
@@ -139,12 +368,24 @@ mod unit {
         }
 
         #[test]
-        fn two_attriubutes_with_trailing_semi_works() {
+        fn two_attributes_with_trailing_semi_works() {
             use crate::map;
             use crate::odbc_uri::ODBCUri;
             let expected =
                 ODBCUri(map! {"driver".to_string() => "Foo", "server".to_string() => "bAr"});
             assert_eq!(expected, ODBCUri::new("Driver=Foo;SERVER=bAr;").unwrap());
+        }
+
+        #[test]
+        fn two_attributes_with_triple_trailing_semis_works() {
+            use crate::map;
+            use crate::odbc_uri::ODBCUri;
+            let expected =
+                ODBCUri(map! {"driver".to_string() => "Foo", "server".to_string() => "bAr"});
+            assert_eq!(
+                expected,
+                ODBCUri::new("Driver=Foo;;;SERVER=bAr;;;").unwrap()
+            );
         }
     }
 
@@ -167,7 +408,7 @@ mod unit {
         fn missing_pwd_is_err() {
             use crate::odbc_uri::ODBCUri;
             assert_eq!(
-            "[MongoDB][API] Invalid Uri: One of [\"pwd\", \"password\"] is required for a valid Mongo ODBC Uri",
+            "[MongoDB][API] Invalid Uri: One of [\"password\", \"pwd\"] is required for a valid Mongo ODBC Uri",
             format!(
                 "{}",
                 ODBCUri::new("USER=foo;SERVER=127.0.0.1:27017")
@@ -181,7 +422,7 @@ mod unit {
         fn missing_user_is_err() {
             use crate::odbc_uri::ODBCUri;
             assert_eq!(
-            "[MongoDB][API] Invalid Uri: One of [\"user\", \"uid\"] is required for a valid Mongo ODBC Uri",
+            "[MongoDB][API] Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri",
             format!(
                 "{}",
                 ODBCUri::new("PWD=bar;SERVER=127.0.0.1:27017")

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -62,7 +62,7 @@ impl<'a> ODBCUri<'a> {
         let (keyword, rest) = odbc_uri.split_at(
             odbc_uri
                 .find('=')
-                .ok_or(ODBCError::InvalidUriFormat(EQUAL_ERROR.to_string()))?,
+                .ok_or_else(|| ODBCError::InvalidUriFormat(EQUAL_ERROR.to_string()))?,
         );
         // remove the leading '=' sign.
         let rest = rest.get(1..).unwrap();
@@ -72,7 +72,7 @@ impl<'a> ODBCUri<'a> {
                 keyword
             )));
         }
-        let (value, rest) = if rest.chars().nth(0).unwrap() == '{' {
+        let (value, rest) = if rest.starts_with('{') {
             let rest = rest.get(1..).ok_or_else(|| {
                 ODBCError::InvalidUriFormat(MISSING_CLOSING_BRACE_ERROR.to_string())
             })?;
@@ -98,7 +98,7 @@ impl<'a> ODBCUri<'a> {
     }
 
     fn handle_unbraced_value(input: &'a str) -> Result<(&'a str, Option<&'a str>)> {
-        let index = input.find(";");
+        let index = input.find(';');
         if index.is_none() {
             return Ok((input, None));
         }

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -3,12 +3,10 @@ use lazy_static::lazy_static;
 use regex::{RegexSet, RegexSetBuilder};
 use std::collections::HashMap;
 
-// TODO SQL-990: These errors will probably change.
 const NOT_EMPTY_ERROR: &str = "URI must not be empty";
 const EQUAL_ERROR: &str = "all URI attributes must be of the form keyword=value";
 const MISSING_CLOSING_BRACE_ERROR: &str = "attribute value beginning with '{' must end with '}'";
 
-// TODO SQL-990: Audit these mandatory attributes
 const USER: &[&str] = &["uid", "user"];
 const PWD: &[&str] = &["password", "pwd"];
 const SERVER: &[&str] = &["server"];
@@ -157,13 +155,8 @@ impl<'a> ODBCUri<'a> {
     pub fn remove_to_mongo_uri(&mut self) -> Result<String> {
         let user = self.remove_mandatory_attribute(USER)?;
         let pwd = self.remove_mandatory_attribute(PWD)?;
-        // TODO SQL-990: Support the PORT attribute, right now the only way to specify PORT is as
-        // part of SERVER. If ports are specified in both SERVER and PORT and they do not match it
-        // should be an error (I think, check the spec if it says...).
         let server = self.remove_mandatory_attribute(SERVER)?;
         let ssl = self.remove(SSL);
-        // TODO SQL-990: we may wish to support more attributes as options.
-        // If we do, add more tests to cover them.
         let ssl_string =
             if ssl.is_some() && ssl.unwrap() != "0" && ssl.unwrap().to_lowercase() != "false" {
                 "?ssl=true"
@@ -330,7 +323,7 @@ mod unit {
             );
         }
     }
-    // TODO SQL-990: Add more tests to cover the ODBC spec with regards to special characters.
+
     mod new {
         #[test]
         fn empty_uri_is_err() {

--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -62,11 +62,10 @@ impl<'a> ODBCUri<'a> {
         }
         let odbc_uri = odbc_uri.get(index.unwrap()..).unwrap();
         // find the first '=' sign, '=' does not appear in any keywords, so this is safe.
-        let (keyword, rest) = odbc_uri.split_at(
-            odbc_uri
-                .find('=')
-                .ok_or_else(|| ODBCError::InvalidUriFormat(EQUAL_ERROR.to_string()))?,
-        );
+        let (keyword, rest) =
+            odbc_uri.split_at(odbc_uri.find('=').ok_or_else(|| {
+                ODBCError::InvalidUriFormat(INVALID_ATTR_FORMAT_ERROR.to_string())
+            })?);
         // remove the leading '=' sign.
         let rest = rest.get(1..).unwrap();
         if !KEYWORDS.is_match(keyword) {

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -24,7 +24,7 @@ if [[ -z $ARG ]]; then
   exit 0
 fi
 
-GO_VERSION="go1.17"
+GO_VERSION="go1.18"
 if [ -d "/opt/golang/$GO_VERSION" ]; then
   GOROOT="/opt/golang/$GO_VERSION"
   GOBINDIR="$GOROOT"/bin


### PR DESCRIPTION
The spec can be found here: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldriverconnect-function?view=sql-server-ver16

the grammar suggests that {} is only allowed for the driver, but the text suggests it is allowed for any value, so that's what I went with.

({} is so that you can have special characters in a value... except obviously }).