### PR TITLE
SQL-985: Implement test file generator

### DIFF
--- a/integration_test/src/bin/test_generator.rs
+++ b/integration_test/src/bin/test_generator.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TestGeneratorError {
+    #[error("Init err: {0}")]
+    Init(String),
+}
+
+type Result<T> = std::result::Result<T, TestGeneratorError>;
+
+fn main() -> Result<()> {
+    Ok(())
+}

--- a/integration_test/src/bin/test_generator.rs
+++ b/integration_test/src/bin/test_generator.rs
@@ -1,13 +1,14 @@
-use thiserror::Error;
+use integration_test::test_runner::{run_integration_tests, Result};
+use odbc::{safe::AutocommitOn, Allocated, NoResult, Statement};
 
-#[derive(Error, Debug)]
-pub enum TestGeneratorError {
-    #[error("Init err: {0}")]
-    Init(String),
-}
-
-type Result<T> = std::result::Result<T, TestGeneratorError>;
-
+/// This is a standalone executable that generates baseline integration test
+/// files based on the description, db, and either the query or meta_function
+/// fields for all test cases in the resources/integration_test/testes
+/// directory. It does this by executing the integration tests and writing
+/// the results to a file instead of validating the results match expectation.
+///
+/// The actual code for generating the test files can be found in the
+/// test_runner module.
 fn main() -> Result<()> {
-    Ok(())
+    run_integration_tests(true)
 }

--- a/integration_test/src/bin/test_generator.rs
+++ b/integration_test/src/bin/test_generator.rs
@@ -1,10 +1,10 @@
 use integration_test::test_runner::{run_integration_tests, Result};
 
 /// This is a standalone executable that generates baseline integration
-/// test files based on the description, db, and the test_definition fields
+/// test files based on the description, db, and test_definition fields
 /// for all test cases in the resources/integration_test/testes directory.
 /// It does this by executing the integration tests and writing the results
-/// to a file instead of validating the results match expectation.
+/// to files instead of validating the results match expectation.
 ///
 /// The actual code for generating the test files can be found in the
 /// test_runner module.

--- a/integration_test/src/bin/test_generator.rs
+++ b/integration_test/src/bin/test_generator.rs
@@ -1,11 +1,10 @@
 use integration_test::test_runner::{run_integration_tests, Result};
-use odbc::{safe::AutocommitOn, Allocated, NoResult, Statement};
 
-/// This is a standalone executable that generates baseline integration test
-/// files based on the description, db, and either the query or meta_function
-/// fields for all test cases in the resources/integration_test/testes
-/// directory. It does this by executing the integration tests and writing
-/// the results to a file instead of validating the results match expectation.
+/// This is a standalone executable that generates baseline integration
+/// test files based on the description, db, and the test_definition fields
+/// for all test cases in the resources/integration_test/testes directory.
+/// It does this by executing the integration tests and writing the results
+/// to a file instead of validating the results match expectation.
 ///
 /// The actual code for generating the test files can be found in the
 /// test_runner module.

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -1,5 +1,4 @@
-#[cfg(test)]
-mod test_runner;
+pub mod test_runner;
 
 #[path = "../tests/common/mod.rs"]
 #[cfg(test)]

--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod test_runner;
 
 #[path = "../tests/common/mod.rs"]
-#[cfg(test)]
 mod common;

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use thiserror::Error;
 
-const TEST_FILE_DIR: &str = "./resources/integration_test/tests";
+const TEST_FILE_DIR: &str = "../resources/integration_test/tests";
 const SQL_NULL_DATA: isize = -1;
 const BUFFER_LENGTH: usize = 200;
 

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use thiserror::Error;
 
-const TEST_FILE_DIR: &str = "../resources/integration_test/tests";
+const TEST_FILE_DIR: &str = "./resources/integration_test/tests";
 const SQL_NULL_DATA: isize = -1;
 const BUFFER_LENGTH: usize = 200;
 

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -12,7 +12,7 @@ use std::{fmt, fs, path::PathBuf};
 
 use crate::{
     common::{get_sql_diagnostics, sql_return_to_string},
-    test_runner::test_generator_util::generate_baseline_test_files,
+    test_runner::test_generator_util::generate_baseline_test_file,
 };
 use thiserror::Error;
 

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -127,6 +127,9 @@ pub fn integration_test() -> Result<()> {
     run_integration_tests(false)
 }
 
