### PR TITLE
SQL-984: Test Harness: Implement Result Set validator

### DIFF
--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -1,2 +1,6 @@
 #[cfg(test)]
 mod test_runner;
+
+#[path = "../tests/common/mod.rs"]
+#[cfg(test)]
+mod common;

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -1,32 +1,37 @@
-use lazy_static::lazy_static;
-use odbc_api::{
-    buffers::{BufferDescription, BufferKind, ColumnarAnyBuffer},
-    handles::Statement,
-    Connection, Cursor, CursorImpl, Environment, Nullability, RowSetCursor,
-};
-use odbc_sys::SqlReturn;
+use odbc::{create_environment_v3, Allocated, Connection, Handle, NoResult, Statement};
+use odbc_sys::{CDataType, HStmt, SqlReturn, USmallInt};
+
+use odbc::safe::AutocommitOn;
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 use std::ptr::null_mut;
-use std::{collections::BTreeMap, env, fmt, fs, path::PathBuf};
+use std::{fmt, fs, path::PathBuf};
+
 use thiserror::Error;
 
 const TEST_FILE_DIR: &str = "../resources/integration_test/tests";
-
-lazy_static! {
-    pub static ref ODBC_ENV: Environment = Environment::new().unwrap();
-}
+const SQL_NULL_DATA: isize = -1;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
-    /*
     #[error("test runner failed for test {test}: expected {expected:?}, actual {actual:?}")]
     IntegrationTest {
         test: String,
         expected: String,
         actual: String,
     },
-     */
+    #[error("mismatch in row counts for test {test}: expected {expected:?}, actual {actual:?}")]
+    RowCount {
+        test: String,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("mismatch in column counts for test {test}: expected {expected:?}, actual {actual:?}")]
+    ColumnCount {
+        test: String,
+        expected: usize,
+        actual: usize,
+    },
     #[error("failed to read file: {0}")]
     InvalidFile(String),
     #[error("failed to read directory: {0}")]
