### PR TITLE
SQL-1156: Add SQL function tracing and output to logfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "file_dbg_macros"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "thiserror",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +727,21 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "function_name"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ab577a896d09940b5fe12ec5ae71f9d8211fff62c919c03a3750a9901e98a7"
+dependencies = [
+ "function_name-proc-macro",
+]
+
+[[package]]
+name = "function_name-proc-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "futures-channel"
@@ -1202,6 +1225,8 @@ dependencies = [
  "bson",
  "chrono",
  "constants",
+ "file_dbg_macros",
+ "function_name",
  "lazy_static",
  "mongo-odbc-core",
  "mongodb",

--- a/file_dbg_macros/Cargo.toml
+++ b/file_dbg_macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "file_dbg_macros"
+version = "0.1.0"
+edition = "2021"
+authors = ["Ryan Chipman <ryan@ryanchipman.com>",
+    "Natacha Bagnard <natacha.bagnard@mongodb.com>",
+    "Patrick Meredith <pmeredit@protonmail.com>"]
+
+[dependencies]
+lazy_static = "1.4.0"
+thiserror = "1"

--- a/file_dbg_macros/Cargo.toml
+++ b/file_dbg_macros/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Ryan Chipman <ryan@ryanchipman.com>",
     "Natacha Bagnard <natacha.bagnard@mongodb.com>",
-    "Patrick Meredith <pmeredit@protonmail.com>"]
+    "Patrick Meredith <pmeredit@protonmail.com>",
+    "Oliver Bucaojit <oliver.bucaojit@mongodb.com>"]
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/file_dbg_macros/src/lib.rs
+++ b/file_dbg_macros/src/lib.rs
@@ -5,6 +5,7 @@ use std::{env, fs::File, sync::Mutex};
 
 // Checks if DBG_FILE_PATH environment variable exists to use as debug file path. If not set,
 // return the OS temp directory joined with default debug filename 'mongodb_odbc.log'
