### PR TITLE
SQL-1086: Audit and cleanup Binary handling

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -74,11 +74,7 @@ impl IntoCData for Bson {
 
     fn to_binary(self) -> Result<Vec<u8>> {
         match self {
-            Bson::Double(f) => {
-                let mut ret = Vec::with_capacity(8);
-                ret.extend(f.to_le_bytes());
-                Ok(ret)
-            }
+            Bson::Double(f) => Ok(f.to_le_bytes().to_vec()),
             Bson::String(s) => Ok(s.into_bytes()),
             Bson::Boolean(b) => Ok(if b { vec![1u8] } else { vec![0u8] }),
             Bson::DateTime(d) => {
@@ -94,22 +90,10 @@ impl IntoCData for Bson {
                 ret.extend(fraction.to_le_bytes());
                 Ok(ret)
             }
-            Bson::Int32(i) => {
-                let mut ret = Vec::with_capacity(4);
-                ret.extend(i.to_le_bytes());
-                Ok(ret)
-            }
-            Bson::Int64(i) => {
-                let mut ret = Vec::with_capacity(8);
-                ret.extend(i.to_le_bytes());
-                Ok(ret)
-            }
+            Bson::Int32(i) => Ok(i.to_le_bytes().to_vec()),
+            Bson::Int64(i) => Ok(i.to_le_bytes().to_vec()),
             Bson::Binary(b) => Ok(b.bytes),
-            Bson::Decimal128(d) => {
-                let mut ret = Vec::with_capacity(16);
-                ret.extend(d.bytes());
-                Ok(ret)
-            }
+            Bson::Decimal128(d) => Ok(d.bytes().to_vec()),
             o => Err(ODBCError::RestrictedDataType(o.to_type_str(), BINARY)),
         }
     }

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -576,15 +576,12 @@ mod unit {
                             out_len_or_ind,
                         )
                     );
-                    match code {
-                        SqlReturn::SUCCESS => {
-                            assert_eq!(expected.len() as isize, *out_len_or_ind);
-                            assert_eq!(
-                                expected,
-                                std::slice::from_raw_parts(buffer as *const u8, expected.len())
-                            );
-                        }
-                        _ => (),
+                    if code == SqlReturn::SUCCESS {
+                        assert_eq!(expected.len() as isize, *out_len_or_ind);
+                        assert_eq!(
+                            expected,
+                            std::slice::from_raw_parts(buffer as *const u8, expected.len())
+                        );
                     }
                 };
 


### PR DESCRIPTION
I didn't do anything with the bson types that aren't C types because the spec is not clear what to do with those.

I'm also not sure what I did for date_time is right... because all it says is that we output data. Ok, that's great. What does that mean? I think it's easy to assume we just output the C struct (Timestamp) field by field, but should it be little endian or big endian? Who knows. I did little endian.