### PR TITLE
SQL-661: Initial support for descriptor handles

### DIFF
--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -64,6 +64,13 @@ macro_rules! must_be_stmt {
     }};
 }
 
+macro_rules! must_be_desc {
+    ($handle:expr) => {{
+        let desc = (*$handle).as_descriptor();
+        must_be_valid!(desc)
+    }};
+}
+
 macro_rules! odbc_unwrap {
     ($value:expr, $handle:expr) => {{
         // force the expression
@@ -1712,7 +1719,10 @@ pub unsafe extern "C" fn SQLGetDiagRecW(
                     let stmt = must_be_stmt!(mongo_handle);
                     get_error(&stmt.errors.read().unwrap())
                 }
-                HandleType::Desc => unimplemented!(),
+                HandleType::Desc => {
+                    let desc = must_be_desc!(mongo_handle);
+                    get_error(&desc.errors.read().unwrap())
+                }
             }
         },
         handle


### PR DESCRIPTION
Added initial infrastructure for descriptor handles. There are some pieces in the handle struct that aren't strictly necessary, but felt right given how other handles function and potential future additions (specifically, a reference to the dbc and a `state`). 