### PR TITLE
SQL-1067: Refactor Mongohandle to use fine grain locking

### DIFF
--- a/core/src/collections.rs
+++ b/core/src/collections.rs
@@ -7,6 +7,7 @@ use crate::{
         BsonTypeName,
     },
     stmt::MongoStatement,
+    util::to_name_regex,
     Error,
 };
 use bson::{doc, Bson, Document};
@@ -169,7 +170,7 @@ impl MongoStatement for MongoCollections {
     // Move the cursor to the next CollectionSpecification.
     // When cursor is exhausted move to next database in list
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
         if self.current_database_index.is_none() {
             if self.collections_for_db_list.is_empty() {
                 return Ok(false);
@@ -242,14 +243,6 @@ impl MongoStatement for MongoCollections {
     fn get_resultset_metadata(&self) -> &Vec<MongoColMetadata> {
         &COLLECTIONS_METADATA
     }
-}
-
-// Replaces SQL wildcard characters with associated regex
-// Returns a doc applying filter to name
-// SQL-1060: Improve SQL-to-Rust regex pattern method
-fn to_name_regex(filter: &str) -> Document {
-    let regex_filter = filter.replace('%', ".*").replace('_', ".");
-    doc! { "name": { "$regex": regex_filter } }
 }
 
 mod unit {

--- a/core/src/databases.rs
+++ b/core/src/databases.rs
@@ -227,7 +227,7 @@ impl MongoDatabases {
 impl MongoStatement for MongoDatabases {
     // Increment current_db_index.
     // Return true if current_db_index index is <= for databases_names.length.
-    fn next(&mut self) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
         self.current_db_index += 1;
         Ok(self.current_db_index <= self.database_names.len())
     }

--- a/core/src/mock_query.rs
+++ b/core/src/mock_query.rs
@@ -1,4 +1,6 @@
-use crate::{col_metadata::MongoColMetadata, err::Result, stmt::MongoStatement, Error};
+use crate::{
+    col_metadata::MongoColMetadata, err::Result, stmt::MongoStatement, Error, MongoConnection,
+};
 use bson::{Bson, Document};
 
 #[derive(Debug, Clone)]
@@ -24,7 +26,7 @@ impl MongoQuery {
 impl MongoStatement for MongoQuery {
     // Move the current index to the next Document in the Vec.
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
         if let Some(current) = self.current {
             self.current = Some(current + 1);
         } else {

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -78,7 +78,7 @@ impl MongoStatement for MongoQuery {
     // Move the cursor to the next document and update the current row.
     // Return true if moving was successful, false otherwise.
     // This method deserializes the current row and stores it in self.
-    fn next(&mut self) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
         let res = self.resultset_cursor.advance().map_err(Error::Mongo);
         if let Ok(false) = res {
             // deserialize_current unwraps None if we do not check the value of advance.

--- a/core/src/stmt.rs
+++ b/core/src/stmt.rs
@@ -1,6 +1,6 @@
 use crate::{
     err::{Error, Result},
-    MongoColMetadata,
+    MongoColMetadata, MongoConnection,
 };
 use bson::Bson;
 use std::fmt::Debug;
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 pub trait MongoStatement: Debug {
     // Move the cursor to the next item.
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self) -> Result<bool>;
+    fn next(&mut self, mongo_connection: Option<&MongoConnection>) -> Result<bool>;
     // Get the BSON value for the cell at the given colIndex on the current row.
     // Fails if the first row has not been retrieved (next must be called at least once before getValue).
     fn get_value(&self, col_index: u16) -> Result<Option<Bson>>;

--- a/core/src/table_types.rs
+++ b/core/src/table_types.rs
@@ -1,4 +1,7 @@
-use crate::{databases::DATABASES_METADATA, err::Result, Error, MongoColMetadata, MongoStatement};
+use crate::{
+    databases::DATABASES_METADATA, err::Result, Error, MongoColMetadata, MongoConnection,
+    MongoStatement,
+};
 use bson::Bson;
 
 const TABLE_TYPES: [&str; 2] = ["TABLE", "VIEW"];
@@ -24,7 +27,7 @@ impl MongoTableTypes {
 impl MongoStatement for MongoTableTypes {
     // Increment current_table_type_index.
     // Return true if current_table_type_index index is <= for table_type.length.
-    fn next(&mut self) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
         self.current_table_type_index += 1;
         Ok(self.current_table_type_index <= self.table_type.len())
     }

--- a/core/src/util/decimal128.rs
+++ b/core/src/util/decimal128.rs
@@ -133,7 +133,7 @@ impl Decimal128Plus for [u8; 16] {
         };
 
         // the exponent if scientific notation is used
-        let scientific_exponent = significand_digits as i32 - 1 + exponent as i32;
+        let scientific_exponent = significand_digits - 1 + exponent;
 
         // The scientific exponent checks are dictated by the string conversion
         // specification and are somewhat arbitrary cutoffs.
@@ -178,7 +178,7 @@ impl Decimal128Plus for [u8; 16] {
             }
             return str_out;
         }
-        let mut radix_position = significand_digits as i32 + exponent;
+        let mut radix_position = significand_digits + exponent;
         if radix_position > 0 {
             // non-zero digits before radix
             let mut i = 0;
@@ -202,7 +202,7 @@ impl Decimal128Plus for [u8; 16] {
         // Note we do not have radix_position - 1 in max here unlike the C code.
         // This is because the C code has radix_position++ in the while condition,
         // so `C radix postion` == `rust radix position` + 1 at this point.
-        while (i < (significand_digits as i32 - std::cmp::max(radix_position, 0)))
+        while (i < (significand_digits - std::cmp::max(radix_position, 0)))
             && str_out.len() < BSON_DECIMAL128_STRING
         {
             str_out.push(char::from_digit(significand[significand_index] as u32, 10).unwrap());

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -1,5 +1,14 @@
 mod decimal128;
+use bson::{doc, Document};
 pub use decimal128::Decimal128Plus;
+
+// Replaces SQL wildcard characters with associated regex
+// Returns a doc applying filter to name
+// SQL-1060: Improve SQL-to-Rust regex pattern method
+pub(crate) fn to_name_regex(filter: &str) -> Document {
+    let regex_filter = filter.replace('%', ".*").replace('_', ".");
+    doc! { "name": { "$regex": regex_filter } }
+}
 
 #[macro_export]
 macro_rules! map {

--- a/odbc/src/api/col_attr_describe_tests.rs
+++ b/odbc/src/api/col_attr_describe_tests.rs
@@ -15,10 +15,10 @@ mod unit {
     // has been called).
     #[test]
     fn unallocated_statement_string_attr() {
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
 
         for desc in [
             Desc::BaseColumnName,
@@ -57,9 +57,9 @@ mod unit {
                         (*stmt_handle)
                             .as_statement()
                             .unwrap()
+                            .errors
                             .read()
-                            .unwrap()
-                            .errors[0]
+                            .unwrap()[0]
                     ),
                 );
                 let _ = Box::from_raw(char_buffer);
@@ -69,10 +69,10 @@ mod unit {
 
     #[test]
     fn unallocated_statement_numeric_attr() {
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
 
         for desc in [
             Desc::AutoUniqueValue,
@@ -118,9 +118,9 @@ mod unit {
                         (*stmt_handle)
                             .as_statement()
                             .unwrap()
+                            .errors
                             .read()
-                            .unwrap()
-                            .errors[0]
+                            .unwrap()[0]
                     ),
                 );
                 let _ = Box::from_raw(char_buffer);
@@ -130,10 +130,10 @@ mod unit {
 
     #[test]
     fn unallocated_statement_describe_col() {
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
         unsafe {
             let name_buffer: *mut std::ffi::c_void = Box::into_raw(Box::new([0u8; 40])) as *mut _;
             let name_buffer_length: SmallInt = 20;
@@ -164,9 +164,9 @@ mod unit {
                     (*stmt_handle)
                         .as_statement()
                         .unwrap()
+                        .errors
                         .read()
-                        .unwrap()
-                        .errors[0]
+                        .unwrap()[0]
                 ),
             );
             let _ = Box::from_raw(name_buffer);
@@ -175,10 +175,10 @@ mod unit {
 
     #[test]
     fn unallocated_statement_unsupported_attr() {
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
 
         for desc in [
             Desc::OctetLengthPtr,
@@ -224,9 +224,9 @@ mod unit {
                         (*stmt_handle)
                             .as_statement()
                             .unwrap()
+                            .errors
                             .read()
-                            .unwrap()
-                            .errors[0]
+                            .unwrap()[0]
                     ),
                 );
                 let _ = Box::from_raw(char_buffer);
@@ -237,8 +237,8 @@ mod unit {
     #[test]
     fn test_index_out_of_bounds_describe() {
         let mut stmt = Statement::with_state(std::ptr::null_mut(), StatementState::Allocated);
-        stmt.mongo_statement = Some(Box::new(MongoFields::empty()));
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(stmt));
+        stmt.mongo_statement = RwLock::new(Some(Box::new(MongoFields::empty())));
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(stmt);
         unsafe {
             for col_index in [0, 30] {
                 let name_buffer: *mut std::ffi::c_void =
@@ -274,9 +274,9 @@ mod unit {
                         (*stmt_handle)
                             .as_statement()
                             .unwrap()
+                            .errors
                             .read()
-                            .unwrap()
-                            .errors[0]
+                            .unwrap()[0]
                     )
                 );
                 let _ = Box::from_raw(name_buffer);
@@ -287,8 +287,8 @@ mod unit {
     #[test]
     fn test_index_out_of_bounds_attr() {
         let mut stmt = Statement::with_state(std::ptr::null_mut(), StatementState::Allocated);
-        stmt.mongo_statement = Some(Box::new(MongoFields::empty()));
-        let mongo_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(stmt));
+        stmt.mongo_statement = RwLock::new(Some(Box::new(MongoFields::empty())));
+        let mongo_handle: *mut _ = &mut MongoHandle::Statement(stmt);
         for desc in [
             // string descriptor
             Desc::TypeName,
@@ -325,9 +325,9 @@ mod unit {
                             (*mongo_handle)
                                 .as_statement()
                                 .unwrap()
+                                .errors
                                 .read()
-                                .unwrap()
-                                .errors[0]
+                                .unwrap()[0]
                         )
                     );
                     let _ = Box::from_raw(char_buffer);
@@ -341,8 +341,8 @@ mod unit {
     fn test_string_field_attributes() {
         unsafe {
             let mut stmt = Statement::with_state(std::ptr::null_mut(), StatementState::Allocated);
-            stmt.mongo_statement = Some(Box::new(MongoFields::empty()));
-            let mongo_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(stmt));
+            stmt.mongo_statement = RwLock::new(Some(Box::new(MongoFields::empty())));
+            let mongo_handle: *mut _ = &mut MongoHandle::Statement(stmt);
             let col_index = 3; //TABLE_NAME
             for (desc, expected) in [
                 (Desc::BaseColumnName, ""),
@@ -390,8 +390,8 @@ mod unit {
     #[test]
     fn test_numeric_field_attributes() {
         let mut stmt = Statement::with_state(std::ptr::null_mut(), StatementState::Allocated);
-        stmt.mongo_statement = Some(Box::new(MongoFields::empty()));
-        let mongo_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(stmt));
+        stmt.mongo_statement = RwLock::new(Some(Box::new(MongoFields::empty())));
+        let mongo_handle: *mut _ = &mut MongoHandle::Statement(stmt);
         let col_index = 3; //TABLE_NAME
         for (desc, expected) in [
             (Desc::AutoUniqueValue, 0isize),
@@ -441,8 +441,8 @@ mod unit {
     fn test_describe_col() {
         unsafe {
             let mut stmt = Statement::with_state(std::ptr::null_mut(), StatementState::Allocated);
-            stmt.mongo_statement = Some(Box::new(MongoFields::empty()));
-            let mongo_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(stmt));
+            stmt.mongo_statement = RwLock::new(Some(Box::new(MongoFields::empty())));
+            let mongo_handle: *mut _ = &mut MongoHandle::Statement(stmt);
             let col_index = 3; //TABLE_NAME
             let name_buffer: *mut std::ffi::c_void = Box::into_raw(Box::new([0u8; 40])) as *mut _;
             let name_buffer_length: SmallInt = 20;

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::ODBCError,
-    handles::definitions::{CachedData, MongoHandle},
+    handles::definitions::{CachedData, MongoHandle, Statement},
 };
 use bson::{spec::BinarySubtype, Bson};
 use chrono::{
@@ -10,7 +10,7 @@ use chrono::{
 use mongo_odbc_core::util::Decimal128Plus;
 use odbc_sys::{CDataType, Date, Len, Pointer, Time, Timestamp, USmallInt};
 use odbc_sys::{Char, Integer, SmallInt, SqlReturn, WChar};
-use std::{cmp::min, collections::HashMap, mem::size_of, ptr::copy_nonoverlapping, str::FromStr};
+use std::{cmp::min, mem::size_of, ptr::copy_nonoverlapping, str::FromStr};
 
 const BINARY: &str = "Binary";
 const DOUBLE: &str = "Double";
@@ -420,10 +420,10 @@ pub unsafe fn format_binary(
     let sql_return = {
         let stmt = (*mongo_handle).as_statement().unwrap();
         isize_len::set_output_binary(
+            stmt,
             data,
             col_num,
             index,
-            stmt.var_data_cache.write().unwrap().as_mut().unwrap(),
             target_value_ptr as *mut _,
             buffer_len as usize,
             str_len_or_ind_ptr,
@@ -442,10 +442,10 @@ macro_rules! char_data {
         let sql_return = {
             let stmt = (*mongo_handle).as_statement().unwrap();
             $func(
+                stmt,
                 $data,
                 $col_num,
                 $index,
-                stmt.var_data_cache.write().unwrap().as_mut().unwrap(),
                 $target_value_ptr as *mut _,
                 $buffer_len as usize,
                 $str_len_or_ind_ptr,
@@ -461,12 +461,7 @@ macro_rules! char_data {
 macro_rules! fixed_data_with_warnings {
     ($mongo_handle:expr, $col_num:expr, $data:expr, $target_value_ptr:expr, $str_len_or_ind_ptr:expr) => {{
         let stmt = (*$mongo_handle).as_statement().unwrap();
-        stmt.var_data_cache
-            .write()
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .insert($col_num, CachedData::Fixed);
+        stmt.insert_var_data_cache($col_num, CachedData::Fixed);
         match $data {
             Ok((u, warning)) => {
                 let sqlreturn =
@@ -493,12 +488,7 @@ pub unsafe fn format_datetime(
     data: Bson,
 ) -> SqlReturn {
     let stmt = (*mongo_handle).as_statement().unwrap();
-    stmt.var_data_cache
-        .write()
-        .unwrap()
-        .as_mut()
-        .unwrap()
-        .insert(col_num, CachedData::Fixed);
+    stmt.insert_var_data_cache(col_num, CachedData::Fixed);
     let dt = data.to_datetime();
     match dt {
         Ok(dt) => {
@@ -529,12 +519,7 @@ pub unsafe fn format_time(
 ) -> SqlReturn {
     let stmt = (*mongo_handle).as_statement().unwrap();
     let dt = data.to_datetime();
-    stmt.var_data_cache
-        .write()
-        .unwrap()
-        .as_mut()
-        .unwrap()
-        .insert(col_num, CachedData::Fixed);
+    stmt.insert_var_data_cache(col_num, CachedData::Fixed);
     match dt {
         Ok(dt) => {
             let data = Time {
@@ -559,12 +544,7 @@ pub unsafe fn format_date(
     data: Bson,
 ) -> SqlReturn {
     let stmt = (*mongo_handle).as_statement().unwrap();
-    stmt.var_data_cache
-        .write()
-        .unwrap()
-        .as_mut()
-        .unwrap()
-        .insert(col_num, CachedData::Fixed);
+    stmt.insert_var_data_cache(col_num, CachedData::Fixed);
     let dt = data.to_datetime();
     match dt {
         Ok(dt) => {
@@ -597,23 +577,13 @@ pub unsafe fn format_cached_data(
             let stmt = (*mongo_handle).as_statement().unwrap();
             // we need to insert Fixed so that we can return SqlReturn::NO_DATA if this is
             // called again.
-            stmt.var_data_cache
-                .write()
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .insert(col_or_param_num, a);
+            stmt.insert_var_data_cache(col_or_param_num, a);
             SqlReturn::NO_DATA
         }
         CachedData::Char(index, data) => {
             if target_type != CDataType::Char {
                 let stmt = (*mongo_handle).as_statement().unwrap();
-                stmt.var_data_cache
-                    .write()
-                    .unwrap()
-                    .as_mut()
-                    .unwrap()
-                    .insert(col_or_param_num, CachedData::Char(index, data));
+                stmt.insert_var_data_cache(col_or_param_num, CachedData::Char(index, data));
                 return SqlReturn::NO_DATA;
             }
             char_data!(
@@ -631,12 +601,7 @@ pub unsafe fn format_cached_data(
             if target_type != CDataType::WChar {
                 let stmt = (*mongo_handle).as_statement().unwrap();
 
-                stmt.var_data_cache
-                    .write()
-                    .unwrap()
-                    .as_mut()
-                    .unwrap()
-                    .insert(col_or_param_num, CachedData::WChar(index, data));
+                stmt.insert_var_data_cache(col_or_param_num, CachedData::WChar(index, data));
                 return SqlReturn::NO_DATA;
             }
             char_data!(
@@ -654,12 +619,7 @@ pub unsafe fn format_cached_data(
             if target_type != CDataType::Binary {
                 let stmt = (*mongo_handle).as_statement().unwrap();
 
-                stmt.var_data_cache
-                    .write()
-                    .unwrap()
-                    .as_mut()
-                    .unwrap()
-                    .insert(col_or_param_num, CachedData::Bin(index, data));
+                stmt.insert_var_data_cache(col_or_param_num, CachedData::Bin(index, data));
                 return SqlReturn::NO_DATA;
             }
             crate::api::data::format_binary(
@@ -697,12 +657,7 @@ pub unsafe fn format_bson_data(
                 return SqlReturn::SUCCESS_WITH_INFO;
             }
             *str_len_or_ind_ptr = odbc_sys::NULL_DATA;
-            stmt.var_data_cache
-                .write()
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .insert(col_num, CachedData::Fixed);
+            stmt.insert_var_data_cache(col_num, CachedData::Fixed);
             return SqlReturn::SUCCESS;
         }
         _ => {}
@@ -1173,10 +1128,10 @@ pub mod isize_len {
     /// This writes to multiple raw C-pointers
     ///
     pub unsafe fn set_output_wstring(
+        stmt: &Statement,
         message: Vec<u16>,
         col_num: USmallInt,
         index: usize,
-        var_data_cache: &mut HashMap<USmallInt, CachedData>,
         output_ptr: *mut WChar,
         buffer_len: usize,
         text_length_ptr: *mut Len,
@@ -1195,7 +1150,7 @@ pub mod isize_len {
             set_output_wstring_helper(message.get(index..).unwrap(), output_ptr, buffer_len);
         // the returned length should always be the total length of the data.
         *text_length_ptr = (message.len() - index) as Len;
-        var_data_cache.insert(col_num, CachedData::WChar(index + len, message));
+        stmt.insert_var_data_cache(col_num, CachedData::WChar(index + len, message));
         ret
     }
 
@@ -1209,10 +1164,10 @@ pub mod isize_len {
     /// This writes to multiple raw C-pointers
     ///
     pub unsafe fn set_output_string(
+        stmt: &Statement,
         message: Vec<u8>,
         col_num: USmallInt,
         index: usize,
-        var_data_cache: &mut HashMap<USmallInt, CachedData>,
         output_ptr: *mut Char,
         buffer_len: usize,
         text_length_ptr: *mut Len,
@@ -1233,7 +1188,7 @@ pub mod isize_len {
         *text_length_ptr = (message.len() - index) as Len;
         // The lenth parameter does not matter because character data uses 8bit words and
         // we can obtain it from message.chars().count() above.
-        var_data_cache.insert(col_num, CachedData::Char(len + index, message));
+        stmt.insert_var_data_cache(col_num, CachedData::Char(len + index, message));
         ret
     }
 
@@ -1247,10 +1202,10 @@ pub mod isize_len {
     /// This writes to multiple raw C-pointers
     ///
     pub unsafe fn set_output_binary(
+        stmt: &Statement,
         data: Vec<u8>,
         col_num: USmallInt,
         index: usize,
-        var_data_cache: &mut HashMap<USmallInt, CachedData>,
         output_ptr: *mut Char,
         buffer_len: usize,
         text_length_ptr: *mut Len,
@@ -1268,7 +1223,7 @@ pub mod isize_len {
         let (len, ret) =
             set_output_binary_helper(data.get(index..).unwrap(), output_ptr, buffer_len);
         *text_length_ptr = (data.len() - index) as Len;
-        var_data_cache.insert(col_num, CachedData::Bin(len + index, data));
+        stmt.insert_var_data_cache(col_num, CachedData::Bin(len + index, data));
         ret
     }
 

--- a/odbc/src/api/env_attr_tests.rs
+++ b/odbc/src/api/env_attr_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     SQLGetDiagRecW, SQLGetEnvAttrW, SQLSetEnvAttrW,
 };
 use odbc_sys::{EnvironmentAttribute, HEnv, HandleType, Integer, Pointer, SqlReturn};
-use std::{collections::BTreeMap, ffi::c_void, mem::size_of, sync::RwLock};
+use std::{collections::BTreeMap, ffi::c_void, mem::size_of};
 
 const OPTIONAL_VALUE_CHANGED: &str = "01S02\0";
 
@@ -76,8 +76,7 @@ mod unit {
     fn test_env_attr() {
         unsafe {
             use crate::map;
-            let env_handle: *mut _ =
-                &mut MongoHandle::Env(RwLock::new(Env::with_state(EnvState::Allocated)));
+            let env_handle: *mut _ = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
 
             get_set_env_attr(
                 env_handle,
@@ -155,8 +154,7 @@ mod unit {
     #[test]
     fn test_optional_value_changed() {
         unsafe {
-            let handle: *mut _ =
-                &mut MongoHandle::Env(RwLock::new(Env::with_state(EnvState::Allocated)));
+            let handle: *mut _ = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
             assert_eq!(
                 SqlReturn::SUCCESS_WITH_INFO,
                 SQLSetEnvAttrW(

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -24,12 +24,7 @@ use odbc_sys::{
     Integer, Len, Nullability, ParamType, Pointer, RetCode, SmallInt, SqlDataType, SqlReturn,
     StatementAttribute, ULen, USmallInt, WChar,
 };
-use std::{
-    collections::HashMap,
-    mem::size_of,
-    panic,
-    sync::{mpsc, RwLock},
-};
+use std::{collections::HashMap, mem::size_of, panic, sync::mpsc};
 
 const NULL_HANDLE_ERROR: &str = "handle cannot be null";
 const HANDLE_MUST_BE_ENV_ERROR: &str = "handle must be env";
@@ -152,7 +147,7 @@ fn sql_alloc_handle(
 ) -> Result<()> {
     match handle_type {
         HandleType::Env => {
-            let env = RwLock::new(Env::with_state(EnvState::Allocated));
+            let env = Env::with_state(EnvState::Allocated);
             let mh = Box::new(MongoHandle::Env(env));
             unsafe {
                 *output_handle = Box::into_raw(mh) as *mut _;
@@ -170,15 +165,11 @@ fn sql_alloc_handle(
                     .as_env()
                     .ok_or(ODBCError::InvalidHandleType(HANDLE_MUST_BE_ENV_ERROR))?
             };
-            let conn = RwLock::new(Connection::with_state(
-                input_handle,
-                ConnectionState::Allocated,
-            ));
-            let mut env_contents = (*env).write().unwrap();
+            let conn = Connection::with_state(input_handle, ConnectionState::Allocated);
             let mh = Box::new(MongoHandle::Connection(conn));
             let mh_ptr = Box::into_raw(mh);
-            env_contents.connections.insert(mh_ptr);
-            env_contents.state = EnvState::ConnectionAllocated;
+            env.connections.write().unwrap().insert(mh_ptr);
+            *(env.state.write().unwrap()) = EnvState::ConnectionAllocated;
             unsafe { *output_handle = mh_ptr as *mut _ }
             Ok(())
         }
@@ -193,15 +184,11 @@ fn sql_alloc_handle(
                     .as_connection()
                     .ok_or(ODBCError::InvalidHandleType(HANDLE_MUST_BE_CONN_ERROR))?
             };
-            let stmt = RwLock::new(Statement::with_state(
-                input_handle,
-                StatementState::Allocated,
-            ));
-            let mut conn_contents = (*conn).write().unwrap();
+            let stmt = Statement::with_state(input_handle, StatementState::Allocated);
             let mh = Box::new(MongoHandle::Statement(stmt));
             let mh_ptr = Box::into_raw(mh);
-            conn_contents.statements.insert(mh_ptr);
-            conn_contents.state = ConnectionState::StatementAllocated;
+            conn.statements.write().unwrap().insert(mh_ptr);
+            *(conn.state.write().unwrap()) = ConnectionState::StatementAllocated;
             unsafe { *output_handle = mh_ptr as *mut _ }
             Ok(())
         }
@@ -376,56 +363,42 @@ pub unsafe extern "C" fn SQLColAttributeW(
 ) -> SqlReturn {
     panic_safe_exec!(
         || {
-            {
-                let mongo_handle = MongoHandleRef::from(statement_handle);
-                mongo_handle.clear_diagnostics();
-                let stmt = must_be_valid!((*mongo_handle).as_statement());
-                let mut stmt_contents = stmt.write().unwrap();
-                if stmt_contents.mongo_statement.is_none() {
-                    stmt_contents.errors.push(ODBCError::NoResultSet);
-                    return SqlReturn::ERROR;
-                }
+            let mongo_handle = MongoHandleRef::from(statement_handle);
+            let stmt = must_be_valid!((*mongo_handle).as_statement());
+            let mongo_stmt = stmt.mongo_statement.read().unwrap();
+            stmt.errors.write().unwrap().clear();
+            if mongo_stmt.is_none() {
+                stmt.errors.write().unwrap().push(ODBCError::NoResultSet);
+                return SqlReturn::ERROR;
             }
             let string_col_attr = |f: &dyn Fn(&MongoColMetadata) -> &str| {
                 let mongo_handle = MongoHandleRef::from(statement_handle);
-                let stmt = (*mongo_handle).as_statement().unwrap();
-                {
-                    let stmt_contents = stmt.read().unwrap();
-                    let col_metadata = stmt_contents
-                        .mongo_statement
-                        .as_ref()
-                        .unwrap()
-                        .get_col_metadata(column_number);
-                    if let Ok(col_metadata) = col_metadata {
-                        return i16_len::set_output_wstring(
-                            (*f)(col_metadata),
-                            character_attribute_ptr as *mut WChar,
-                            buffer_length as usize,
-                            string_length_ptr,
-                        );
-                    }
+                let col_metadata = mongo_stmt.as_ref().unwrap().get_col_metadata(column_number);
+                if let Ok(col_metadata) = col_metadata {
+                    return i16_len::set_output_wstring(
+                        (*f)(col_metadata),
+                        character_attribute_ptr as *mut WChar,
+                        buffer_length as usize,
+                        string_length_ptr,
+                    );
                 }
                 // unfortunately, we cannot use odbc_unwrap! on the value because it causes a deadlock.
                 mongo_handle.add_diag_info(ODBCError::InvalidDescriptorIndex(column_number));
                 SqlReturn::ERROR
             };
             let numeric_col_attr = |f: &dyn Fn(&MongoColMetadata) -> Len| {
-                let mongo_handle = MongoHandleRef::from(statement_handle);
-                let stmt = (*mongo_handle).as_statement().unwrap();
                 {
-                    let stmt_contents = stmt.read().unwrap();
-                    let col_metadata = stmt_contents
-                        .mongo_statement
-                        .as_ref()
-                        .unwrap()
-                        .get_col_metadata(column_number);
+                    let col_metadata = mongo_stmt.as_ref().unwrap().get_col_metadata(column_number);
                     if let Ok(col_metadata) = col_metadata {
                         *numeric_attribute_ptr = (*f)(col_metadata);
                         return SqlReturn::SUCCESS;
                     }
                 }
                 // unfortunately, we cannot use odbc_unwrap! on the value because it causes a deadlock.
-                mongo_handle.add_diag_info(ODBCError::InvalidDescriptorIndex(column_number));
+                stmt.errors
+                    .write()
+                    .unwrap()
+                    .push(ODBCError::InvalidDescriptorIndex(column_number));
                 SqlReturn::ERROR
             };
             match field_identifier {
@@ -438,19 +411,8 @@ pub unsafe extern "C" fn SQLColAttributeW(
                     SqlReturn::SUCCESS
                 }
                 Desc::Count => {
-                    let mongo_handle = MongoHandleRef::from(statement_handle);
-                    let stmt = must_be_valid!((*mongo_handle).as_statement());
-                    let stmt_contents = stmt.read().unwrap();
-                    if stmt_contents.mongo_statement.is_none() {
-                        *numeric_attribute_ptr = 0 as Len;
-                        return SqlReturn::SUCCESS;
-                    }
-                    *numeric_attribute_ptr = stmt_contents
-                        .mongo_statement
-                        .as_ref()
-                        .unwrap()
-                        .get_resultset_metadata()
-                        .len() as Len;
+                    *numeric_attribute_ptr =
+                        mongo_stmt.as_ref().unwrap().get_resultset_metadata().len() as Len;
                     SqlReturn::SUCCESS
                 }
                 Desc::CaseSensitive => numeric_col_attr(&|x: &MongoColMetadata| {
@@ -782,16 +744,12 @@ pub unsafe extern "C" fn SQLDescribeColW(
             stmt_handle.clear_diagnostics();
             {
                 let stmt = must_be_valid!(stmt_handle.as_statement());
-                let mut stmt_contents = stmt.write().unwrap();
-                if stmt_contents.mongo_statement.is_none() {
-                    stmt_contents.errors.push(ODBCError::NoResultSet);
+                let mongo_stmt = stmt.mongo_statement.write().unwrap();
+                if mongo_stmt.is_none() {
+                    stmt.errors.write().unwrap().push(ODBCError::NoResultSet);
                     return SqlReturn::ERROR;
                 }
-                let col_metadata = stmt_contents
-                    .mongo_statement
-                    .as_ref()
-                    .unwrap()
-                    .get_col_metadata(col_number);
+                let col_metadata = mongo_stmt.as_ref().unwrap().get_col_metadata(col_number);
                 if let Ok(col_metadata) = col_metadata {
                     *data_type = col_metadata.sql_type;
                     *col_size = col_metadata.display_size.unwrap_or(0) as usize;
@@ -844,31 +802,29 @@ pub unsafe extern "C" fn SQLDisconnect(connection_handle: HDbc) -> SqlReturn {
             let conn = must_be_valid!((*conn_handle).as_connection());
             // set the mongo_connection to None. This will cause the previous mongo_connection
             // to drop and disconnect.
-            conn.write().unwrap().mongo_connection = None;
+            *conn.mongo_connection.write().unwrap() = None;
             SqlReturn::SUCCESS
         },
         connection_handle
     );
 }
 
-fn sql_driver_connect(
-    conn_handle: &RwLock<Connection>,
-    odbc_uri_string: &str,
-) -> Result<MongoConnection> {
-    let conn_reader = conn_handle.read().unwrap();
+fn sql_driver_connect(conn: &Connection, odbc_uri_string: &str) -> Result<MongoConnection> {
     let mut odbc_uri = ODBCUri::new(odbc_uri_string)?;
     let mongo_uri = odbc_uri.remove_to_mongo_uri()?;
     let auth_src = odbc_uri.remove_or_else(|| "admin", &["auth_src"]);
     odbc_uri
         .remove(&["driver", "dsn"])
         .ok_or(ODBCError::MissingDriverOrDSNProperty)?;
-    let database = if conn_reader.attributes.current_catalog.is_some() {
-        conn_reader.attributes.current_catalog.as_deref()
+    let conn_attrs = conn.attributes.read().unwrap();
+    let database = if conn_attrs.current_catalog.is_some() {
+        conn_attrs.current_catalog.as_deref()
     } else {
         odbc_uri.remove(&["database"])
     };
-    let connection_timeout = conn_reader.attributes.connection_timeout;
-    let login_timeout = conn_reader.attributes.login_timeout;
+    let conn_attrs = conn.attributes.read().unwrap();
+    let connection_timeout = conn_attrs.connection_timeout;
+    let login_timeout = conn_attrs.login_timeout;
     let application_name = odbc_uri.remove(&["app_name", "application_name"]);
     // ODBCError has an impl From mongo_odbc_core::Error, but that does not
     // create an impl From Result<T, mongo_odbc_core::Error> to Result<T, ODBCError>
@@ -916,7 +872,7 @@ pub unsafe extern "C" fn SQLDriverConnect(
                 input_text_to_string(in_connection_string, string_length_1 as usize);
             let mongo_connection =
                 odbc_unwrap!(sql_driver_connect(conn, &odbc_uri_string), conn_handle);
-            conn.write().unwrap().mongo_connection = Some(mongo_connection);
+            *conn.mongo_connection.write().unwrap() = Some(mongo_connection);
             let buffer_len = usize::try_from(buffer_length).unwrap();
             let sql_return = i16_len::set_output_string(
                 &odbc_uri_string,
@@ -968,7 +924,7 @@ pub unsafe extern "C" fn SQLDriverConnectW(
                 input_wtext_to_string(in_connection_string, string_length_1 as usize);
             let mongo_connection =
                 odbc_unwrap!(sql_driver_connect(conn, &odbc_uri_string), conn_handle);
-            conn.write().unwrap().mongo_connection = Some(mongo_connection);
+            *conn.mongo_connection.write().unwrap() = Some(mongo_connection);
             let buffer_len = usize::try_from(buffer_length).unwrap();
             let sql_return = i16_len::set_output_wstring(
                 &odbc_uri_string,
@@ -1060,19 +1016,18 @@ pub unsafe extern "C" fn SQLExecDirect(
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let stmt = must_be_valid!(mongo_handle.as_statement());
             let mongo_statement = {
-                let stmt_guard = stmt.read().unwrap();
-                let connection = must_be_valid!((*stmt_guard.connection).as_connection());
-                let connection_guard = connection.read().unwrap();
-                let timeout = connection_guard.attributes.connection_timeout;
-                if let Some(ref mongo_connection) = connection_guard.mongo_connection {
+                let connection = must_be_valid!((*stmt.connection).as_connection());
+                let timeout = connection.attributes.read().unwrap().connection_timeout;
+                if let Some(mongo_connection) = connection.mongo_connection.read().unwrap().as_ref()
+                {
                     MongoQuery::execute(mongo_connection, timeout, &query).map_err(|e| e.into())
                 } else {
                     Err(ODBCError::General("Statement has no parent Connection"))
                 }
             };
+
             if let Ok(statement) = mongo_statement {
-                let mut stmt_guard = stmt.write().unwrap();
-                stmt_guard.mongo_statement = Some(Box::new(statement));
+                *stmt.mongo_statement.write().unwrap() = Some(Box::new(statement));
                 return SqlReturn::SUCCESS;
             }
             mongo_handle.add_diag_info(mongo_statement.unwrap_err());
@@ -1102,19 +1057,17 @@ pub unsafe extern "C" fn SQLExecDirectW(
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let stmt = must_be_valid!(mongo_handle.as_statement());
             let mongo_statement = {
-                let stmt_guard = stmt.read().unwrap();
-                let connection = must_be_valid!((*stmt_guard.connection).as_connection());
-                let connection_guard = connection.read().unwrap();
-                let timeout = connection_guard.attributes.connection_timeout;
-                if let Some(ref mongo_connection) = connection_guard.mongo_connection {
+                let connection = must_be_valid!((*stmt.connection).as_connection());
+                let timeout = connection.attributes.read().unwrap().connection_timeout;
+                if let Some(mongo_connection) = connection.mongo_connection.read().unwrap().as_ref()
+                {
                     MongoQuery::execute(mongo_connection, timeout, &query).map_err(|e| e.into())
                 } else {
                     Err(ODBCError::InvalidCursorState)
                 }
             };
             if let Ok(statement) = mongo_statement {
-                let mut stmt_guard = stmt.write().unwrap();
-                stmt_guard.mongo_statement = Some(Box::new(statement));
+                *stmt.mongo_statement.write().unwrap() = Some(Box::new(statement));
                 return SqlReturn::SUCCESS;
             }
             mongo_handle.add_diag_info(mongo_statement.unwrap_err());
@@ -1145,37 +1098,40 @@ pub unsafe extern "C" fn SQLExecute(statement_handle: HStmt) -> SqlReturn {
 pub unsafe extern "C" fn SQLFetch(statement_handle: HStmt) -> SqlReturn {
     panic_safe_exec!(
         || {
-            let mut error = None;
             let mongo_handle = MongoHandleRef::from(statement_handle);
-            // This scope is introduced to make the RWLock Guard expire before we write
-            // any error values via add_diag_info as RWLock::write is not reentrant on
-            // all operating systems, and the docs say it can panic.
-            {
-                let stmt = must_be_valid!((*mongo_handle).as_statement());
-                let mut guard = stmt.write().unwrap();
-                let mongo_stmt = guard.mongo_statement.as_mut();
-                match mongo_stmt {
-                    None => error = Some(ODBCError::InvalidCursorState),
-                    Some(mongo_stmt) => {
-                        let res = mongo_stmt.next();
-                        match res {
-                            Err(e) => error = Some(e.into()),
-                            Ok(b) => {
-                                if !b {
-                                    guard.attributes.row_index_is_valid = false;
-                                    return SqlReturn::NO_DATA;
-                                }
-                                guard.attributes.row_index_is_valid = true;
-                            }
-                        }
-                        guard.var_data_cache = Some(HashMap::new());
-                    }
-                }
-            }
-            if let Some(e) = error {
-                mongo_handle.add_diag_info(e);
+            let stmt = must_be_valid!((*mongo_handle).as_statement());
+            let mut mongo_stmt = stmt.mongo_statement.write().unwrap();
+            let connection = must_be_valid!((*stmt.connection).as_connection());
+
+            if mongo_stmt.is_none() {
+                stmt.errors
+                    .write()
+                    .unwrap()
+                    .push(ODBCError::InvalidCursorState);
                 return SqlReturn::ERROR;
             }
+
+            let res = mongo_stmt
+                .as_mut()
+                .unwrap()
+                .next(connection.mongo_connection.read().unwrap().as_ref());
+
+            match res {
+                Err(e) => {
+                    stmt.errors.write().unwrap().push(e.into());
+                    return SqlReturn::ERROR;
+                }
+                Ok(b) => {
+                    let mut stmt_attrs = stmt.attributes.write().unwrap();
+                    if !b {
+                        stmt_attrs.row_index_is_valid = false;
+                        return SqlReturn::NO_DATA;
+                    }
+                    stmt_attrs.row_index_is_valid = true;
+                }
+            }
+
+            *stmt.var_data_cache.write().unwrap() = Some(HashMap::new());
             SqlReturn::SUCCESS
         },
         statement_handle
@@ -1285,16 +1241,15 @@ fn sql_free_handle(handle_type: HandleType, handle: *mut MongoHandle) -> Result<
                     .as_connection()
                     .ok_or(ODBCError::InvalidHandleType(HANDLE_MUST_BE_CONN_ERROR))?
             };
-            let mut env_contents = unsafe {
-                (*conn.write().unwrap().env)
+            let env = unsafe {
+                (*conn.env)
                     .as_env()
                     .ok_or(ODBCError::InvalidHandleType(HANDLE_MUST_BE_ENV_ERROR))?
-                    .write()
-                    .unwrap()
             };
-            env_contents.connections.remove(&handle);
-            if env_contents.connections.is_empty() {
-                env_contents.state = EnvState::Allocated;
+            let mut connections = env.connections.write().unwrap();
+            connections.remove(&handle);
+            if connections.is_empty() {
+                *env.state.write().unwrap() = EnvState::Allocated;
             }
         }
         HandleType::Stmt => {
@@ -1305,16 +1260,15 @@ fn sql_free_handle(handle_type: HandleType, handle: *mut MongoHandle) -> Result<
             };
             // Actually reading this value would make ASAN fail, but this
             // is what the ODBC standard expects.
-            let mut conn_contents = unsafe {
-                (*stmt.write().unwrap().connection)
+            let conn = unsafe {
+                (*stmt.connection)
                     .as_connection()
                     .ok_or(ODBCError::InvalidHandleType(HANDLE_MUST_BE_CONN_ERROR))?
-                    .write()
-                    .unwrap()
             };
-            conn_contents.statements.remove(&handle);
-            if conn_contents.statements.is_empty() {
-                conn_contents.state = ConnectionState::Connected;
+            let mut statements = conn.statements.write().unwrap();
+            statements.remove(&handle);
+            if statements.is_empty() {
+                *conn.state.write().unwrap() = ConnectionState::Connected;
             }
         }
         HandleType::Desc => {
@@ -1386,7 +1340,7 @@ pub unsafe extern "C" fn SQLGetConnectAttrW(
             // all operating systems, and the docs say it can panic.
             let sql_return = {
                 let conn = must_be_valid!((*conn_handle).as_connection());
-                let attributes = &conn.read().unwrap().attributes;
+                let attributes = &conn.attributes.read().unwrap();
 
                 match attribute {
                     ConnectionAttribute::CurrentCatalog => {
@@ -1488,9 +1442,12 @@ pub unsafe extern "C" fn SQLGetData(
             {
                 let res = {
                     let stmt = must_be_valid!((*mongo_handle).as_statement());
-                    let mut guard = stmt.write().unwrap();
-                    let indices = guard.var_data_cache.as_mut().unwrap();
-                    indices.remove(&col_or_param_num)
+                    stmt.var_data_cache
+                        .write()
+                        .unwrap()
+                        .as_mut()
+                        .unwrap()
+                        .remove(&col_or_param_num)
                 };
                 if let Some(cached_data) = res {
                     return crate::api::data::format_cached_data(
@@ -1504,9 +1461,8 @@ pub unsafe extern "C" fn SQLGetData(
                     );
                 }
                 let stmt = (*mongo_handle).as_statement().unwrap();
-                let mut guard = stmt.write().unwrap();
-                let mongo_stmt = guard.mongo_statement.as_mut();
-                let bson = match mongo_stmt {
+                let mut mongo_stmt = stmt.mongo_statement.write().unwrap();
+                let bson = match mongo_stmt.as_mut() {
                     None => Err(ODBCError::InvalidCursorState),
                     Some(mongo_stmt) => mongo_stmt
                         .get_value(col_or_param_num)
@@ -1729,15 +1685,15 @@ pub unsafe extern "C" fn SQLGetDiagRecW(
             match handle_type {
                 HandleType::Env => {
                     let env = must_be_env!(mongo_handle);
-                    get_error(&(*env).read().unwrap().errors)
+                    get_error(&env.errors.read().unwrap())
                 }
                 HandleType::Dbc => {
                     let dbc = must_be_conn!(mongo_handle);
-                    get_error(&(*dbc).read().unwrap().errors)
+                    get_error(&dbc.errors.read().unwrap())
                 }
                 HandleType::Stmt => {
                     let stmt = must_be_stmt!(mongo_handle);
-                    get_error(&(*stmt).read().unwrap().errors)
+                    get_error(&stmt.errors.read().unwrap())
                 }
                 HandleType::Desc => unimplemented!(),
             }
@@ -1784,24 +1740,23 @@ pub unsafe extern "C" fn SQLGetEnvAttrW(
             let env_handle = MongoHandleRef::from(environment_handle);
             env_handle.clear_diagnostics();
             let env = must_be_valid!(env_handle.as_env());
-            let env_contents = env.read().unwrap();
             if value_ptr.is_null() {
                 set_str_length(string_length, 0);
             } else {
                 set_str_length(string_length, size_of::<Integer>() as Integer);
                 match attribute {
                     EnvironmentAttribute::OdbcVersion => {
-                        *(value_ptr as *mut OdbcVersion) = env_contents.attributes.odbc_ver;
+                        *(value_ptr as *mut OdbcVersion) = env.attributes.read().unwrap().odbc_ver;
                     }
                     EnvironmentAttribute::OutputNts => {
-                        *(value_ptr as *mut SqlBool) = env_contents.attributes.output_nts;
+                        *(value_ptr as *mut SqlBool) = env.attributes.read().unwrap().output_nts;
                     }
                     EnvironmentAttribute::ConnectionPooling => {
                         *(value_ptr as *mut ConnectionPooling) =
-                            env_contents.attributes.connection_pooling;
+                            env.attributes.read().unwrap().connection_pooling;
                     }
                     EnvironmentAttribute::CpMatch => {
-                        *(value_ptr as *mut CpMatch) = env_contents.attributes.cp_match;
+                        *(value_ptr as *mut CpMatch) = env.attributes.read().unwrap().cp_match;
                     }
                 }
             }
@@ -1930,8 +1885,7 @@ unsafe fn sql_get_infow_helper(
             let conn_handle = MongoHandleRef::from(connection_handle);
             let res = {
                 let conn = must_be_valid!((*conn_handle).as_connection());
-                let c = conn.read().unwrap();
-                let version = c.mongo_connection.as_ref().unwrap().get_adf_version();
+                let version = conn.mongo_connection.read().unwrap().as_ref().unwrap().get_adf_version();
                 match version {
                     Ok(version) => i16_len::set_output_wstring(
                         version.as_str(),
@@ -2346,124 +2300,125 @@ pub unsafe extern "C" fn SQLGetStmtAttrW(
             if value_ptr.is_null() {
                 return SqlReturn::ERROR;
             }
-            let stmt_contents = stmt.read().unwrap();
             // Most attributes have type SQLULEN, so default to the size of that
             // type.
             set_str_length(string_length_ptr, size_of::<ULen>() as Integer);
             match attribute {
                 StatementAttribute::AppRowDesc => {
-                    *(value_ptr as *mut Pointer) = stmt_contents.attributes.app_row_desc;
+                    *(value_ptr as *mut Pointer) = stmt.attributes.read().unwrap().app_row_desc;
                     set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 }
                 StatementAttribute::AppParamDesc => {
-                    *(value_ptr as *mut Pointer) = stmt_contents.attributes.app_param_desc;
+                    *(value_ptr as *mut Pointer) = stmt.attributes.read().unwrap().app_param_desc;
                     set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 }
                 StatementAttribute::ImpRowDesc => {
-                    *(value_ptr as *mut Pointer) = stmt_contents.attributes.imp_row_desc;
+                    *(value_ptr as *mut Pointer) = stmt.attributes.read().unwrap().imp_row_desc;
                     set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 }
                 StatementAttribute::ImpParamDesc => {
-                    *(value_ptr as *mut Pointer) = stmt_contents.attributes.imp_param_desc;
+                    *(value_ptr as *mut Pointer) = stmt.attributes.read().unwrap().imp_param_desc;
                     set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 }
                 StatementAttribute::FetchBookmarkPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.fetch_bookmark_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().fetch_bookmark_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut Len>() as Integer);
                 }
                 StatementAttribute::CursorScrollable => {
                     *(value_ptr as *mut CursorScrollable) =
-                        stmt_contents.attributes.cursor_scrollable;
+                        stmt.attributes.read().unwrap().cursor_scrollable;
                 }
                 StatementAttribute::CursorSensitivity => {
                     *(value_ptr as *mut CursorSensitivity) =
-                        stmt_contents.attributes.cursor_sensitivity;
+                        stmt.attributes.read().unwrap().cursor_sensitivity;
                 }
                 StatementAttribute::AsyncEnable => {
-                    *(value_ptr as *mut AsyncEnable) = stmt_contents.attributes.async_enable;
+                    *(value_ptr as *mut AsyncEnable) = stmt.attributes.read().unwrap().async_enable;
                 }
                 StatementAttribute::Concurrency => {
-                    *(value_ptr as *mut Concurrency) = stmt_contents.attributes.concurrency;
+                    *(value_ptr as *mut Concurrency) = stmt.attributes.read().unwrap().concurrency;
                 }
                 StatementAttribute::CursorType => {
-                    *(value_ptr as *mut CursorType) = stmt_contents.attributes.cursor_type;
+                    *(value_ptr as *mut CursorType) = stmt.attributes.read().unwrap().cursor_type;
                 }
                 StatementAttribute::EnableAutoIpd => {
-                    *(value_ptr as *mut SqlBool) = stmt_contents.attributes.enable_auto_ipd;
+                    *(value_ptr as *mut SqlBool) = stmt.attributes.read().unwrap().enable_auto_ipd;
                 }
                 StatementAttribute::KeysetSize => {
                     *(value_ptr as *mut ULen) = 0;
                 }
                 StatementAttribute::MaxLength => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.max_length;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().max_length;
                 }
                 StatementAttribute::MaxRows => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.max_rows;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().max_rows;
                 }
                 StatementAttribute::NoScan => {
-                    *(value_ptr as *mut NoScan) = stmt_contents.attributes.no_scan;
+                    *(value_ptr as *mut NoScan) = stmt.attributes.read().unwrap().no_scan;
                 }
                 StatementAttribute::ParamBindOffsetPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.param_bind_offset_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_bind_offset_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer)
                 }
                 StatementAttribute::ParamBindType => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.param_bind_type;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().param_bind_type;
                 }
                 StatementAttribute::ParamOpterationPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.param_operation_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_operation_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer)
                 }
                 StatementAttribute::ParamStatusPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.param_status_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_status_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer)
                 }
                 StatementAttribute::ParamsProcessedPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.param_processed_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_processed_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer)
                 }
                 StatementAttribute::ParamsetSize => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.paramset_size;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().paramset_size;
                 }
                 StatementAttribute::QueryTimeout => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.query_timeout;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().query_timeout;
                 }
                 StatementAttribute::RetrieveData => {
-                    *(value_ptr as *mut RetrieveData) = stmt_contents.attributes.retrieve_data;
+                    *(value_ptr as *mut RetrieveData) =
+                        stmt.attributes.read().unwrap().retrieve_data;
                 }
                 StatementAttribute::RowBindOffsetPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.row_bind_offset_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_bind_offset_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer)
                 }
                 StatementAttribute::RowBindType => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.row_bind_type;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().row_bind_type;
                 }
                 StatementAttribute::RowNumber => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.row_number;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().row_number;
                 }
                 StatementAttribute::RowOperationPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.row_operation_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_operation_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer)
                 }
                 StatementAttribute::RowStatusPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.row_status_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_status_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer)
                 }
                 StatementAttribute::RowsFetchedPtr => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.rows_fetched_ptr;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().rows_fetched_ptr;
                     set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer)
                 }
                 StatementAttribute::RowArraySize => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.row_array_size;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().row_array_size;
                 }
                 StatementAttribute::SimulateCursor => {
-                    *(value_ptr as *mut ULen) = stmt_contents.attributes.simulate_cursor;
+                    *(value_ptr as *mut ULen) = stmt.attributes.read().unwrap().simulate_cursor;
                 }
                 StatementAttribute::UseBookmarks => {
-                    *(value_ptr as *mut UseBookmarks) = stmt_contents.attributes.use_bookmarks;
+                    *(value_ptr as *mut UseBookmarks) =
+                        stmt.attributes.read().unwrap().use_bookmarks;
                 }
                 StatementAttribute::AsyncStmtEvent => {
-                    *(value_ptr as *mut _) = stmt_contents.attributes.async_stmt_event;
+                    *(value_ptr as *mut _) = stmt.attributes.read().unwrap().async_stmt_event;
                 }
                 StatementAttribute::MetadataId => {
                     todo!();
@@ -2565,14 +2520,19 @@ pub unsafe extern "C" fn SQLNumResultCols(
     panic_safe_exec!(
         || {
             let mongo_handle = MongoHandleRef::from(statement_handle);
+
             let stmt = must_be_valid!((*mongo_handle).as_statement());
-            let stmt_contents = stmt.read().unwrap();
-            let mongo_statement = stmt_contents.mongo_statement.as_ref();
+
+            let mongo_statement = stmt.mongo_statement.read().unwrap();
             if mongo_statement.is_none() {
                 *column_count_ptr = 0;
                 return SqlReturn::SUCCESS;
             }
-            *column_count_ptr = mongo_statement.unwrap().get_resultset_metadata().len() as SmallInt;
+            *column_count_ptr = mongo_statement
+                .as_ref()
+                .unwrap()
+                .get_resultset_metadata()
+                .len() as SmallInt;
             SqlReturn::SUCCESS
         },
         statement_handle
@@ -2832,11 +2792,10 @@ pub unsafe extern "C" fn SQLSetConnectAttrW(
             // all operating systems, and the docs say it can panic.
             let sql_return = {
                 let conn = must_be_valid!((*conn_handle).as_connection());
-                let mut conn_guard = conn.write().unwrap();
 
                 match attribute {
                     ConnectionAttribute::LoginTimeout => {
-                        conn_guard.attributes.login_timeout = Some(value_ptr as u32);
+                        conn.attributes.write().unwrap().login_timeout = Some(value_ptr as u32);
                         SqlReturn::SUCCESS
                     }
                     _ => {
@@ -2983,8 +2942,7 @@ pub unsafe extern "C" fn SQLSetEnvAttrW(
             match attribute {
                 EnvironmentAttribute::OdbcVersion => match FromPrimitive::from_i32(value as i32) {
                     Some(version) => {
-                        let mut env_contents = (*env).write().unwrap();
-                        env_contents.attributes.odbc_ver = version;
+                        env.attributes.write().unwrap().odbc_ver = version;
                         SqlReturn::SUCCESS
                     }
                     None => {
@@ -3147,16 +3105,12 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
                     SqlReturn::ERROR
                 }
                 StatementAttribute::MaxRows => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.max_rows = value as ULen;
+                    stmt.attributes.write().unwrap().max_rows = value as ULen;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::NoScan => {
                     match FromPrimitive::from_i32(value as i32) {
-                        Some(ns) => {
-                            let mut stmt_contents = stmt.write().unwrap();
-                            stmt_contents.attributes.no_scan = ns
-                        }
+                        Some(ns) => stmt.attributes.write().unwrap().no_scan = ns,
                         None => stmt_handle
                             .add_diag_info(ODBCError::InvalidAttrValue("SQL_ATTR_NOSCAN")),
                     }
@@ -3191,8 +3145,7 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
                     SqlReturn::ERROR
                 }
                 StatementAttribute::QueryTimeout => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.query_timeout = value as ULen;
+                    stmt.attributes.write().unwrap().query_timeout = value as ULen;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::RetrieveData => match FromPrimitive::from_i32(value as i32) {
@@ -3209,13 +3162,11 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
                     SqlReturn::ERROR
                 }
                 StatementAttribute::RowBindType => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.row_bind_type = value as ULen;
+                    stmt.attributes.write().unwrap().row_bind_type = value as ULen;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::RowNumber => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.row_number = value as ULen;
+                    stmt.attributes.write().unwrap().row_number = value as ULen;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::RowOperationPtr => {
@@ -3224,19 +3175,16 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
                     SqlReturn::ERROR
                 }
                 StatementAttribute::RowStatusPtr => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.row_status_ptr = value as *mut USmallInt;
+                    stmt.attributes.write().unwrap().row_status_ptr = value as *mut USmallInt;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::RowsFetchedPtr => {
-                    let mut stmt_contents = stmt.write().unwrap();
-                    stmt_contents.attributes.rows_fetched_ptr = value as *mut ULen;
+                    stmt.attributes.write().unwrap().rows_fetched_ptr = value as *mut ULen;
                     SqlReturn::SUCCESS
                 }
                 StatementAttribute::RowArraySize => match FromPrimitive::from_i32(value as i32) {
                     Some(ras) => {
-                        let mut stmt_contents = stmt.write().unwrap();
-                        stmt_contents.attributes.row_array_size = ras;
+                        stmt.attributes.write().unwrap().row_array_size = ras;
                         SqlReturn::SUCCESS
                     }
                     None => {
@@ -3251,8 +3199,7 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
                 }
                 StatementAttribute::UseBookmarks => match FromPrimitive::from_i32(value as i32) {
                     Some(ub) => {
-                        let mut stmt_contents = stmt.write().unwrap();
-                        stmt_contents.attributes.use_bookmarks = ub;
+                        stmt.attributes.write().unwrap().use_bookmarks = ub;
                         SqlReturn::SUCCESS
                     }
                     None => {
@@ -3456,24 +3403,24 @@ pub unsafe extern "C" fn SQLTablesW(
             let schema = input_wtext_to_string(schema_name, name_length_2 as usize);
             let table = input_wtext_to_string(table_name, name_length_3 as usize);
             let table_t = input_wtext_to_string(table_type, name_length_4 as usize);
-            let connection = stmt.read().unwrap().connection;
+            let connection = stmt.connection;
             let mongo_statement = sql_tables(
                 (*connection)
                     .as_connection()
                     .unwrap()
+                    .mongo_connection
                     .read()
                     .unwrap()
-                    .mongo_connection
                     .as_ref()
                     .unwrap(),
-                stmt.read().unwrap().attributes.query_timeout as i32,
+                stmt.attributes.read().unwrap().query_timeout as i32,
                 &catalog,
                 &schema,
                 &table,
                 &table_t,
             );
             let mongo_statement = odbc_unwrap!(mongo_statement, mongo_handle);
-            stmt.write().unwrap().mongo_statement = Some(mongo_statement);
+            *stmt.mongo_statement.write().unwrap() = Some(mongo_statement);
             SqlReturn::SUCCESS
         },
         statement_handle

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -822,7 +822,6 @@ fn sql_driver_connect(conn: &Connection, odbc_uri_string: &str) -> Result<MongoC
     } else {
         odbc_uri.remove(&["database"])
     };
-    let conn_attrs = conn.attributes.read().unwrap();
     let connection_timeout = conn_attrs.connection_timeout;
     let login_timeout = conn_attrs.login_timeout;
     let application_name = odbc_uri.remove(&["app_name", "application_name"]);

--- a/odbc/src/api/get_diag_rec_tests.rs
+++ b/odbc/src/api/get_diag_rec_tests.rs
@@ -1,6 +1,5 @@
 use crate::{api::errors::ODBCError, handles::definitions::*, SQLGetDiagRecW};
 use odbc_sys::{HandleType, SqlReturn};
-use std::sync::RwLock;
 
 const UNIMPLEMENTED_FUNC: &str = "HYC00\0";
 
@@ -48,26 +47,25 @@ mod unit {
             }
         }
 
-        let env_handle: *mut _ =
-            &mut MongoHandle::Env(RwLock::new(Env::with_state(EnvState::Allocated)));
+        let env_handle: *mut _ = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
         validate_diag_rec(HandleType::Env, env_handle);
 
-        let conn_handle: *mut _ = &mut MongoHandle::Connection(RwLock::new(
-            Connection::with_state(env_handle, ConnectionState::Allocated),
+        let conn_handle: *mut _ = &mut MongoHandle::Connection(Connection::with_state(
+            env_handle,
+            ConnectionState::Allocated,
         ));
         validate_diag_rec(HandleType::Dbc, conn_handle);
 
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
         validate_diag_rec(HandleType::Stmt, stmt_handle);
     }
 
     #[test]
     fn test_error_message() {
-        let env_handle: *mut _ =
-            &mut MongoHandle::Env(RwLock::new(Env::with_state(EnvState::Allocated)));
+        let env_handle: *mut _ = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
 
         // Initialize buffers
         let sql_state = &mut [0u16; 6] as *mut _;
@@ -121,8 +119,7 @@ mod unit {
 
     #[test]
     fn test_invalid_ops() {
-        let env_handle: *mut _ =
-            &mut MongoHandle::Env(RwLock::new(Env::with_state(EnvState::Allocated)));
+        let env_handle: *mut _ = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
 
         // Initialize buffers
         let sql_state = &mut [0u16; 6] as *mut _;

--- a/odbc/src/api/stmt_attr_tests.rs
+++ b/odbc/src/api/stmt_attr_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     map, SQLGetStmtAttrW, SQLSetStmtAttrW,
 };
 use odbc_sys::{HStmt, Integer, Pointer, SqlReturn, StatementAttribute, ULen, USmallInt};
-use std::{collections::BTreeMap, mem::size_of, sync::RwLock};
+use std::{collections::BTreeMap, mem::size_of};
 
 fn get_set_stmt_attr(
     handle: *mut MongoHandle,
@@ -121,10 +121,10 @@ mod unit {
     #[test]
     fn test_supported_attributes() {
         use crate::map;
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
 
         get_set_stmt_attr(
             stmt_handle,
@@ -252,10 +252,10 @@ mod unit {
     #[test]
     fn test_unsupported_attributes() {
         use crate::map;
-        let stmt_handle: *mut _ = &mut MongoHandle::Statement(RwLock::new(Statement::with_state(
+        let stmt_handle: *mut _ = &mut MongoHandle::Statement(Statement::with_state(
             std::ptr::null_mut(),
             StatementState::Allocated,
-        )));
+        ));
 
         get_set_stmt_attr(
             stmt_handle,

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -313,4 +313,13 @@ impl Statement {
             mongo_statement: RwLock::new(None),
         }
     }
+
+    pub(crate) fn insert_var_data_cache(&self, col: u16, data: CachedData) {
+        self.var_data_cache
+            .write()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .insert(col, data);
+    }
 }


### PR DESCRIPTION
(also add Option<&MongoConnection> to next())

The impetus for this was actually that I needed to add MongoConnection to next to make the fields call (SQLColumns) not completely terrible, this way we can lazily get the schema info.

The other benefit is this will reduce lock contention. I don't think anything here will cause a deadlock, try to reason about that. But I think our biggest double lock holds are read on attributes with simultaneous write to errors. Nothing is trying to write to attributes and errors at the same time, so I think we should be good. 

Actually, most lock grabs now only exist for the span of one statement. But there are still a few to look at.