### PR TITLE
SQL-1093: audit to_x for i32, i64, u32, and u64

### DIFF
--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "mongo-odbc-driver"
 version = "0.1.0"
-authors = ["Ryan Chipman <ryan@ryanchipman.com>",
+authors = [
+    "Ryan Chipman <ryan@ryanchipman.com>",
     "Natacha Bagnard <natacha.bagnard@mongodb.com>",
     "Patrick Meredith <pmeredit@protonmail.com>",
-    "Varsha Subrahmanyam <varsha.subrahmanyam@mongodb.com>"]
+    "Varsha Subrahmanyam <varsha.subrahmanyam@mongodb.com>",
+    "Nathan Leniz <nathan.leniz@gmail.com>",
+]
 edition = "2021"
 
 [dependencies]
@@ -36,4 +39,4 @@ thiserror = "1"
 
 [lib]
 name = "mongoodbc"
-crate-type = ["cdylib","lib"]
+crate-type = ["cdylib", "lib"]

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1425,9 +1425,9 @@ mod unit {
 
         #[test]
         fn negative_values_to_u64_fail() {
-            let bson_double_to_u64 = Bson::Double(-42.).to_u32();
-            let bson_int64_to_u64 = Bson::Int64(-42).to_u32();
-            let bson_int32_to_u64 = Bson::Int32(-42).to_u32();
+            let bson_double_to_u64 = Bson::Double(-42.).to_u64();
+            let bson_int64_to_u64 = Bson::Int64(-42).to_u64();
+            let bson_int32_to_u64 = Bson::Int32(-42).to_u64();
 
             assert!(bson_double_to_u64.is_err());
             assert!(bson_int64_to_u64.is_err());

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -161,14 +161,16 @@ impl IntoCData for Bson {
                 Err(ODBCError::IntegralTruncation(x.to_string()))
             }
             _ => self.to_i64().map_or_else(
-                |e| match e {
-                    ODBCError::RestrictedDataType(s, _) => {
-                        Err(ODBCError::RestrictedDataType(s, INT32))
-                    }
-                    ODBCError::InvalidCharacterValue(s, _) => {
-                        Err(ODBCError::InvalidCharacterValue(s, INT32))
-                    }
-                    _ => Err(e),
+                |e| {
+                    Err(match e {
+                        ODBCError::RestrictedDataType(s, _) => {
+                            ODBCError::RestrictedDataType(s, INT32)
+                        }
+                        ODBCError::InvalidCharacterValue(s, _) => {
+                            ODBCError::InvalidCharacterValue(s, INT32)
+                        }
+                        _ => e,
+                    })
                 },
                 |(u, w)| Ok((u as i32, w)),
             ),
@@ -232,14 +234,16 @@ impl IntoCData for Bson {
             }
             Bson::Int32(x) if *x < 0i32 => Err(ODBCError::IntegralTruncation(x.to_string())),
             _ => self.to_i64().map_or_else(
-                |e| match e {
-                    ODBCError::RestrictedDataType(s, _) => {
-                        Err(ODBCError::RestrictedDataType(s, UINT32))
-                    }
-                    ODBCError::InvalidCharacterValue(s, _) => {
-                        Err(ODBCError::InvalidCharacterValue(s, UINT32))
-                    }
-                    _ => Err(e),
+                |e| {
+                    Err(match e {
+                        ODBCError::RestrictedDataType(s, _) => {
+                            ODBCError::RestrictedDataType(s, UINT32)
+                        }
+                        ODBCError::InvalidCharacterValue(s, _) => {
+                            ODBCError::InvalidCharacterValue(s, UINT32)
+                        }
+                        _ => e,
+                    })
                 },
                 |(u, w)| Ok((u as u32, w)),
             ),

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1219,7 +1219,40 @@ mod unit {
         }
 
         #[test]
-        fn positive_values_with_truncation_to_u64_succeed_with_info() {
+        fn positive_values_without_truncation_to_i64_succeed() {
+            let bson_double_to_i64 = Bson::Double(42.).to_i64();
+            let bson_int64_to_i64 = Bson::Int64(42).to_i64();
+            let bson_int32_to_i64 = Bson::Int32(42).to_i64();
+
+            assert_eq!(bson_double_to_i64.unwrap().0, 42);
+            assert_eq!(bson_int64_to_i64.unwrap().0, 42);
+            assert_eq!(bson_int32_to_i64.unwrap().0, 42);
+        }
+
+        #[test]
+        fn positive_values_without_truncation_to_u32_succeed() {
+            let bson_double_to_u32 = Bson::Double(42.).to_u32();
+            let bson_int64_to_u32 = Bson::Int64(42).to_u32();
+            let bson_int32_to_u32 = Bson::Int32(42).to_u32();
+
+            assert_eq!(bson_double_to_u32.unwrap().0, 42);
+            assert_eq!(bson_int64_to_u32.unwrap().0, 42);
+            assert_eq!(bson_int32_to_u32.unwrap().0, 42);
+        }
+
+        #[test]
+        fn positive_values_without_truncation_to_i32_succeed() {
+            let bson_double_to_i32 = Bson::Double(42.).to_u32();
+            let bson_int64_to_i32 = Bson::Int64(42).to_u32();
+            let bson_int32_to_i32 = Bson::Int32(42).to_u32();
+
+            assert_eq!(bson_double_to_i32.unwrap().0, 42);
+            assert_eq!(bson_int64_to_i32.unwrap().0, 42);
+            assert_eq!(bson_int32_to_i32.unwrap().0, 42);
+        }
+
+        #[test]
+        fn positive_values_with_fractional_truncation_to_u64_succeed_with_info() {
             let bson_double_to_u64 = Bson::Double(42.05).to_u64();
 
             assert_eq!(bson_double_to_u64.as_ref().unwrap().0, 42);
@@ -1228,35 +1261,38 @@ mod unit {
                 FRACTIONAL_TRUNCATION
             );
         }
-        #[test]
-        fn negative_values_to_u64_fail() {
-            let bson_double_to_u64 = Bson::Double(-42.).to_u64();
-            let bson_int64_to_u64 = Bson::Int64(-42).to_u64();
-            let bson_int32_to_u64 = Bson::Int32(-42).to_u64();
 
+        #[test]
+        fn positive_values_with_fractional_truncation_to_i64_succeed_with_info() {
+            let bson_double_to_i64 = Bson::Double(42.05).to_i64();
+
+            assert_eq!(bson_double_to_i64.as_ref().unwrap().0, 42);
             assert_eq!(
-                bson_double_to_u64.unwrap_err().get_sql_state(),
-                INTEGRAL_TRUNCATION
-            );
-            assert_eq!(
-                bson_int64_to_u64.unwrap_err().get_sql_state(),
-                INTEGRAL_TRUNCATION
-            );
-            assert_eq!(
-                bson_int32_to_u64.unwrap_err().get_sql_state(),
-                INTEGRAL_TRUNCATION
+                bson_double_to_i64.unwrap().1.unwrap().get_sql_state(),
+                FRACTIONAL_TRUNCATION
             );
         }
 
         #[test]
-        fn positive_values_without_truncation_to_u32_succeed() {
-            let bson_double_to_u32 = Bson::Double(u32::MAX as f64).to_u32();
-            let bson_int64_to_u32 = Bson::Int64(u32::MAX as i64).to_u32();
-            let bson_int32_to_u32 = Bson::Int32(i32::MAX as i32).to_u32();
+        fn positive_values_with_fractional_truncation_to_u32_succeed_with_info() {
+            let bson_double_to_u32 = Bson::Double(42.05).to_i64();
 
-            assert_eq!(bson_double_to_u32.unwrap().0, u32::MAX as u32,);
-            assert_eq!(bson_int64_to_u32.unwrap().0, u32::MAX as u32);
-            assert_eq!(bson_int32_to_u32.unwrap().0, i32::MAX as u32);
+            assert_eq!(bson_double_to_u32.as_ref().unwrap().0, 42);
+            assert_eq!(
+                bson_double_to_u32.unwrap().1.unwrap().get_sql_state(),
+                FRACTIONAL_TRUNCATION
+            );
+        }
+
+        #[test]
+        fn positive_values_with_fractional_truncation_to_i32_succeed_with_info() {
+            let bson_double_to_i32 = Bson::Double(42.05).to_i64();
+
+            assert_eq!(bson_double_to_i32.as_ref().unwrap().0, 42);
+            assert_eq!(
+                bson_double_to_i32.unwrap().1.unwrap().get_sql_state(),
+                FRACTIONAL_TRUNCATION
+            );
         }
 
         #[test]
@@ -1315,6 +1351,30 @@ mod unit {
             );
             assert_eq!(
                 bson_int32_to_u32.unwrap_err().get_sql_state(),
+                INTEGRAL_TRUNCATION
+            );
+        }
+
+        #[test]
+        fn negative_values_to_u64_fail() {
+            let bson_double_to_u64 = Bson::Double(-42.).to_u32();
+            let bson_int64_to_u64 = Bson::Int64(-42).to_u32();
+            let bson_int32_to_u64 = Bson::Int32(-42).to_u32();
+
+            assert!(bson_double_to_u64.is_err());
+            assert!(bson_int64_to_u64.is_err());
+            assert!(bson_int32_to_u64.is_err());
+
+            assert_eq!(
+                bson_double_to_u64.unwrap_err().get_sql_state(),
+                INTEGRAL_TRUNCATION
+            );
+            assert_eq!(
+                bson_int64_to_u64.unwrap_err().get_sql_state(),
+                INTEGRAL_TRUNCATION
+            );
+            assert_eq!(
+                bson_int32_to_u64.unwrap_err().get_sql_state(),
                 INTEGRAL_TRUNCATION
             );
         }

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -257,7 +257,7 @@ impl IntoCData for Bson {
             Bson::Int32(i) if *i < 0i32 => Err(ODBCError::IntegralTruncation(i.to_string())),
             Bson::String(s) => Bson::Double(
                 f64::from_str(s)
-                    .map_err(|_| ODBCError::InvalidCharacterValue(s.clone(), UINT64))?,
+                    .map_err(|_| ODBCError::InvalidCharacterValue(s.clone(), UINT32))?,
             )
             .to_u32(),
             _ => self.to_i64().map_or_else(

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -1177,26 +1177,26 @@ mod unit {
                     ARRAY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type array cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type array cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     BIN_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type binData cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type binData cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(BOOL_COL, 1, SqlReturn::SUCCESS, "");
                 u64_val_test(
                     DATETIME_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type date cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type date cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     DOC_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type object cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type object cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     DOUBLE_COL,
@@ -1210,44 +1210,44 @@ mod unit {
                     JS_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type javascript cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type javascript cannot be converted to ODBC type UInt64",
                 );
-                u64_val_test(JS_W_S_COL, 0, SqlReturn::ERROR, "[MongoDB][API] BSON type javascriptWithScope cannot be converted to ODBC type Int64");
+                u64_val_test(JS_W_S_COL, 0, SqlReturn::ERROR, "[MongoDB][API] BSON type javascriptWithScope cannot be converted to ODBC type UInt64");
                 u64_val_test(
                     MAXKEY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type maxKey cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type maxKey cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     MINKEY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type minKey cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type minKey cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     OID_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type objectId cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type objectId cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     REGEX_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type regex cannot be converted to ODBC type Int64",
+                    "[MongoDB][API] BSON type regex cannot be converted to ODBC type UInt64",
                 );
                 u64_val_test(
                     STRING_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] invalid character value: \"hello world!\" for cast to type: Int64",
+                    "[MongoDB][API] invalid character value: \"hello world!\" for cast to type: UInt64",
                 );
                 u64_val_test(
                     NEGATIVE_COL,
-                    18446744073709551615u64,
-                    SqlReturn::SUCCESS,
-                    "",
+                    0,
+                    SqlReturn::ERROR,
+                    "[MongoDB][API] integral data \"-1\" was truncated due to overflow",
                 );
             }
 
@@ -1549,26 +1549,26 @@ mod unit {
                     ARRAY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type array cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type array cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     BIN_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type binData cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type binData cannot be converted to ODBC type UInt32",
                 );
-                u32_val_test(BOOL_COL, 1, SqlReturn::SUCCESS, "");
+                u32_val_test(BOOL_COL, 1, SqlReturn::SUCCESS, "convert bool to u32");
                 u32_val_test(
                     DATETIME_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type date cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type date cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     DOC_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type object cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type object cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     DOUBLE_COL,
@@ -1576,46 +1576,51 @@ mod unit {
                     SqlReturn::SUCCESS_WITH_INFO,
                     "[MongoDB][API] floating point data \"1.3\" was truncated to fixed point",
                 );
-                u32_val_test(I32_COL, 1, SqlReturn::SUCCESS, "");
-                u32_val_test(I64_COL, 0, SqlReturn::SUCCESS, "");
+                u32_val_test(I32_COL, 1, SqlReturn::SUCCESS, "convert i32 to u32");
+                u32_val_test(I64_COL, 0, SqlReturn::SUCCESS, "convert i64 to u32");
                 u32_val_test(
                     JS_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type javascript cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type javascript cannot be converted to ODBC type UInt32",
                 );
-                u32_val_test(JS_W_S_COL, 0, SqlReturn::ERROR, "[MongoDB][API] BSON type javascriptWithScope cannot be converted to ODBC type Int32");
+                u32_val_test(JS_W_S_COL, 0, SqlReturn::ERROR, "[MongoDB][API] BSON type javascriptWithScope cannot be converted to ODBC type UInt32");
                 u32_val_test(
                     MAXKEY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type maxKey cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type maxKey cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     MINKEY_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type minKey cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type minKey cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     OID_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type objectId cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type objectId cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     REGEX_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] BSON type regex cannot be converted to ODBC type Int32",
+                    "[MongoDB][API] BSON type regex cannot be converted to ODBC type UInt32",
                 );
                 u32_val_test(
                     STRING_COL,
                     0,
                     SqlReturn::ERROR,
-                    "[MongoDB][API] invalid character value: \"hello world!\" for cast to type: Int32",
+                    "[MongoDB][API] invalid character value: \"hello world!\" for cast to type: UInt32",
                 );
-                u32_val_test(NEGATIVE_COL, 4294967295, SqlReturn::SUCCESS, "");
+                u32_val_test(
+                    NEGATIVE_COL,
+                    0,
+                    SqlReturn::ERROR,
+                    "[MongoDB][API] integral data \"-1\" was truncated due to overflow",
+                );
             }
 
             {


### PR DESCRIPTION
I've audited the tests, added more, and refined some error messages.

Per the spec (as I understand it), integer truncation is a "loss of the whole" and is an error rather than an Ok with a result and warning.

Interestingly, I'm getting intermittent test failures for test panic. Would appreciate a point out to where it might be.

```sh
cargo test --package mongo-odbc-driver --lib

...
failures:

---- api::panic_safe_exec_tests::unit::test_panic stdout ----
thread 'api::panic_safe_exec_tests::unit::test_panic' panicked at 'assertion failed: `(left == right)`
  left: `"Panic(\"panic test\\nOk(\\\"in file '"`,
 right: `"Panic(\"panic test\\nErr(RecvError)"`', odbc/src/api/panic_safe_exec_tests.rs:61:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    api::panic_safe_exec_tests::unit::test_panic
```