@@ -35,14 +40,14 @@ pub enum Error {
     InvalidFilePath(String),
     #[error("unable to deserialize YAML file: {0}")]
     CannotDeserializeYaml(String),
-    #[error("unsuccessful SQL return code encountered: {0}")]
-    SqlReturn(String),
     #[error("not enough values in array expected: {0}, actual: {1}")]
     NotEnoughArguments(usize, usize),
     #[error("unsupported function {0}")]
     UnsupportedFunction(String),
     #[error("overflow caused by value {0}, err {1}")]
     ValueOverflowI16(i64, String),
+    #[error("function {0} failed with sql code {1}")]
+    OdbcFunctionFailed(String, String),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,7 +60,7 @@ pub struct TestEntry {
     pub description: String,
     pub db: String,
     pub test_definition: TestDef,
-    pub expected_result: Option<Vec<BTreeMap<String, Value>>>,
+    pub expected_result: Option<Vec<Vec<String>>>,
     pub skip_reason: Option<String>,
     pub ordered: Option<bool>,
     pub expected_column_name: Option<Vec<String>>,
@@ -107,41 +112,11 @@ pub fn parse_test_file_yaml(path: &str) -> Result<IntegrationTest, Error> {
     Ok(integration_test)
 }
 
-/// connect obtains a connection to the local Atlas Data Federation instance and returns Connection
-/// it fetches environment variables to create the connection string
-fn connect() -> Result<Connection<'static>, Error> {
-    let user_name = env::var("ADF_TEST_LOCAL_USER").expect("ADF_TEST_LOCAL_USER is not set");
-    let password = env::var("ADF_TEST_LOCAL_PWD").expect("ADF_TEST_LOCAL_PWD is not set");
-    let host = env::var("ADF_TEST_LOCAL_HOST").expect("ADF_TEST_LOCAL_HOST is not set");
-    let auth_db = match env::var("ADF_TEST_LOCAL_AUTH_DB") {
-        Ok(val) => val,
-        Err(_) => "admin".to_string(), //Default auth db
-    };
-    let db = match env::var("ADF_TEST_LOCAL_DB") {
-        Ok(val) => val,
-        Err(_) => "integration_test".to_string(), //Default DB name
-    };
-    let driver = match env::var("ADF_TEST_LOCAL_DRIVER") {
-        Ok(val) => val,
-        Err(_) => "ADF_ODBC_DRIVER".to_string(), //Default driver name
-    };
-
-    let connection_string = format!(
-        "Driver={};PWD={};USER={};SERVER={};AUTH_SRC={};Database={}",
-        driver, password, user_name, host, auth_db, db
-    );
-    let connection = ODBC_ENV
-        .connect_with_connection_string(&connection_string)
-        .unwrap();
-
-    assert!(!connection.is_dead().unwrap());
-    Ok(connection)
-}
-
 /// integration_test runs the query and function tests contained in the TEST_FILE_DIR directory
 #[test]
 #[ignore]
 pub fn integration_test() -> Result<(), Error> {
+    let env = create_environment_v3().unwrap();
     let paths = load_file_paths(PathBuf::from(TEST_FILE_DIR)).unwrap();
     for path in paths {
         let yaml = parse_test_file_yaml(&path).unwrap();
@@ -150,23 +125,21 @@ pub fn integration_test() -> Result<(), Error> {
             match test.skip_reason {
                 Some(sr) => println!("Skip Reason: {}", sr),
                 None => {
-                    let connection = connect().unwrap();
+                    let mut conn_str = crate::common::generate_default_connection_str();
+                    conn_str.push_str(&(";DATABASE=".to_owned() + &test.db));
+                    let connection = env
+                        .connect_with_connection_string(conn_str.as_str())
+                        .unwrap();
                     let test_result = match test.test_definition {
                         TestDef::Query(ref q) => run_query_test(q, &test, &connection),
                         TestDef::Function(ref f) => run_function_test(f, &test, &connection),
                     };
                     drop(connection);
-                    return test_result;
+                    assert_eq!(Ok(()), test_result);
                 }
             }
         }
     }
-    Ok(())
-}
-
-fn run_query_test(query: &str, entry: &TestEntry, conn: &Connection) -> Result<(), Error> {
-    let cursor = conn.execute(query, ()).unwrap().unwrap();
-    validate_result_set(entry, cursor);
     Ok(())
 }
 
@@ -180,19 +153,19 @@ fn str_or_null(value: &Value) -> *const u8 {
     }
 }
 
