### PR TITLE
SQL-1176: corrects odbc version; updates driver version test

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -1,6 +1,7 @@
 pub const VENDOR_IDENTIFIER: &str = "MongoDB";
 pub const DRIVER_NAME: &str = "MongoDB Atlas SQL interface ODBC Driver";
 pub const DBMS_NAME: &str = "MongoDB Atlas";
+pub const ODBC_VERSION: &str = "03.80";
 
 // SQL states
 pub const NOT_IMPLEMENTED: &str = "HYC00";

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 use ::function_name::named;
 use bson::Bson;
-use constants::{DBMS_NAME, DRIVER_NAME, SQL_ALL_CATALOGS, SQL_ALL_SCHEMAS, SQL_ALL_TABLE_TYPES};
+use constants::{
+    DBMS_NAME, DRIVER_NAME, ODBC_VERSION, SQL_ALL_CATALOGS, SQL_ALL_SCHEMAS, SQL_ALL_TABLE_TYPES,
+};
 use file_dbg_macros::dbg_write;
 use mongo_odbc_core::{
     odbc_uri::ODBCUri, MongoColMetadata, MongoCollections, MongoConnection, MongoDatabases,
@@ -2197,7 +2199,7 @@ unsafe fn sql_get_infow_helper(
                 InfoType::SQL_DRIVER_ODBC_VER => {
                     // This driver supports version 3.8.
                     i16_len::set_output_wstring(
-                        "03.08",
+                        ODBC_VERSION,
                         info_value_ptr as *mut WChar,
                         buffer_length as usize,
                         string_length_ptr,

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -86,8 +86,10 @@ unsafe fn modify_u16_value(value_ptr: Pointer, _: usize) -> u16 {
 }
 
 mod unit {
+    use crate::util::format_version;
+
     use super::*;
-    use constants::{DBMS_NAME, DRIVER_NAME};
+    use constants::{DBMS_NAME, DRIVER_NAME, ODBC_VERSION};
 
     test_get_info!(
         driver_name,
@@ -105,7 +107,11 @@ mod unit {
         expected_sql_return = SqlReturn::SUCCESS,
         buffer_length = 11,
         expected_length = 10,
-        expected_value = "00.01.0000",
+        expected_value = format_version(
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            env!("CARGO_PKG_VERSION_MINOR"),
+            env!("CARGO_PKG_VERSION_PATCH"),
+        ),
         actual_value_modifier = modify_string_value,
     );
 
@@ -115,7 +121,7 @@ mod unit {
         expected_sql_return = SqlReturn::SUCCESS,
         buffer_length = 6,
         expected_length = 5,
-        expected_value = "03.08",
+        expected_value = ODBC_VERSION,
         actual_value_modifier = modify_string_value,
     );
 

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -133,8 +133,8 @@ mod unit {
     format_version_test!(
         format_cargo_version,
         expected = "00.01.0000",
-        major = env!("CARGO_PKG_VERSION_MAJOR"),
-        minor = env!("CARGO_PKG_VERSION_MINOR"),
-        patch = env!("CARGO_PKG_VERSION_PATCH")
+        major = "0",
+        minor = "1",
+        patch = "0"
     );
 }


### PR DESCRIPTION
I extracted the odbc version to a constant located with other constants.

Also, while I was lookihng at the test suite I noticed that we were hard coding a version expectation, even though we derive the driver version from our cargo.toml file. I updated the the associated tests.