### PR TITLE
SQL-984: Test Harness - Update test and runner to work with driver changes

### DIFF
--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -627,7 +627,7 @@ fn get_data(
             BUFFER_LENGTH as isize,
             out_len_or_ind,
         ) {
-            SqlReturn::SUCCESS => {
+            SqlReturn::SUCCESS | SqlReturn::NO_DATA => {
                 if *out_len_or_ind == SQL_NULL_DATA {
                     data = json!(null);
                 } else if data_type == CDataType::Char {

--- a/resources/integration_test/tests/functions.yaml
+++ b/resources/integration_test/tests/functions.yaml
@@ -3,8 +3,8 @@ tests:
     test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "", 0 ]
     db: integration_test
     expected_result:
-      - ["db2", null, null, null, null]
-      - ["integration_test", null, null, null, null]
+      - ["db2", null, null, null, ""]
+      - ["integration_test", null, null, null, ""]
     expected_bson_type: ["string", "string", "string", "string", "string"]
     expected_case_sensitive: [ "", "", "", "", "" ]
     expected_catalog_name: [ "", "", "", "", "" ]
@@ -16,7 +16,7 @@ tests:
     expected_sql_type: [12, 12, 12, 12, 12]
     expected_precision: [0, 0, 0, 0, 0]
     expected_scale: [0, 0, 0, 0, 0]
-    expected_nullability: [1, 0, 0, 0, 0]
+    expected_nullability: [0, 1, 1, 1, 1]
 
 
 

--- a/resources/integration_test/tests/queries.yaml
+++ b/resources/integration_test/tests/queries.yaml
@@ -17,5 +17,5 @@ tests:
     expected_sql_type: [4, 12]
     expected_precision: [10, 0]
     expected_scale: [0, 0]
-    expected_nullability: [0, 0]
+    expected_nullability: [1, 1]
 


### PR DESCRIPTION
Updates were made in the driver for the `REMARKS` column and values for nullability.  
This change updates the test files and allowing `SqlReturn::NO_DATA` from SQLGetData() (which is returned when the value is an empty string) to get the result set test to pass again.