### PR TITLE
SQL-1147: Support app_name/application_name options in connection string

### DIFF
--- a/odbc/src/api/odbc_uri.rs
+++ b/odbc/src/api/odbc_uri.rs
@@ -14,6 +14,8 @@ const SSL: &[&str] = &["ssl", "tls"];
 
 lazy_static! {
     static ref KEYWORDS: RegexSet = RegexSetBuilder::new([
+        "^APP_NAME$",
+        "^APPLICATION_NAME$",
         "^AUTH_SRC$",
         "^DATABASE$",
         "^DRIVER$",
@@ -530,6 +532,21 @@ mod unit {
                     .unwrap()
                     .remove_to_mongo_uri()
                     .unwrap()
+            );
+        }
+
+        #[test]
+        fn app_name_options_are_valid() {
+            use crate::odbc_uri::ODBCUri;
+            assert_eq!(
+                "mongodb://foo:bar@127.0.0.1:27017".to_string(),
+                ODBCUri::new(
+                    "APP_NAME=app name test;APPLICATION_NAME=application name test;\
+                              USER=foo;PWD=bar;SERVER=127.0.0.1:27017"
+                )
+                .unwrap()
+                .remove_to_mongo_uri()
+                .unwrap()
             );
         }
     }


### PR DESCRIPTION
Small fix to add app_name/application_name to the list of valid keywords in the URI.

Confirmed that the application_name value set in the PowerBI connector gets set in the ADF logs:
`"commandName": "aggregate", "appName": "MongoDB Atlas SQL - PowerBI", "username": "mhuser" ...`

@pmeredit I can hold off on this change if you are making changes to the KEYWORDS.