+/// Run an integration test. The generate argument indicates whether
+/// the test results should written to a file for baseline test file
+/// generation, or be asserted for correctness.
 pub fn run_integration_tests(generate: bool) -> Result<()> {
     let env = create_environment_v3().unwrap();
     let paths = load_file_paths(PathBuf::from(TEST_FILE_DIR)).unwrap();
@@ -157,8 +160,8 @@ pub fn run_integration_tests(generate: bool) -> Result<()> {
     Ok(())
 }
 
-/// load_file_paths reads the given directory and returns a list its file path
-/// names.
+/// load_file_paths reads the given directory and returns a list of its file
+/// path names.
 pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>> {
     let mut paths: Vec<String> = vec![];
     let entries = fs::read_dir(dir).map_err(|e| Error::InvalidDirectory(format!("{:?}", e)))?;
@@ -222,6 +225,9 @@ fn check_array_length(array: &Vec<Value>, length: usize) -> Result<()> {
     Ok(())
 }
 
+/// Run a query integration test. The generate argument indicates
+/// whether the test results should written to a file for baseline
+/// test file generation, or be asserted for correctness.
 fn run_query_test(
     query: &str,
     entry: &TestEntry,
@@ -251,6 +257,9 @@ fn run_query_test(
     }
 }
 
+/// Run a function integration test. The generate argument indicates
+/// whether the test results should written to a file for baseline
+/// test file generation, or be asserted for correctness.
 fn run_function_test(
     function: &Vec<Value>,
     entry: &TestEntry,

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -105,7 +105,7 @@ pub struct TestEntry {
     pub expected_nullability: Option<Vec<Value>>,
 }
 
-#[derive(Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Error, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum TestDef {
     Query(String),

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -74,6 +74,8 @@ pub enum Error {
     ValueOverflowI16(i64, String),
     #[error("Function {0} failed with sql code {1}. Error message: {2}")]
     OdbcFunctionFailed(String, String, String),
+    #[error("yaml err: {0}")]
+    Yaml(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -235,7 +237,7 @@ fn run_query_test(
         ) {
             SqlReturn::SUCCESS => {
                 if generate {
-                    generate_baseline_test_files(entry, stmt)
+                    generate_baseline_test_file(entry, stmt)
                 } else {
                     validate_result_set(entry, stmt)
                 }
@@ -398,7 +400,7 @@ fn run_function_test(
         }
     }
     if generate {
-        generate_baseline_test_files(entry, statement)
+        generate_baseline_test_file(entry, statement)
     } else {
         validate_result_set(entry, statement)
     }

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -1,3 +1,5 @@
+mod test_generator_util;
+
 use odbc::{create_environment_v3, Allocated, Connection, Handle, NoResult, Statement};
 use odbc_sys::{CDataType, Desc, HStmt, HandleType, SmallInt, SqlReturn, USmallInt};
 
@@ -8,7 +10,10 @@ use serde_json::value::Value;
 use std::ptr::null_mut;
 use std::{fmt, fs, path::PathBuf};
 
-use crate::common::{get_sql_diagnostics, sql_return_to_string};
+use crate::{
+    common::{get_sql_diagnostics, sql_return_to_string},
+    test_runner::test_generator_util::generate_baseline_test_files,
+};
 use thiserror::Error;
 
 const TEST_FILE_DIR: &str = "../resources/integration_test/tests";
@@ -71,6 +76,8 @@ pub enum Error {
     OdbcFunctionFailed(String, String, String),
 }
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IntegrationTest {
     pub tests: Vec<TestEntry>,
@@ -111,9 +118,46 @@ impl fmt::Display for TestDef {
     }
 }
 
+/// integration_test runs the query and function tests contained in the TEST_FILE_DIR directory
+#[test]
+#[ignore]
+pub fn integration_test() -> Result<()> {
+    run_integration_tests(false)
+}
+
+pub fn run_integration_tests(generate: bool) -> Result<()> {
+    let env = create_environment_v3().unwrap();
+    let paths = load_file_paths(PathBuf::from(TEST_FILE_DIR)).unwrap();
+    for path in paths {
+        let yaml = parse_test_file_yaml(&path).unwrap();
+
+        for test in yaml.tests {
+            match test.skip_reason {
+                Some(sr) => println!("Skip Reason: {}", sr),
+                None => {
+                    let mut conn_str = crate::common::generate_default_connection_str();
+                    conn_str.push_str(&("DATABASE=".to_owned() + &test.db));
+                    let connection = env
+                        .connect_with_connection_string(conn_str.as_str())
+                        .unwrap();
+                    let test_result = match test.test_definition {
+                        TestDef::Query(ref q) => run_query_test(q, &test, &connection, generate),
+                        TestDef::Function(ref f) => {
+                            run_function_test(f, &test, &connection, generate)
+                        }
+                    };
+                    drop(connection);
+                    assert_eq!(Ok(()), test_result);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// load_file_paths reads the given directory and returns a list its file path
 /// names.
-pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>, Error> {
+pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>> {
     let mut paths: Vec<String> = vec![];
     let entries = fs::read_dir(dir).map_err(|e| Error::InvalidDirectory(format!("{:?}", e)))?;
     for entry in entries {
@@ -132,42 +176,11 @@ pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>, Error> {
 
 /// parse_test_file_yaml deserializes the given YAML file into a
 /// IntegrationTest struct.
-pub fn parse_test_file_yaml(path: &str) -> Result<IntegrationTest, Error> {
+pub fn parse_test_file_yaml(path: &str) -> Result<IntegrationTest> {
     let f = fs::File::open(path).map_err(|e| Error::InvalidFile(format!("{:?}", e)))?;
     let integration_test: IntegrationTest =
         serde_yaml::from_reader(f).map_err(|e| Error::CannotDeserializeYaml(format!("{:?}", e)))?;
     Ok(integration_test)
-}
-
-/// integration_test runs the query and function tests contained in the TEST_FILE_DIR directory
-#[test]
-#[ignore]
-pub fn integration_test() -> Result<(), Error> {
-    let env = create_environment_v3().unwrap();
-    let paths = load_file_paths(PathBuf::from(TEST_FILE_DIR)).unwrap();
-    for path in paths {
-        let yaml = parse_test_file_yaml(&path).unwrap();
-
-        for test in yaml.tests {
-            match test.skip_reason {
-                Some(sr) => println!("Skip Reason: {}", sr),
-                None => {
-                    let mut conn_str = crate::common::generate_default_connection_str();
-                    conn_str.push_str(&("DATABASE=".to_owned() + &test.db));
-                    let connection = env
-                        .connect_with_connection_string(conn_str.as_str())
-                        .unwrap();
-                    let test_result = match test.test_definition {
-                        TestDef::Query(ref q) => run_query_test(q, &test, &connection),
-                        TestDef::Function(ref f) => run_function_test(f, &test, &connection),
-                    };
-                    drop(connection);
-                    assert_eq!(Ok(()), test_result);
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 /// str_or_null converts value to a narrow string or null_mut() if null
@@ -195,12 +208,12 @@ fn to_wstr_ptr(string: &str) -> *const u16 {
     v.as_ptr()
 }
 
-fn to_i16(value: &Value) -> Result<i16, Error> {
+fn to_i16(value: &Value) -> Result<i16> {
     let val = value.as_i64().expect("Unable to cast value as i64");
     i16::try_from(val).map_err(|e| Error::ValueOverflowI16(val, e.to_string()))
 }
 
-fn check_array_length(array: &Vec<Value>, length: usize) -> Result<(), Error> {
+fn check_array_length(array: &Vec<Value>, length: usize) -> Result<()> {
     if array.len() < length {
         return Err(Error::NotEnoughArguments(length, array.len()));
     }
@@ -211,7 +224,8 @@ fn run_query_test(
     query: &str,
     entry: &TestEntry,
     conn: &Connection<AutocommitOn>,
-) -> Result<(), Error> {
+    generate: bool,
+) -> Result<()> {
     let stmt = Statement::with_parent(conn).unwrap();
     unsafe {
         match odbc_sys::SQLExecDirectW(
@@ -219,7 +233,13 @@ fn run_query_test(
             to_wstr_ptr(query),
             query.len() as i32,
         ) {
-            SqlReturn::SUCCESS => validate_result_set(entry, stmt),
+            SqlReturn::SUCCESS => {
+                if generate {
+                    generate_baseline_test_files(entry, stmt)
+                } else {
+                    validate_result_set(entry, stmt)
+                }
+            }
             sql_return => Err(Error::OdbcFunctionFailed(
                 "SQLExecDirectW".to_string(),
                 sql_return_to_string(sql_return),
@@ -233,7 +253,8 @@ fn run_function_test(
     function: &Vec<Value>,
     entry: &TestEntry,
     conn: &Connection<AutocommitOn>,
-) -> Result<(), Error> {
+    generate: bool,
+) -> Result<()> {
     let statement = Statement::with_parent(conn).unwrap();
     check_array_length(function, 1)?;
     let function_name = function[0].as_str().unwrap().to_lowercase();
@@ -376,13 +397,17 @@ fn run_function_test(
             ));
         }
     }
-    validate_result_set(entry, statement)
+    if generate {
+        generate_baseline_test_files(entry, statement)
+    } else {
+        validate_result_set(entry, statement)
+    }
 }
 
 fn validate_result_set(
     entry: &TestEntry,
     stmt: Statement<Allocated, NoResult, AutocommitOn>,
-) -> Result<(), Error> {
+) -> Result<()> {
     let column_count = get_column_count(&stmt)?;
     let mut row_counter = 0;
     if let Some(expected_result) = entry.expected_result.as_ref() {
@@ -437,7 +462,7 @@ fn validate_result_set_metadata_helper(
     description: String,
     descriptor: Desc,
     expected_metadata: &Option<Vec<Value>>,
-) -> Result<(), Error> {
+) -> Result<()> {
     if let Some(exp_metadata) = &expected_metadata {
         if column_count != exp_metadata.len() {
             return Err(Error::MetadataColumnCount {
@@ -484,7 +509,7 @@ fn validate_result_set_metadata(
     entry: &TestEntry,
     column_count: usize,
     stmt: Statement<Allocated, NoResult, AutocommitOn>,
-) -> Result<(), Error> {
+) -> Result<()> {
     validate_result_set_metadata_helper(
         &stmt,
         column_count,
@@ -577,7 +602,7 @@ fn get_column_attribute(
     column: usize,
     field_identifier: Desc,
     column_metadata_type: &Value,
-) -> Result<Value, Error> {
+) -> Result<Value> {
     let string_length_ptr = &mut 0;
     let character_attrib_ptr: *mut std::ffi::c_void =
         Box::into_raw(Box::new([0u16; BUFFER_LENGTH])) as *mut _;
@@ -613,7 +638,7 @@ fn get_data(
     stmt: &Statement<Allocated, NoResult, AutocommitOn>,
     column: USmallInt,
     data_type: CDataType,
-) -> Result<Value, Error> {
+) -> Result<Value> {
     let out_len_or_ind = &mut 0;
     let buffer: *mut std::ffi::c_void = Box::into_raw(Box::new([0u8; BUFFER_LENGTH])) as *mut _;
     let mut data: Value = Default::default();
@@ -648,7 +673,7 @@ fn get_data(
     }
 }
 
-fn get_column_count(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<usize, Error> {
+fn get_column_count(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<usize> {
     unsafe {
         let columns = &mut 0;
         match odbc_sys::SQLNumResultCols(stmt.handle() as HStmt, columns) {
@@ -662,7 +687,7 @@ fn get_column_count(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Resu
     }
 }
 
-fn fetch_row(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<bool, Error> {
+fn fetch_row(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<bool> {
     unsafe {
         match odbc_sys::SQLFetch(stmt.handle() as HStmt) {
             SqlReturn::SUCCESS => Ok(true),

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -7,7 +7,7 @@ use odbc_sys::{CDataType, Desc, SqlDataType, USmallInt};
 use serde_json::{Number, Value};
 use std::string::ToString;
 
-const GENERATED_TEST_DIR: &str = "../resources/generated_test";
+const GENERATED_TEST_DIR: &str = "./resources/generated_test";
 
 lazy_static! {
     static ref STRING_VAL: Value = Value::String("".to_string());

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -1,0 +1,15 @@
+use super::{Result, TestEntry};
+use odbc::{safe::AutocommitOn, Allocated, NoResult, Statement};
+
+const GENERATED_TEST_DIR: &str = "../resources/generated_test";
+
+/// Given a TestEntry and Statement, write the results of the test entry to
+/// a file in the GENERATED_TEST_DIR. The only fields retained from the initial
+/// TestEntry are description, db, and either query or meta_function.
+pub fn generate_baseline_test_files(
+    entry: &TestEntry,
+    stmt: Statement<Allocated, NoResult, AutocommitOn>,
+) -> Result<()> {
+    // TODO
+    Ok(())
+}

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -115,7 +115,7 @@ pub fn generate_baseline_test_file(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis();
-    let desc = entry.description.clone().replace(" ", "_");
+    let desc = entry.description.clone().replace(' ', "_");
     let file_name = format!("{}-{}.yml", desc, now);
 
     let writer = std::fs::OpenOptions::new()

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -133,7 +133,7 @@ fn get_expected_data_type(sql_type: &Value) -> CDataType {
         Value::Number(n) => {
             let sdt = SqlDataType(n.as_i64().unwrap() as i16);
             match sdt {
-                SqlDataType::UNKNOWN_TYPE => CDataType::Default,
+                SqlDataType::UNKNOWN_TYPE => CDataType::Char,
                 SqlDataType::CHAR => CDataType::Char,
                 SqlDataType::NUMERIC => CDataType::Numeric,
                 SqlDataType::DECIMAL => CDataType::Numeric,
@@ -146,8 +146,8 @@ fn get_expected_data_type(sql_type: &Value) -> CDataType {
                 SqlDataType::VARCHAR => CDataType::Char,
                 SqlDataType::DATE => CDataType::TypeDate,
                 SqlDataType::TIME => CDataType::TypeTime,
-                SqlDataType::TIMESTAMP => CDataType::Default,
-                SqlDataType::EXT_TIME_OR_INTERVAL => CDataType::Default,
+                SqlDataType::TIMESTAMP => CDataType::Char,
+                SqlDataType::EXT_TIME_OR_INTERVAL => CDataType::Char,
                 SqlDataType::EXT_TIMESTAMP => CDataType::Default,
                 SqlDataType::EXT_LONG_VARCHAR => CDataType::Char,
                 SqlDataType::EXT_BINARY => CDataType::Binary,

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -129,6 +129,40 @@ pub fn generate_baseline_test_file(
 
 // Get the expected CDataType for the provided sql_type.
 fn get_expected_data_type(sql_type: &Value) -> CDataType {
-    // TODO create mapping from sql_type to cdatatype
-    todo!()
+    match sql_type {
+        Value::Number(n) => {
+            let sdt = SqlDataType(n.as_i64().unwrap() as i16);
+            match sdt {
+                SqlDataType::UNKNOWN_TYPE => CDataType::Default,
+                SqlDataType::CHAR => CDataType::Char,
+                SqlDataType::NUMERIC => CDataType::Numeric,
+                SqlDataType::DECIMAL => CDataType::Numeric,
+                SqlDataType::INTEGER => CDataType::SLong,
+                SqlDataType::SMALLINT => CDataType::SShort,
+                SqlDataType::FLOAT => CDataType::Float,
+                SqlDataType::REAL => CDataType::Numeric,
+                SqlDataType::DOUBLE => CDataType::Double,
+                SqlDataType::DATETIME => CDataType::TypeTimestamp,
+                SqlDataType::VARCHAR => CDataType::Char,
+                SqlDataType::DATE => CDataType::TypeDate,
+                SqlDataType::TIME => CDataType::TypeTime,
+                SqlDataType::TIMESTAMP => CDataType::Default,
+                SqlDataType::EXT_TIME_OR_INTERVAL => CDataType::Default,
+                SqlDataType::EXT_TIMESTAMP => CDataType::Default,
+                SqlDataType::EXT_LONG_VARCHAR => CDataType::Char,
+                SqlDataType::EXT_BINARY => CDataType::Binary,
+                SqlDataType::EXT_VAR_BINARY => CDataType::Binary,
+                SqlDataType::EXT_LONG_VAR_BINARY => CDataType::Binary,
+                SqlDataType::EXT_BIG_INT => CDataType::SBigInt,
+                SqlDataType::EXT_TINY_INT => CDataType::STinyInt,
+                SqlDataType::EXT_BIT => CDataType::Bit,
+                SqlDataType::EXT_W_CHAR => CDataType::WChar,
+                SqlDataType::EXT_W_VARCHAR => CDataType::WChar,
+                SqlDataType::EXT_W_LONG_VARCHAR => CDataType::WChar,
+                SqlDataType::EXT_GUID => CDataType::Guid,
+                v => unreachable!("invalid sql_type encountered: {:?}", v),
+            }
+        }
+        v => unreachable!("sql_type should always be a number: {:?}", v),
+    }
 }

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -1,7 +1,18 @@
-use super::{Result, TestEntry};
+use crate::test_runner::{
+    fetch_row, get_column_attribute, get_column_count, get_data, Result, TestEntry,
+};
+use lazy_static::lazy_static;
 use odbc::{safe::AutocommitOn, Allocated, NoResult, Statement};
+use odbc_sys::{CDataType, Desc, SqlDataType, USmallInt};
+use serde_json::{Number, Value};
+use std::string::ToString;
 
 const GENERATED_TEST_DIR: &str = "../resources/generated_test";
+
+lazy_static! {
+    static ref STRING_VAL: Value = Value::String("".to_string());
+    static ref NUMBER_VAL: Value = Value::Number(Number::from(0));
+}
 
 /// Given a TestEntry and Statement, write the results of the test entry to
 /// a file in the GENERATED_TEST_DIR. The only fields retained from the initial
@@ -10,6 +21,102 @@ pub fn generate_baseline_test_files(
     entry: &TestEntry,
     stmt: Statement<Allocated, NoResult, AutocommitOn>,
 ) -> Result<()> {
-    // TODO
+    let column_count = get_column_count(&stmt)?;
+
+    // 1. Get result set metadata
+    let mut expected_catalog_name: Vec<Value> = vec![];
+    let mut expected_case_sensitive: Vec<Value> = vec![];
+    let mut expected_column_name: Vec<Value> = vec![];
+    let mut expected_display_size: Vec<Value> = vec![];
+    let mut expected_length: Vec<Value> = vec![];
+    let mut expected_is_searchable: Vec<Value> = vec![];
+    let mut expected_is_unsigned: Vec<Value> = vec![];
+    let mut expected_sql_type: Vec<Value> = vec![];
+    let mut expected_bson_type: Vec<Value> = vec![];
+    let mut expected_precision: Vec<Value> = vec![];
+    let mut expected_scale: Vec<Value> = vec![];
+    let mut expected_nullability: Vec<Value> = vec![];
+
+    for i in 1..(column_count + 1) {
+        let catalog_name = get_column_attribute(&stmt, i, Desc::CatalogName, &STRING_VAL)?;
+        expected_catalog_name.push(catalog_name);
+
+        let case_sensitive = get_column_attribute(&stmt, i, Desc::CaseSensitive, &STRING_VAL)?;
+        expected_case_sensitive.push(case_sensitive);
+
+        let column_name = get_column_attribute(&stmt, i, Desc::Name, &STRING_VAL)?;
+        expected_column_name.push(column_name);
+
+        let display_size = get_column_attribute(&stmt, i, Desc::DisplaySize, &NUMBER_VAL)?;
+        expected_display_size.push(display_size);
+
+        let length = get_column_attribute(&stmt, i, Desc::Length, &NUMBER_VAL)?;
+        expected_length.push(length);
+
+        let is_searchable = get_column_attribute(&stmt, i, Desc::Searchable, &NUMBER_VAL)?;
+        expected_is_searchable.push(is_searchable);
+
+        let is_unsigned = get_column_attribute(&stmt, i, Desc::Unsigned, &NUMBER_VAL)?;
+        expected_is_unsigned.push(is_unsigned);
+
+        let sql_type = get_column_attribute(&stmt, i, Desc::Type, &NUMBER_VAL)?;
+        expected_sql_type.push(sql_type);
+
+        let bson_type = get_column_attribute(&stmt, i, Desc::TypeName, &STRING_VAL)?;
+        expected_bson_type.push(bson_type);
+
+        let precision = get_column_attribute(&stmt, i, Desc::Precision, &NUMBER_VAL)?;
+        expected_precision.push(precision);
+
+        let scale = get_column_attribute(&stmt, i, Desc::Scale, &NUMBER_VAL)?;
+        expected_scale.push(scale);
+
+        let nullability = get_column_attribute(&stmt, i, Desc::Nullable, &NUMBER_VAL)?;
+        expected_nullability.push(nullability);
+    }
+
+    // 2. Get result set data
+    let mut expected_result: Vec<Vec<Value>> = vec![];
+
+    while fetch_row(&stmt)? {
+        let mut row: Vec<Value> = vec![];
+        for i in 0..(column_count) {
+            let expected_data_type = get_expected_data_type(expected_sql_type.get(i).unwrap());
+            let field = get_data(&stmt, i as USmallInt, expected_data_type)?;
+            row.push(field);
+        }
+        expected_result.push(row);
+    }
+
+    // 3. Create new TestEntry with all the data
+    let test_entry = TestEntry {
+        description: entry.description.clone(),
+        db: entry.db.clone(),
+        test_definition: entry.test_definition.clone(),
+        expected_result: Some(expected_result),
+        skip_reason: None,
+        ordered: entry.ordered,
+        expected_catalog_name: Some(expected_catalog_name),
+        expected_case_sensitive: Some(expected_case_sensitive),
+        expected_column_name: Some(expected_column_name),
+        expected_display_size: Some(expected_display_size),
+        expected_length: Some(expected_length),
+        expected_is_searchable: Some(expected_is_searchable),
+        expected_is_unsigned: Some(expected_is_unsigned),
+        expected_sql_type: Some(expected_sql_type),
+        expected_bson_type: Some(expected_bson_type),
+        expected_precision: Some(expected_precision),
+        expected_scale: Some(expected_scale),
+        expected_nullability: Some(expected_nullability),
+    };
+
+    // TODO: write yaml to file
+
     Ok(())
+}
+
+// Get the expected CDataType for the provided sql_type.
+fn get_expected_data_type(sql_type: &Value) -> CDataType {
+    // TODO create mapping from sql_type to cdatatype
+    todo!()
 }


### PR DESCRIPTION
This PR adds a test file generator executable which runs the integration tests in `resources/integration_test/tests` and writes the results to yaml files. This is heavily influenced by the JDBC test generator (shout out to @bucaojit 💯 ).

Caveats:
- `serde_yaml` is criminally underfeatured and does not support any formatting options. I looked into a few other libraries for formatting but those required quite a bit of overhead to get going and I didn't find any that could natively integrate with serde_yaml. I'm thinking when people generate tests, they can use a command line utility or built-in IDE/text-editor utility to format the generated yaml as desired.
- The `SqlDateType` to `CDataType` mapping is imperfect and possibly incorrect in places, so please take a close look at that!
- I only tested this locally so far and always skipped actually running the integration tests (since I am running on a Mac). I am going to check on a windows host that this runs end-to-end as expected but anticipate only minor bug fixes (if any) to come from that, so this is ready for review 👍 