### PR TITLE
SQL-1109: Finish SQLGetInfoW implementation

### DIFF
--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -7,7 +7,7 @@ use crate::{
         definitions::*,
         errors::{ODBCError, Result},
         odbc_uri::ODBCUri,
-        util::connection_attribute_to_string,
+        util::{connection_attribute_to_string, format_version},
     },
     handles::definitions::*,
 };
@@ -1843,25 +1843,24 @@ unsafe fn sql_get_infow_helper(
                 string_length_ptr,
             )
         }
-        // TODO: SQL-1109: implement InfoType::DriverVer for SQLGetInfoW
-        // // SQL_DRIVER_VER
-        // InfoType::DriverVer => { 
-        //     // The driver version can be obtained from the Cargo.toml file.
-        //     // The env! macro call below gets the version from the Cargo file
-        //     // at compile time.
-        //     let version_major = env!("CARGO_PKG_VERSION_MAJOR");
-        //     let version_minor = env!("CARGO_PKG_VERSION_MINOR");
-        //     let version_patch = env!("CARGO_PKG_VERSION_PATCH");
-        //     
-        //     let version = format_version(version_major, version_minor, version_patch);
-        //     
-        //     i16_len::set_output_wstring(
-        //         version.as_str(),
-        //         info_value_ptr as *mut WChar,
-        //         buffer_length as usize,
-        //         string_length_ptr,
-        //     )
-        // }
+        // SQL_DRIVER_VER
+        InfoType::DriverVer => {
+            // The driver version can be obtained from the Cargo.toml file.
+            // The env! macro call below gets the version from the Cargo file
+            // at compile time.
+            let version_major = env!("CARGO_PKG_VERSION_MAJOR");
+            let version_minor = env!("CARGO_PKG_VERSION_MINOR");
+            let version_patch = env!("CARGO_PKG_VERSION_PATCH");
+
+            let version = format_version(version_major, version_minor, version_patch);
+
+            i16_len::set_output_wstring(
+                version.as_str(),
+                info_value_ptr as *mut WChar,
+                buffer_length as usize,
+                string_length_ptr,
+            )
+        }
         // SQL_DRIVER_ODBC_VER
         InfoType::DriverOdbcVer => {
             // This driver supports version 3.8.

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -2269,7 +2269,6 @@ unsafe fn sql_get_infow_helper(
             // MongoSQL does not have a maximum identifier length.
             i16_len::set_output_fixed_data(&SQL_U16_ZERO, info_value_ptr, string_length_ptr)
         }
-        _ => SqlReturn::SUCCESS,
     }
 }
 

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -80,4 +80,12 @@ mod unit {
         minor = "222",
         patch = "33333"
     );
+
+    format_version_test!(
+        format_cargo_version,
+        expected = "00.01.0000",
+        major = env!("CARGO_PKG_VERSION_MAJOR"),
+        minor = env!("CARGO_PKG_VERSION_MINOR"),
+        patch = env!("CARGO_PKG_VERSION_PATCH")
+    );
 }

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -27,58 +27,57 @@ pub(crate) fn connection_attribute_to_string(attr: ConnectionAttribute) -> Strin
     }
 }
 
-// TODO: SQL-1109
-// pub(crate) fn format_version(major: &str, minor: &str, patch: &str) -> String {
-//     format!(
-//         "{}.{}.{}",
-//         format_version_part(major, 2),
-//         format_version_part(minor, 2),
-//         format_version_part(patch, 4)
-//     )
-// }
-//
-// fn format_version_part(part: &str, len: usize) -> String {
-//     if len < part.len() {
-//         return part.to_string();
-//     }
-//     format!("{}{}", "0".repeat(len - part.len()), part)
-// }
-//
-// mod unit {
-//     #[cfg(test)]
-//     use super::format_version;
-//
-//     macro_rules! format_version_test {
-//         ($func_name:ident, expected = $expected:expr, major = $major:expr, minor = $minor:expr, patch = $patch:expr) => {
-//             #[test]
-//             fn $func_name() {
-//                 let actual = format_version($major, $minor, $patch);
-//                 assert_eq!($expected, actual)
-//             }
-//         };
-//     }
-//
-//     format_version_test!(
-//         no_padding_needed,
-//         expected = "10.11.1213",
-//         major = "10",
-//         minor = "11",
-//         patch = "1213"
-//     );
-//
-//     format_version_test!(
-//         padding_needed,
-//         expected = "01.01.0001",
-//         major = "1",
-//         minor = "1",
-//         patch = "1"
-//     );
-//
-//     format_version_test!(
-//         parts_larger_than_length,
-//         expected = "111.222.33333",
-//         major = "111",
-//         minor = "222",
-//         patch = "33333"
-//     );
-// }
+pub(crate) fn format_version(major: &str, minor: &str, patch: &str) -> String {
+    format!(
+        "{}.{}.{}",
+        format_version_part(major, 2),
+        format_version_part(minor, 2),
+        format_version_part(patch, 4)
+    )
+}
+
+fn format_version_part(part: &str, len: usize) -> String {
+    if len < part.len() {
+        return part.to_string();
+    }
+    format!("{}{}", "0".repeat(len - part.len()), part)
+}
+
+mod unit {
+    #[cfg(test)]
+    use super::format_version;
+
+    macro_rules! format_version_test {
+        ($func_name:ident, expected = $expected:expr, major = $major:expr, minor = $minor:expr, patch = $patch:expr) => {
+            #[test]
+            fn $func_name() {
+                let actual = format_version($major, $minor, $patch);
+                assert_eq!($expected, actual)
+            }
+        };
+    }
+
+    format_version_test!(
+        no_padding_needed,
+        expected = "10.11.1213",
+        major = "10",
+        minor = "11",
+        patch = "1213"
+    );
+
+    format_version_test!(
+        padding_needed,
+        expected = "01.01.0001",
+        major = "1",
+        minor = "1",
+        patch = "1"
+    );
+
+    format_version_test!(
+        parts_larger_than_length,
+        expected = "111.222.33333",
+        major = "111",
+        minor = "222",
+        patch = "33333"
+    );
+}


### PR DESCRIPTION
This PR uncomments the last `SQLGetInfoW` match case. As we know, this results in integration test memory failures, but these seem to be unrelated to this code directly so we could just override dependencies and get this into master anyway.