-/// strw_or_null converts value to a wide string or null_mut() if null
-fn strw_or_null(value: &Value) -> *const u16 {
+/// wstr_or_null converts value to a wide string or null_mut() if null
+fn wstr_or_null(value: &Value) -> *const u16 {
     if value.is_null() {
         null_mut()
     } else {
-        let mut v: Vec<u16> = value
-            .as_str()
-            .expect("Unable to cast value as string")
-            .encode_utf16()
-            .collect();
-        v.push(0);
-        v.as_ptr()
+        to_wstr_ptr(value.as_str().expect("Unable to cast value as string"))
     }
+}
+
+fn to_wstr_ptr(string: &str) -> *const u16 {
+    let mut v: Vec<u16> = string.encode_utf16().collect();
+    v.push(0);
+    v.as_ptr()
 }
 
 fn to_i16(value: &Value) -> Result<i16, Error> {
@@ -207,13 +180,36 @@ fn check_array_length(array: &Vec<Value>, length: usize) -> Result<(), Error> {
     Ok(())
 }
 
+fn run_query_test(
+    query: &str,
+    entry: &TestEntry,
+    conn: &Connection<AutocommitOn>,
+) -> Result<(), Error> {
+    let stmt = Statement::with_parent(conn).unwrap();
+    unsafe {
+        match odbc_sys::SQLExecDirectW(
+            stmt.handle() as *mut _,
+            to_wstr_ptr(query),
+            query.len() as i32,
+        ) {
+            SqlReturn::SUCCESS => {}
+            sql_return => {
+                return Err(Error::OdbcFunctionFailed(
+                    "SQLExecDirectW".to_string(),
+                    format!("{:?}", sql_return),
+                ))
+            }
+        }
+        validate_result_set(entry, stmt)
+    }
+}
+
 fn run_function_test(
     function: &Vec<Value>,
     entry: &TestEntry,
-    conn: &Connection,
+    conn: &Connection<AutocommitOn>,
 ) -> Result<(), Error> {
-    let preallocated = conn.preallocate().unwrap();
-    let statement = preallocated.into_statement();
+    let statement = Statement::with_parent(conn).unwrap();
     check_array_length(function, 1)?;
     let function_name = function[0].as_str().unwrap().to_lowercase();
     let sql_return = match function_name.as_str() {
@@ -222,14 +218,17 @@ fn run_function_test(
             unsafe {
                 let data_type: odbc_sys::SqlDataType =
                     std::mem::transmute(function[1].as_i64().unwrap() as i16);
-                Ok(odbc_sys::SQLGetTypeInfo(statement.as_sys(), data_type))
+                Ok(odbc_sys::SQLGetTypeInfo(
+                    statement.handle() as HStmt,
+                    data_type,
+                ))
             }
         }
         "sqltables" => {
             check_array_length(function, 9)?;
             unsafe {
                 Ok(odbc_sys::SQLTables(
-                    statement.as_sys(),
+                    statement.handle() as HStmt,
                     str_or_null(&function[1]),
                     to_i16(&function[2])?,
                     str_or_null(&function[3]),
@@ -241,33 +240,50 @@ fn run_function_test(
                 ))
             }
         }
+        "sqltablesw" => {
+            check_array_length(function, 9)?;
+            unsafe {
+                Ok(odbc_sys::SQLTablesW(
+                    statement.handle() as HStmt,
+                    wstr_or_null(&function[1]),
+                    to_i16(&function[2])?,
+                    wstr_or_null(&function[3]),
+                    to_i16(&function[4])?,
+                    wstr_or_null(&function[5]),
+                    to_i16(&function[6])?,
+                    wstr_or_null(&function[7]),
+                    to_i16(&function[8])?,
+                ))
+            }
+        }
         "sqlforeignkeysw" => {
             check_array_length(function, 13)?;
             unsafe {
                 Ok(odbc_sys::SQLForeignKeysW(
-                    statement.as_sys(),
-                    strw_or_null(&function[1]),
+                    statement.handle() as HStmt,
+                    wstr_or_null(&function[1]),
                     to_i16(&function[2])?,
-                    strw_or_null(&function[3]),
+                    wstr_or_null(&function[3]),
                     to_i16(&function[4])?,
-                    strw_or_null(&function[5]),
+                    wstr_or_null(&function[5]),
                     to_i16(&function[6])?,
-                    strw_or_null(&function[7]),
+                    wstr_or_null(&function[7]),
                     to_i16(&function[8])?,
-                    strw_or_null(&function[7]),
+                    wstr_or_null(&function[7]),
                     to_i16(&function[8])?,
-                    strw_or_null(&function[7]),
+                    wstr_or_null(&function[7]),
                     to_i16(&function[8])?,
                 ))
             }
         }
         /*
+        // SQL-1015: Investigate how to test missing functions from odbc-sys
         // The following functions are not implemented in odbc-sys
 
         "sqlprimarykeys" => {
             unsafe {
                 Ok(odbc_sys::SQLPrimaryKeys(
-                    statement.as_sys(),
+                    statement.handle() as HStmt,
                     str_or_null(&function[1]),
                     to_i16(&function[2]),
                     str_or_null(&function[3]),
@@ -280,7 +296,7 @@ fn run_function_test(
         "sqlspecialcolumns" => {
             unsafe {
                 Ok(odbc_sys::SQLSpecialColumns(
-                    statement.as_sys(),
+                    statement.handle() as HStmt,
                     to_i16(&function[1]),
                     str_or_null(&function[2]),
                     to_i16(&function[3]),
@@ -296,7 +312,7 @@ fn run_function_test(
         "sqlstatistics" => {
             unsafe {
                 Ok(odbc_sys::SQLStatistics(
-                    statement.as_sys(),
+                    statement.handle() as HStmt,
                     str_or_null(&function[1]),
                     to_i16(&function[2]),
                     str_or_null(&function[3]),
@@ -311,7 +327,7 @@ fn run_function_test(
         "sqltableprivileges" => {
             unsafe {
                 Ok(odbc_sys::SQLTablePrivileges(
-                    statement.as_sys(),
+                    statement.handle() as HStmt,
                     str_or_null(&function[1]),
                     to_i16(&function[2]),
                     str_or_null(&function[3]),
@@ -322,47 +338,125 @@ fn run_function_test(
             }
         }
          */
-        _ => Err(Error::UnsupportedFunction(function_name)),
+        _ => Err(Error::UnsupportedFunction(function_name.clone())),
     };
 
     let sql_return_val = sql_return.unwrap();
     if sql_return_val != SqlReturn::SUCCESS {
-        return Err(Error::SqlReturn(format!("{:?}", sql_return_val)));
+        return Err(Error::OdbcFunctionFailed(function_name, format!("{:?}", sql_return_val)));
     }
-    unsafe {
-        let cursor = CursorImpl::new(statement);
-        validate_result_set(entry, cursor);
-    }
+    validate_result_set(entry, statement)
+}
 
+fn validate_result_set(
+    entry: &TestEntry,
+    stmt: Statement<Allocated, NoResult, AutocommitOn>,
+) -> Result<(), Error> {
+    let columns = get_column_count(&stmt)?;
+    let mut row_counter = 0;
+    if let Some(expected_result) = entry.expected_result.as_ref() {
+        while fetch_row(&stmt)? {
+            let expected_row_check = expected_result.get(row_counter);
+            // If there are no more expected rows, continue fetching to get actual row count
+            if let Some(expected_row) = expected_row_check {
+                if expected_row.len() != columns {
+                    return Err(Error::ColumnCount {
+                        test: entry.description.clone(),
+                        expected: expected_row.len(),
+                        actual: columns,
+                    });
+                }
+
+                for i in 1..(columns + 1) {
+                    let expected_field = expected_row.get(i - 1);
+                    let data = get_data_as_string(&stmt, i as USmallInt)?;
+                    if *expected_field.unwrap() != data {
+                        return Err(Error::IntegrationTest {
+                            test: entry.description.clone(),
+                            expected: (*expected_field.unwrap().to_string()).parse().unwrap(),
+                            actual: data,
+                        });
+                    }
+                }
+            }
+            row_counter += 1;
+        }
+        if expected_result.len() != row_counter {
+            return Err(Error::RowCount {
+                test: entry.description.clone(),
+                expected: expected_result.len(),
+                actual: row_counter,
+            });
+        }
+    }
     Ok(())
 }
 
-/// allocate_buffer takes the cursor and allocates a buffer based on the types of the columns
-pub fn allocate_buffer(mut cursor: impl Cursor) -> RowSetCursor<impl Cursor, ColumnarAnyBuffer> {
-    let mut column_description = Default::default();
-    let buffer_description: Vec<_> = (0..cursor.num_result_cols().unwrap())
-        .map(|index| {
-            cursor
-                .describe_col(index as u16 + 1, &mut column_description)
-                .unwrap();
-            Ok(BufferDescription {
-                nullable: matches!(
-                    column_description.nullability,
-                    Nullability::Unknown | Nullability::Nullable
-                ),
-                // Use reasonable sized text, in case we do not know the buffer type.
-                kind: BufferKind::from_data_type(column_description.data_type)
-                    .unwrap_or(BufferKind::Text { max_str_len: 255 }),
-            })
-        })
-        .collect::<Result<_, Error>>()
-        .unwrap();
-    let buffer = ColumnarAnyBuffer::from_description(5000, buffer_description.into_iter());
-    cursor.bind_buffer(buffer).unwrap()
+fn get_data_as_string(
+    stmt: &Statement<Allocated, NoResult, AutocommitOn>,
+    column: USmallInt,
+) -> Result<String, Error> {
+    const BUFFER_LENGTH: usize = 200;
+    let out_len_or_ind = &mut 0;
+    let char_buffer: *mut std::ffi::c_void =
+        Box::into_raw(Box::new([0u8; BUFFER_LENGTH])) as *mut _;
+    let data: String;
+    unsafe {
+        match odbc_sys::SQLGetData(
+            stmt.handle() as *mut _,
+            column,
+            CDataType::Char,
+            char_buffer as *mut _,
+            BUFFER_LENGTH as isize,
+            out_len_or_ind,
+        ) {
+            SqlReturn::SUCCESS => {}
+            sql_return => {
+                return Err(Error::OdbcFunctionFailed(
+                    "SQLGetData".to_string(),
+                    format!("{:?}", sql_return),
+                ))
+            }
+        }
+
+        if *out_len_or_ind == SQL_NULL_DATA {
+            // Mapping `null` data type to string "NULL"
+            // Make sure not to have "NULL" string values in dataset
+            data = "NULL".to_string();
+        } else {
+            data = (String::from_utf8_lossy(&*(char_buffer as *const [u8; 256])))
+                [0..*out_len_or_ind as usize]
+                .to_string();
+        }
+    }
+    Ok(data)
 }
 
-fn validate_result_set(_entry: &TestEntry, cursor: impl Cursor) {
-    let _row_set_cursor = allocate_buffer(cursor);
-    // Compare expected to actual rowset
-    // Implement as part of SQL-984
+fn get_column_count(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<usize, Error> {
+    unsafe {
+        let columns = &mut 0;
+        match odbc_sys::SQLNumResultCols(stmt.handle() as HStmt, columns) {
+            SqlReturn::SUCCESS => {}
+            sql_return => {
+                return Err(Error::OdbcFunctionFailed(
+                    "SQLNumResultCols".to_string(),
+                    format!("{:?}", sql_return),
+                ))
+            }
+        }
+        Ok(*columns as usize)
+    }
+}
+
+fn fetch_row(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<bool, Error> {
+    unsafe {
+        match odbc_sys::SQLFetch(stmt.handle() as HStmt) {
+            SqlReturn::SUCCESS => Ok(true),
+            SqlReturn::NO_DATA => Ok(false),
+            sql_return => Err(Error::OdbcFunctionFailed(
+                "SQLFetch".to_string(),
+                format!("{:?}", sql_return),
+            )),
+        }
+    }
 }

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -374,7 +374,7 @@ fn validate_result_set(
                 for i in 1..(columns + 1) {
                     let expected_field = expected_row.get(i - 1).unwrap();
                     let expected_data_type = if expected_field.is_number() {
-                        CDataType::Numeric
+                        CDataType::SLong
                     } else {
                         CDataType::Char
                     };
@@ -435,8 +435,8 @@ fn get_data(
             data = json!((String::from_utf8_lossy(&*(buffer as *const [u8; 256])))
                 [0..*out_len_or_ind as usize]
                 .to_string());
-        } else if data_type == CDataType::Numeric {
-            data = json!(buffer as i64);
+        } else if data_type == CDataType::SLong {
+            data = json!(*(buffer as *const i64));
         }
     }
     Ok(data)

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -343,7 +343,10 @@ fn run_function_test(
 
     let sql_return_val = sql_return.unwrap();
     if sql_return_val != SqlReturn::SUCCESS {
-        return Err(Error::OdbcFunctionFailed(function_name, format!("{:?}", sql_return_val)));
+        return Err(Error::OdbcFunctionFailed(
+            function_name,
+            format!("{:?}", sql_return_val),
+        ));
     }
     validate_result_set(entry, statement)
 }

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -126,7 +126,7 @@ pub fn integration_test() -> Result<(), Error> {
                 Some(sr) => println!("Skip Reason: {}", sr),
                 None => {
                     let mut conn_str = crate::common::generate_default_connection_str();
-                    conn_str.push_str(&(";DATABASE=".to_owned() + &test.db));
+                    conn_str.push_str(&("DATABASE=".to_owned() + &test.db));
                     let connection = env
                         .connect_with_connection_string(conn_str.as_str())
                         .unwrap();

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -27,7 +27,7 @@ pub fn generate_default_connection_str() -> String {
 
     // If a db is specified add it to the connection string
     match db {
-        Ok(val) => connection_string.push_str(&("DATABASE=".to_owned() + &val)),
+        Ok(val) => connection_string.push_str(&("DATABASE=".to_owned() + &val + ";")),
         Err(_e) => (), // Do nothing
     };
 

--- a/resources/integration_test/tests/functions.yaml
+++ b/resources/integration_test/tests/functions.yaml
@@ -1,6 +1,10 @@
 tests:
-  - description: stub function test
+  - description: SQLTablesW function get all catalogs
     skip_reason: "SQL-987: Create ODBC Result Set function tests"
-    test_definition: [  ]
+    test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "", 0 ]
     db: integration_test
+    expected_result:
+      - ["db2", "NULL", "NULL", "NULL", "NULL"]
+      - ["integration_test", "NULL", "NULL", "NULL", "NULL"]
+
 

--- a/resources/integration_test/tests/functions.yaml
+++ b/resources/integration_test/tests/functions.yaml
@@ -1,10 +1,9 @@
 tests:
   - description: SQLTablesW function get all catalogs
-    skip_reason: "SQL-987: Create ODBC Result Set function tests"
     test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "", 0 ]
     db: integration_test
     expected_result:
-      - ["db2", "NULL", "NULL", "NULL", "NULL"]
-      - ["integration_test", "NULL", "NULL", "NULL", "NULL"]
+      - ["db2", null, null, null, null]
+      - ["integration_test", null, null, null, null]
 
 

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -4,5 +4,5 @@ tests:
     db: integration_test
     expected_result:
       - ['{"$numberInt":"0"}', "a" ]
-      - ['{"$numberInt":"1"}', "b"]
+      - [1, "b"]
       - ['{"$numberInt":"2"}', "c"]

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -1,7 +1,7 @@
 tests:
   - description: simple query test
     skip_reason: "SQL-986: Create ODBC Result Set query tests"
-    test_definition: "select * from integration_test.example"
+    test_definition: "select * from example"
     db: integration_test
     expected_result:
       - ['{"$numberInt":"0"}', "a"]

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -1,9 +1,8 @@
 tests:
   - description: simple query test
-    skip_reason: "SQL-986: Create ODBC Result Set query tests"
     test_definition: "select * from example"
     db: integration_test
     expected_result:
-      - ['{"$numberInt":"0"}', "a"]
+      - ['{"$numberInt":"0"}', "a" ]
       - ['{"$numberInt":"1"}', "b"]
       - ['{"$numberInt":"2"}', "c"]

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -1,5 +1,9 @@
 tests:
-  - description: stub query test
-    skip_reason: "SQL-986: Create ODBC Result Set query tests"
-    test_definition: ""
+  - description: simple query test
+    skip_reason: "SQL-987: Create ODBC Result Set function tests"
+    test_definition: "select * from integration_test.example"
     db: integration_test
+    expected_result:
+      - ['{"$numberInt":"0"}', "a"]
+      - ['{"$numberInt":"1"}', "b"]
+      - ['{"$numberInt":"2"}', "c"]

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -1,6 +1,6 @@
 tests:
   - description: simple query test
-    skip_reason: "SQL-987: Create ODBC Result Set function tests"
+    skip_reason: "SQL-986: Create ODBC Result Set query tests"
     test_definition: "select * from integration_test.example"
     db: integration_test
     expected_result:


### PR DESCRIPTION
Implemented the query and function result set validation.  
There is still work to validate the column metadata, I will create a ticket to cover that. 
I have tested retrieving null and string data and added the query and function tests in `resources/integration_test/tests/queries.yaml|functions.yaml`.  I will test the numeric types before I merge. 
One area that could be improved is if there is a way to run the tests as a separate `#[test]` like in the connection tests [here](https://github.com/mongodb/mongo-odbc-driver/blob/master/odbc/tests/connection_tests.rs).  The issue is that the tests are run from integration_test() function, open to any suggestions.