+#[cfg(debug_assertions)]
 fn get_file_path() -> String {
     if let Ok(file_path) = env::var("DBG_FILE_PATH") {
         return file_path;

--- a/file_dbg_macros/src/lib.rs
+++ b/file_dbg_macros/src/lib.rs
@@ -1,0 +1,96 @@
+#[cfg(debug_assertions)]
+use lazy_static::lazy_static;
+#[cfg(debug_assertions)]
+use std::{env, fs::File, sync::Mutex};
+
+// Checks if DBG_FILE_PATH environment variable exists to use as debug file path. If not set,
+// return the OS temp directory joined with default debug filename 'mongodb_odbc.log'
+fn get_file_path() -> String {
+    if let Ok(file_path) = env::var("DBG_FILE_PATH") {
+        return file_path;
+    }
+    let temp_dir = env::temp_dir();
+    let temp_path = temp_dir.as_path();
+    temp_path.join("mongodb_odbc.log").display().to_string()
+}
+
+#[cfg(debug_assertions)]
+lazy_static! {
+    #[derive(Debug)]
+    pub static ref FILE_PATH: String =  get_file_path();
+
+    pub static ref LOGGER_FILE: Mutex<File> =
+        match std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(true)
+        .open(&*FILE_PATH) {
+                    Err(why) => panic!("couldn't open {:?}: {}", FILE_PATH, why),
+                    Ok(file) => Mutex::new(file),
+        };
+}
+
+#[macro_export]
+macro_rules! dbg_write {
+    () => {
+        #[cfg(debug_assertions)]
+        {
+            use chrono::{Local, SecondsFormat};
+            use file_dbg_macros::{FILE_PATH, LOGGER_FILE};
+            use std::io::Write;
+
+            let mut logger_file = LOGGER_FILE.lock();
+            while logger_file.is_err() {
+                logger_file = LOGGER_FILE.lock();
+            }
+            let mut logger_file = logger_file.unwrap();
+            match (*logger_file).write_all(
+                format!(
+                    "{}: {}:{}\n",
+                    Local::now().to_rfc3339_opts(SecondsFormat::Millis, false),
+                    file!(),
+                    line!()
+                )
+                .as_bytes(),
+            ) {
+                Err(why) => panic!("couldn't write to {:?}: {}", FILE_PATH, why),
+                Ok(_) => (),
+            };
+            match (*logger_file).flush() {
+                Err(why) => panic!("couldn't flush {:?}: {}", FILE_PATH, why),
+                Ok(_) => (),
+            }
+        }
+    };
+    ( $val:expr ) => {
+        #[cfg(debug_assertions)]
+        {
+            use chrono::{Local, SecondsFormat};
+            use file_dbg_macros::{FILE_PATH, LOGGER_FILE};
+            use std::io::Write;
+
+            let mut logger_file = LOGGER_FILE.lock();
+            while logger_file.is_err() {
+                logger_file = LOGGER_FILE.lock();
+            }
+            let mut logger_file = logger_file.unwrap();
+            match (*logger_file).write_all(
+                format!(
+                    "{}: {}:{} - {:?}\n",
+                    Local::now().to_rfc3339_opts(SecondsFormat::Millis, false),
+                    file!(),
+                    line!(),
+                    $val
+                )
+                .as_bytes(),
+            ) {
+                Err(why) => panic!("couldn't write to {:?}: {}", FILE_PATH, why),
+                Ok(_) => (),
+            };
+            match (*logger_file).flush() {
+                Err(why) => panic!("couldn't flush {:?}: {}", FILE_PATH, why),
+                Ok(_) => (),
+            }
+        }
+    };
+}

--- a/file_dbg_macros/src/lib.rs
+++ b/file_dbg_macros/src/lib.rs
@@ -26,7 +26,7 @@ lazy_static! {
         .create(true)
         .append(true)
         .open(&*FILE_PATH) {
-                    Err(why) => panic!("couldn't open {:?}: {}", FILE_PATH, why),
+                    Err(why) => panic!("couldn't open log file {:?}: {}", FILE_PATH, why),
                     Ok(file) => Mutex::new(file),
         };
 }

--- a/file_dbg_macros/src/lib.rs
+++ b/file_dbg_macros/src/lib.rs
@@ -54,11 +54,11 @@ macro_rules! dbg_write {
                 )
                 .as_bytes(),
             ) {
-                Err(why) => panic!("couldn't write to {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't write to log file {:?}: {}", FILE_PATH, why),
                 Ok(_) => (),
             };
             match (*logger_file).flush() {
-                Err(why) => panic!("couldn't flush {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't flush log file {:?}: {}", FILE_PATH, why),
                 Ok(_) => (),
             }
         }
@@ -85,11 +85,11 @@ macro_rules! dbg_write {
                 )
                 .as_bytes(),
             ) {
-                Err(why) => panic!("couldn't write to {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't write to log file {:?}: {}", FILE_PATH, why),
                 Ok(_) => (),
             };
             match (*logger_file).flush() {
-                Err(why) => panic!("couldn't flush {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't flush log file {:?}: {}", FILE_PATH, why),
                 Ok(_) => (),
             }
         }

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -20,6 +20,8 @@ regex = "1.6.0"
 chrono = "0.4.22"
 constants = { path = "../constants" }
 mongo-odbc-core = { path = "../core" }
+file_dbg_macros = { path = "../file_dbg_macros" }
+function_name = "0.3.0"
 
 [dependencies.mongodb]
 version = "2.0.2"
@@ -29,6 +31,7 @@ features = ["sync"]
 [dependencies.bson]
 version = "2.0.1"
 features = ["chrono-0_4"]
+
 
 
 [dev-dependencies]

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use bson::{spec::BinarySubtype, Bson};
 use chrono::{offset::Utc, DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use file_dbg_macros::dbg_write;
 use mongo_odbc_core::util::Decimal128Plus;
 use odbc_sys::{CDataType, Date, Len, Pointer, Time, Timestamp, USmallInt};
 use odbc_sys::{Char, Integer, SmallInt, SqlReturn, WChar};
@@ -1360,6 +1361,7 @@ pub mod isize_len {
 /// unsupported functions.
 ///
 pub fn unsupported_function(handle: &mut MongoHandle, name: &'static str) -> SqlReturn {
+    dbg_write!(format!("Unsupported Function: {}, SQLReturn = ERROR", name));
     handle.clear_diagnostics();
     handle.add_diag_info(ODBCError::Unimplemented(name));
     SqlReturn::ERROR

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -34,8 +34,9 @@ const HANDLE_MUST_BE_CONN_ERROR: &str = "handle must be conn";
 const HANDLE_MUST_BE_STMT_ERROR: &str = "handle must be stmt";
 const HANDLE_MUST_BE_DESC_ERROR: &str = "handle must be desc";
 
-// Verifies that the expected SQL State, message text, and native error in the handle match
-// the expected input
+///
+/// trace_call_and_outcome returns a formatted function name and sql return type
+///
 pub fn trace_call_and_outcome(function_name: &str, sql_return: &SqlReturn) -> String {
     let outcome = match *sql_return {
         SqlReturn::SUCCESS => "SUCCESS",

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -123,6 +123,7 @@ macro_rules! panic_safe_exec {
         panic::set_hook(previous_hook);
         match result {
             Ok(sql_return) => {
+                #[allow(unused_variables)]
                 let trace = trace_call_and_outcome(function_name!(), &sql_return);
                 dbg_write!(&trace);
                 return sql_return;
@@ -135,6 +136,7 @@ macro_rules! panic_safe_exec {
                 };
                 handle_ref.add_diag_info(ODBCError::Panic(msg));
                 let sql_return = SqlReturn::ERROR;
+                #[allow(unused_variables)]
                 let trace = trace_call_and_outcome(function_name!(), &sql_return);
                 dbg_write!(&trace);
                 return sql_return;

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -11,8 +11,10 @@ use crate::{
     },
     handles::definitions::*,
 };
+use ::function_name::named;
 use bson::Bson;
 use constants::{DBMS_NAME, DRIVER_NAME, SQL_ALL_CATALOGS, SQL_ALL_SCHEMAS, SQL_ALL_TABLE_TYPES};
+use file_dbg_macros::dbg_write;
 use mongo_odbc_core::{
     odbc_uri::ODBCUri, MongoColMetadata, MongoCollections, MongoConnection, MongoDatabases,
     MongoFields, MongoQuery, MongoStatement, MongoTableTypes,
@@ -31,6 +33,23 @@ const HANDLE_MUST_BE_ENV_ERROR: &str = "handle must be env";
 const HANDLE_MUST_BE_CONN_ERROR: &str = "handle must be conn";
 const HANDLE_MUST_BE_STMT_ERROR: &str = "handle must be stmt";
 const HANDLE_MUST_BE_DESC_ERROR: &str = "handle must be desc";
+
+// Verifies that the expected SQL State, message text, and native error in the handle match
+// the expected input
+pub fn trace_call_and_outcome(function_name: &str, sql_return: &SqlReturn) -> String {
+    let outcome = match *sql_return {
+        SqlReturn::SUCCESS => "SUCCESS",
+        SqlReturn::ERROR => "ERROR",
+        SqlReturn::SUCCESS_WITH_INFO => "SUCCESS_WITH_INFO",
+        SqlReturn::INVALID_HANDLE => "INVALID_HANDLE",
+        SqlReturn::NEED_DATA => "NEED_DATA",
+        SqlReturn::NO_DATA => "NO_DATA",
+        SqlReturn::PARAM_DATA_AVAILABLE => "PARAM_DATA_AVAILABLE",
+        SqlReturn::STILL_EXECUTING => "STILL_EXECUTING",
+        _ => "unknown sql_return",
+    };
+    format!("{}, SQLReturn = {}", function_name, outcome)
+}
 
 macro_rules! must_be_valid {
     ($maybe_handle:expr) => {{
@@ -103,7 +122,11 @@ macro_rules! panic_safe_exec {
         let result = panic::catch_unwind(function);
         panic::set_hook(previous_hook);
         match result {
-            Ok(sql_return) => return sql_return,
+            Ok(sql_return) => {
+                let trace = trace_call_and_outcome(function_name!(), &sql_return);
+                dbg_write!(&trace);
+                return sql_return;
+            }
             Err(err) => {
                 let msg = if let Some(msg) = err.downcast_ref::<&'static str>() {
                     format!("{}\n{:?}", msg, r.recv())
@@ -111,7 +134,10 @@ macro_rules! panic_safe_exec {
                     format!("{:?}\n{:?}", err, r.recv())
                 };
                 handle_ref.add_diag_info(ODBCError::Panic(msg));
-                return SqlReturn::ERROR;
+                let sql_return = SqlReturn::ERROR;
+                let trace = trace_call_and_outcome(function_name!(), &sql_return);
+                dbg_write!(&trace);
+                return sql_return;
             }
         };
     }};
@@ -131,6 +157,7 @@ macro_rules! unimpl {
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLAllocHandle(
     handle_type: HandleType,
@@ -225,6 +252,7 @@ fn sql_alloc_handle(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLBindCol(
     hstmt: HStmt,
@@ -285,6 +313,7 @@ pub unsafe extern "C" fn SQLBrowseConnect(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLBrowseConnectW(
     connection_handle: HDbc,
@@ -317,6 +346,7 @@ pub unsafe extern "C" fn SQLBulkOperations(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLCancel(statement_handle: HStmt) -> SqlReturn {
     unimpl!(statement_handle);
@@ -328,6 +358,7 @@ pub unsafe extern "C" fn SQLCancel(statement_handle: HStmt) -> SqlReturn {
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLCancelHandle(_handle_type: HandleType, handle: Handle) -> SqlReturn {
     unimpl!(handle);
@@ -372,6 +403,7 @@ pub unsafe extern "C" fn SQLColAttribute(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLColAttributeW(
     statement_handle: HStmt,
@@ -548,6 +580,7 @@ pub unsafe extern "C" fn SQLColumnPrivileges(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLColumnPrivilegesW(
     statement_handle: HStmt,
@@ -569,6 +602,7 @@ pub unsafe extern "C" fn SQLColumnPrivilegesW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLColumns(
     statement_handle: HStmt,
@@ -639,6 +673,7 @@ pub unsafe extern "C" fn SQLColumns(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLColumnsW(
     statement_handle: HStmt,
@@ -854,6 +889,7 @@ pub unsafe extern "C" fn SQLDescribeCol(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLDescribeColW(
     hstmt: HStmt,
@@ -922,6 +958,7 @@ pub unsafe extern "C" fn SQLDescribeParam(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLDisconnect(connection_handle: HDbc) -> SqlReturn {
     panic_safe_exec!(
@@ -968,6 +1005,7 @@ fn sql_driver_connect(conn: &Connection, odbc_uri_string: &str) -> Result<MongoC
 /// # Safety
 /// Because this is a C-infereface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLDriverConnect(
     connection_handle: HDbc,
@@ -1020,6 +1058,7 @@ pub unsafe extern "C" fn SQLDriverConnect(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLDriverConnectW(
     connection_handle: HDbc,
@@ -1112,6 +1151,7 @@ pub unsafe extern "C" fn SQLDriversW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLEndTran(
     _handle_type: HandleType,
@@ -1127,6 +1167,7 @@ pub unsafe extern "C" fn SQLEndTran(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLExecDirect(
     statement_handle: HStmt,
@@ -1168,6 +1209,7 @@ pub unsafe extern "C" fn SQLExecDirect(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLExecDirectW(
     statement_handle: HStmt,
@@ -1217,6 +1259,7 @@ pub unsafe extern "C" fn SQLExecute(statement_handle: HStmt) -> SqlReturn {
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLFetch(statement_handle: HStmt) -> SqlReturn {
     panic_safe_exec!(
@@ -1267,6 +1310,7 @@ pub unsafe extern "C" fn SQLFetch(statement_handle: HStmt) -> SqlReturn {
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLFetchScroll(
     statement_handle: HStmt,
@@ -1309,6 +1353,7 @@ pub unsafe extern "C" fn SQLForeignKeys(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLForeignKeysW(
     statement_handle: HStmt,
@@ -1334,6 +1379,7 @@ pub unsafe extern "C" fn SQLForeignKeysW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLFreeHandle(handle_type: HandleType, handle: Handle) -> SqlReturn {
     panic_safe_exec!(
@@ -1414,6 +1460,7 @@ fn sql_free_handle(handle_type: HandleType, handle: *mut MongoHandle) -> Result<
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLFreeStmt(statement_handle: HStmt, _option: SmallInt) -> SqlReturn {
     panic_safe_exec!(
@@ -1449,6 +1496,7 @@ pub unsafe extern "C" fn SQLGetConnectAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetConnectAttrW(
     connection_handle: HDbc,
@@ -1536,6 +1584,7 @@ pub unsafe extern "C" fn SQLGetCursorName(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetCursorNameW(
     statement_handle: HStmt,
@@ -1552,6 +1601,7 @@ pub unsafe extern "C" fn SQLGetCursorNameW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetData(
     statement_handle: HStmt,
@@ -1734,6 +1784,7 @@ pub unsafe extern "C" fn SQLGetDiagField(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetDiagFieldW(
     _handle_type: HandleType,
@@ -1858,6 +1909,7 @@ macro_rules! sql_get_diag_rec_impl {
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetDiagRec(
     handle_type: HandleType,
@@ -1890,6 +1942,7 @@ pub unsafe extern "C" fn SQLGetDiagRec(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetDiagRecW(
     handle_type: HandleType,
@@ -1939,6 +1992,7 @@ pub unsafe extern "C" fn SQLGetEnvAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetEnvAttrW(
     environment_handle: HEnv,
@@ -2003,6 +2057,7 @@ pub unsafe extern "C" fn SQLGetInfo(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetInfoW(
     connection_handle: HDbc,
@@ -2489,6 +2544,7 @@ pub unsafe extern "C" fn SQLGetStmtAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetStmtAttrW(
     handle: HStmt,
@@ -2645,6 +2701,7 @@ pub unsafe extern "C" fn SQLGetStmtAttrW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLGetTypeInfo(handle: HStmt, _data_type: SqlDataType) -> SqlReturn {
     unimpl!(handle);
@@ -2689,6 +2746,7 @@ pub unsafe extern "C" fn SQLNativeSql(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLNativeSqlW(
     connection_handle: HDbc,
@@ -2721,6 +2779,7 @@ pub unsafe extern "C" fn SQLNumParams(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLNumResultCols(
     statement_handle: HStmt,
@@ -2818,6 +2877,7 @@ pub unsafe extern "C" fn SQLPrimaryKeys(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLPrimaryKeysW(
     statement_handle: HStmt,
@@ -2942,6 +3002,7 @@ pub unsafe extern "C" fn SQLPutData(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLRowCount(
     statement_handle: HStmt,
@@ -2984,6 +3045,7 @@ pub unsafe extern "C" fn SQLSetConnectAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSetConnectAttrW(
     connection_handle: HDbc,
@@ -3048,6 +3110,7 @@ pub unsafe extern "C" fn SQLSetCursorName(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSetCursorNameW(
     statement_handle: HStmt,
@@ -3080,9 +3143,10 @@ pub unsafe extern "C" fn SQLSetDescField(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSetDescRec(
-    _desc_handle: HDesc,
+    desc_handle: HDesc,
     _rec_number: SmallInt,
     _desc_type: SmallInt,
     _desc_sub_type: SmallInt,
@@ -3093,7 +3157,7 @@ pub unsafe extern "C" fn SQLSetDescRec(
     _string_length_ptr: *const Len,
     _indicator_ptr: *const Len,
 ) -> SqlReturn {
-    unimplemented!()
+    unimpl!(desc_handle)
 }
 
 ///
@@ -3136,6 +3200,7 @@ pub unsafe extern "C" fn SQLSetEnvAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSetEnvAttrW(
     environment_handle: HEnv,
@@ -3219,6 +3284,7 @@ pub unsafe extern "C" fn SQLSetStmtAttr(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSetStmtAttrW(
     hstmt: HStmt,
@@ -3461,6 +3527,7 @@ pub unsafe extern "C" fn SQLSpecialColumns(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLSpecialColumnsW(
     statement_handle: HStmt,
@@ -3483,6 +3550,7 @@ pub unsafe extern "C" fn SQLSpecialColumnsW(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLStatistics(
     statement_handle: HStmt,
@@ -3525,6 +3593,7 @@ pub unsafe extern "C" fn SQLTablePrivileges(
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
+#[named]
 #[no_mangle]
 pub unsafe extern "C" fn SQLTablesPrivilegesW(
     statement_handle: HStmt,
@@ -3593,6 +3662,7 @@ fn sql_tables(
 /// Because this is a C-interface, this is necessarily unsafe
 ///
 #[no_mangle]
+#[named]
 pub unsafe extern "C" fn SQLTablesW(
     statement_handle: HStmt,
     catalog_name: *const WChar,

--- a/odbc/src/api/panic_safe_exec_tests.rs
+++ b/odbc/src/api/panic_safe_exec_tests.rs
@@ -1,17 +1,22 @@
+use crate::trace_call_and_outcome;
 use crate::{
     errors::ODBCError,
     handles::definitions::{MongoHandle, MongoHandleRef, Statement, StatementState},
     panic_safe_exec,
 };
+use ::function_name::named;
+use file_dbg_macros::dbg_write;
 use odbc_sys::{HStmt, SqlReturn};
 use std::{panic, sync::mpsc};
 
 mod unit {
     use super::*;
+    #[named]
     fn non_panic_fn(stmt_handle: HStmt) -> SqlReturn {
         panic_safe_exec!(|| { SqlReturn::SUCCESS }, stmt_handle);
     }
 
+    #[named]
     fn panic_fn(stmt_handle: HStmt) -> SqlReturn {
         panic_safe_exec!(|| { panic!("panic test") }, stmt_handle);
     }


### PR DESCRIPTION
This patch is based on @nbagnard 's tracing changes in this branch [branch](https://github.com/nbagnard/mongo-odbc-driver/tree/SQL-639-Playaround).

Sample output:
```
2023-01-05T19:41:20.764-08:00: odbc\src\api\functions.rs:1614 - "SQLGetData, SQLReturn = SUCCESS"
2023-01-05T19:41:20.765-08:00: odbc\src\api\functions.rs:1614 - "SQLGetData, SQLReturn = SUCCESS"
2023-01-05T19:41:20.766-08:00: odbc\src\api\functions.rs:1614 - "SQLGetData, SQLReturn = NO_DATA"
2023-01-05T19:41:20.767-08:00: odbc\src\api\functions.rs:1265 - "SQLFetch, SQLReturn = NO_DATA"
2023-01-05T19:41:20.768-08:00: odbc\src\api\functions.rs:1385 - "SQLFreeHandle, SQLReturn = SUCCESS"
2023-01-05T19:41:20.768-08:00: odbc\src\api\functions.rs:964 - "SQLDisconnect, SQLReturn = SUCCESS"
2023-01-05T19:41:20.769-08:00: odbc\src\api\functions.rs:1385 - "SQLFreeHandle, SQLReturn = SUCCESS"
```
Output with an unsupported function:
```
2023-01-05T09:15:02.321-08:00: odbc\src\api\data.rs:1364 - "Unsupported Function: SQLBindParameter, SQLReturn = ERROR"
```
The file name env variable for the user to specify a path/file name is `DBG_FILE_PATH` and the default log file name is `mongodb_odbc.log`.