### PR TITLE
SQL-1185: Fix SQLTablesW not listing table names

### DIFF
--- a/core/src/col_metadata.rs
+++ b/core/src/col_metadata.rs
@@ -320,8 +320,8 @@ mod unit {
 
             match actual {
                 Err(Error::InvalidResultSetJsonSchema) => (),
-                Err(e) => panic!("unexpected error: {:?}", e),
-                Ok(ok) => panic!("unexpected result: {:?}", ok),
+                Err(e) => panic!("unexpected error: {e:?}"),
+                Ok(ok) => panic!("unexpected result: {ok:?}"),
             }
         }
 
@@ -348,8 +348,8 @@ mod unit {
 
             match actual {
                 Err(Error::InvalidResultSetJsonSchema) => (),
-                Err(e) => panic!("unexpected error: {:?}", e),
-                Ok(ok) => panic!("unexpected result: {:?}", ok),
+                Err(e) => panic!("unexpected error: {e:?}"),
+                Ok(ok) => panic!("unexpected result: {ok:?}"),
             }
         }
 
@@ -395,7 +395,7 @@ mod unit {
             let res = input.process_result_metadata("test_db");
 
             match res {
-                Err(e) => panic!("unexpected error: {:?}", e),
+                Err(e) => panic!("unexpected error: {e:?}"),
                 Ok(actual) => {
                     // There should be 3 fields
                     assert_eq!(3, actual.len());
@@ -558,8 +558,8 @@ mod unit {
             let nullability = input_schema.get_field_nullability("a".to_string());
             match nullability {
                 Err(Error::UnknownColumn(_)) => (),
-                Err(e) => panic!("unexpected error: {:?}", e),
-                Ok(ok) => panic!("unexpected result: {:?}", ok),
+                Err(e) => panic!("unexpected error: {e:?}"),
+                Ok(ok) => panic!("unexpected result: {ok:?}"),
             }
         }
     }

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -157,7 +157,8 @@ impl<'a> ODBCUri<'a> {
         self.remove(names).ok_or_else(|| {
             if names.len() == 1 {
                 Error::InvalidUriFormat(format!(
-                    "{} is required for a valid Mongo ODBC Uri", names[0]
+                    "{} is required for a valid Mongo ODBC Uri",
+                    names[0]
                 ))
             } else {
                 Error::InvalidUriFormat(format!(

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -78,8 +78,7 @@ impl<'a> ODBCUri<'a> {
         let rest = rest.get(1..).unwrap();
         if !KEYWORDS.is_match(keyword) {
             return Err(Error::InvalidUriFormat(format!(
-                "'{}' is not a valid URI keyword",
-                keyword
+                "'{keyword}' is not a valid URI keyword"
             )));
         }
         let (value, rest) = if rest.starts_with('{') {
@@ -158,13 +157,11 @@ impl<'a> ODBCUri<'a> {
         self.remove(names).ok_or_else(|| {
             if names.len() == 1 {
                 Error::InvalidUriFormat(format!(
-                    "{} is required for a valid Mongo ODBC Uri",
-                    names[0]
+                    "{} is required for a valid Mongo ODBC Uri", names[0]
                 ))
             } else {
                 Error::InvalidUriFormat(format!(
-                    "One of {:?} is required for a valid Mongo ODBC Uri",
-                    names
+                    "One of {names:?} is required for a valid Mongo ODBC Uri"
                 ))
             }
         })
@@ -189,8 +186,7 @@ impl<'a> ODBCUri<'a> {
             .is_none()
         {
             return Err(Error::InvalidUriFormat(format!(
-                "One of {:?} is required for a valid Mongo ODBC Uri",
-                USER_KWS,
+                "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri"
             )));
         }
         if client_options
@@ -201,8 +197,7 @@ impl<'a> ODBCUri<'a> {
             .is_none()
         {
             return Err(Error::InvalidUriFormat(format!(
-                "One of {:?} is required for a valid Mongo ODBC Uri",
-                PWD_KWS,
+                "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri"
             )));
         }
         Ok(())

--- a/core/src/util/decimal128.rs
+++ b/core/src/util/decimal128.rs
@@ -163,9 +163,9 @@ impl Decimal128Plus for [u8; 16] {
             // Exponent
             str_out.push('E');
             if scientific_exponent > 0 {
-                str_out.push_str(format!("+{}", scientific_exponent).as_str());
+                str_out.push_str(format!("+{scientific_exponent}").as_str());
             } else {
-                str_out.push_str(format!("{}", scientific_exponent).as_str());
+                str_out.push_str(format!("{scientific_exponent}").as_str());
             }
             return str_out;
         }

--- a/file_dbg_macros/src/lib.rs
+++ b/file_dbg_macros/src/lib.rs
@@ -26,7 +26,7 @@ lazy_static! {
         .create(true)
         .append(true)
         .open(&*FILE_PATH) {
-                    Err(why) => panic!("couldn't open log file {:?}: {}", FILE_PATH, why),
+                    Err(why) => panic!("couldn't open log file {FILE_PATH:?}: {why}"),
                     Ok(file) => Mutex::new(file),
         };
 }
@@ -54,11 +54,11 @@ macro_rules! dbg_write {
                 )
                 .as_bytes(),
             ) {
-                Err(why) => panic!("couldn't write to log file {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't write to log file {FILE_PATH:?}: {why}"),
                 Ok(_) => (),
             };
             match (*logger_file).flush() {
-                Err(why) => panic!("couldn't flush log file {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't flush log file {FILE_PATH:?}: {why}"),
                 Ok(_) => (),
             }
         }
@@ -85,11 +85,11 @@ macro_rules! dbg_write {
                 )
                 .as_bytes(),
             ) {
-                Err(why) => panic!("couldn't write to log file {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't write to log file {FILE_PATH:?}: {why}"),
                 Ok(_) => (),
             };
             match (*logger_file).flush() {
-                Err(why) => panic!("couldn't flush log file {:?}: {}", FILE_PATH, why),
+                Err(why) => panic!("couldn't flush log file {FILE_PATH:?}: {why}"),
                 Ok(_) => (),
             }
         }

--- a/integration_test/src/bin/data_loader.rs
+++ b/integration_test/src/bin/data_loader.rs
@@ -122,7 +122,7 @@ fn read_data_files(dir_path: &str) -> Result<Vec<TestData>> {
                 if ext == "yml" || ext == "yaml" {
                     return Some(path);
                 } else {
-                    println!("Ignoring file without '.y[a]ml' extension: {:?}", path);
+                    println!("Ignoring file without '.y[a]ml' extension: {path:?}");
                 }
             }
             None
@@ -170,7 +170,7 @@ fn drop_collections(client: Client, datasets: Vec<TestData>) -> Result<()> {
     for (db, c) in namespaces_to_drop {
         let database = client.database(db.as_str());
         database.collection::<Bson>(c.as_str()).drop(None)?;
-        println!("Dropped {}.{}", db, c)
+        println!("Dropped {db}.{c}")
     }
 
     Ok(())

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -118,7 +118,7 @@ pub enum TestDef {
 
 impl fmt::Display for TestDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -140,7 +140,7 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
 
         for test in yaml.tests {
             match test.skip_reason {
-                Some(sr) => println!("Skip Reason: {}", sr),
+                Some(sr) => println!("Skip Reason: {sr}"),
                 None => {
                     let mut conn_str = crate::common::generate_default_connection_str();
                     conn_str.push_str(&("DATABASE=".to_owned() + &test.db));
@@ -166,7 +166,7 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
 /// path names.
 pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>> {
     let mut paths: Vec<String> = vec![];
-    let entries = fs::read_dir(dir).map_err(|e| Error::InvalidDirectory(format!("{:?}", e)))?;
+    let entries = fs::read_dir(dir).map_err(|e| Error::InvalidDirectory(format!("{e:?}")))?;
     for entry in entries {
         match entry {
             Ok(de) => {
@@ -175,7 +175,7 @@ pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>> {
                     paths.push(path.to_str().unwrap().to_string());
                 }
             }
-            Err(e) => return Err(Error::InvalidFilePath(format!("{:?}", e))),
+            Err(e) => return Err(Error::InvalidFilePath(format!("{e:?}"))),
         };
     }
     Ok(paths)
@@ -184,9 +184,9 @@ pub fn load_file_paths(dir: PathBuf) -> Result<Vec<String>> {
 /// parse_test_file_yaml deserializes the given YAML file into a
 /// IntegrationTest struct.
 pub fn parse_test_file_yaml(path: &str) -> Result<IntegrationTest> {
-    let f = fs::File::open(path).map_err(|e| Error::InvalidFile(format!("{:?}", e)))?;
+    let f = fs::File::open(path).map_err(|e| Error::InvalidFile(format!("{e:?}")))?;
     let integration_test: IntegrationTest =
-        serde_yaml::from_reader(f).map_err(|e| Error::CannotDeserializeYaml(format!("{:?}", e)))?;
+        serde_yaml::from_reader(f).map_err(|e| Error::CannotDeserializeYaml(format!("{e:?}")))?;
     Ok(integration_test)
 }
 
@@ -523,7 +523,7 @@ fn validate_result_set_metadata_helper(
                 test: description,
                 expected: exp_metadata.len(),
                 actual: column_count,
-                descriptor: format!("{:?}", descriptor),
+                descriptor: format!("{descriptor:?}"),
             });
         }
         for (i, current_exp_metadata) in exp_metadata.iter().enumerate().take(column_count) {
@@ -536,7 +536,7 @@ fn validate_result_set_metadata_helper(
                             test: description,
                             expected: n.to_string(),
                             actual: actual_value.to_string(),
-                            descriptor: format!("{:?}", descriptor),
+                            descriptor: format!("{descriptor:?}"),
                             column: i,
                         });
                     }
@@ -547,12 +547,12 @@ fn validate_result_set_metadata_helper(
                             test: description,
                             expected: s.to_string(),
                             actual: actual_value.to_string(),
-                            descriptor: format!("{:?}", descriptor),
+                            descriptor: format!("{descriptor:?}"),
                             column: i,
                         });
                     }
                 }
-                meta_type => return Err(Error::UnexpectedMetadataType(format!("{:?}", meta_type))),
+                meta_type => return Err(Error::UnexpectedMetadataType(format!("{meta_type:?}"))),
             }
         }
     }
@@ -677,7 +677,7 @@ fn get_column_attribute(
                 ))[0..*string_length_ptr as usize]
                     .to_string()),
                 Value::Number(_) => json!(*numeric_attrib_ptr),
-                meta_type => return Err(Error::UnexpectedMetadataType(format!("{:?}", meta_type))),
+                meta_type => return Err(Error::UnexpectedMetadataType(format!("{meta_type:?}"))),
             }),
             sql_return => Err(Error::OdbcFunctionFailed(
                 "SQLColAttributeW".to_string(),

--- a/integration_test/src/test_runner/test_generator_util.rs
+++ b/integration_test/src/test_runner/test_generator_util.rs
@@ -116,12 +116,12 @@ pub fn generate_baseline_test_file(
         .unwrap()
         .as_millis();
     let desc = entry.description.clone().replace(' ', "_");
-    let file_name = format!("{}-{}.yml", desc, now);
+    let file_name = format!("{desc}-{now}.yml");
 
     let writer = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
-        .open(format!("{}/{}", GENERATED_TEST_DIR, file_name))
+        .open(format!("{GENERATED_TEST_DIR}/{file_name}"))
         .expect("could not open or create test file");
 
     serde_yaml::to_writer(writer, &test_entry).map_err(|err| Error::Yaml(err.to_string()))

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -16,9 +16,8 @@ pub fn generate_default_connection_str() -> String {
         Err(_e) => "ADF_ODBC_DRIVER".to_string(), //Default driver name
     };
 
-    let mut connection_string = format!(
-        "Driver={{{driver}}};USER={user_name};PWD={password};SERVER={host};"
-    );
+    let mut connection_string =
+        format!("Driver={{{driver}}};USER={user_name};PWD={password};SERVER={host};");
 
     // If a db is specified add it to the connection string
     match db {

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -17,8 +17,7 @@ pub fn generate_default_connection_str() -> String {
     };
 
     let mut connection_string = format!(
-        "Driver={{{}}};USER={};PWD={};SERVER={};",
-        driver, user_name, password, host,
+        "Driver={{{driver}}};USER={user_name};PWD={password};SERVER={host};"
     );
 
     // If a db is specified add it to the connection string
@@ -67,7 +66,7 @@ pub fn sql_return_to_string(return_code: SqlReturn) -> String {
         SqlReturn::NO_DATA => "NO_DATA".to_string(),
         SqlReturn::ERROR => "ERROR".to_string(),
         _ => {
-            format!("{:?}", return_code)
+            format!("{return_code:?}")
         }
     }
 }

--- a/integration_test/tests/power_bi_tests.rs
+++ b/integration_test/tests/power_bi_tests.rs
@@ -166,12 +166,8 @@ mod integration {
         unsafe {
             let input_len = in_connection_string.len() as SmallInt;
 
-            println!(
-                "Input connection string = {in_connection_string}\nLength is {input_len}"
-            );
-            println!(
-                "Output connection string = {out_connection_string}\nLength is {output_len}"
-            );
+            println!("Input connection string = {in_connection_string}\nLength is {input_len}");
+            println!("Output connection string = {out_connection_string}\nLength is {output_len}");
             // The output string should be the same as the input string except with extra curly braces around the driver name
             assert_eq!(input_len, output_len, "Expect that both connection the input connection string and ouptput connection string have the same length but input string length is {input_len} and output string length is {output_len}");
 

--- a/integration_test/tests/power_bi_tests.rs
+++ b/integration_test/tests/power_bi_tests.rs
@@ -167,15 +167,13 @@ mod integration {
             let input_len = in_connection_string.len() as SmallInt;
 
             println!(
-                "Input connection string = {}\nLength is {}",
-                in_connection_string, input_len
+                "Input connection string = {in_connection_string}\nLength is {input_len}"
             );
             println!(
-                "Output connection string = {}\nLength is {}",
-                out_connection_string, output_len
+                "Output connection string = {out_connection_string}\nLength is {output_len}"
             );
             // The output string should be the same as the input string except with extra curly braces around the driver name
-            assert_eq!(input_len, output_len, "Expect that both connection the input connection string and ouptput connection string have the same length but input string length is {} and output string length is {}",input_len, output_len);
+            assert_eq!(input_len, output_len, "Expect that both connection the input connection string and ouptput connection string have the same length but input string length is {input_len} and output string length is {output_len}");
 
             let str_len_ptr = &mut 0;
             const BUFFER_LENGTH: SmallInt = 300;

--- a/odbc/src/api/col_attr_describe_tests.rs
+++ b/odbc/src/api/col_attr_describe_tests.rs
@@ -3,7 +3,7 @@ use crate::{
     SQLColAttributeW, SQLDescribeColW,
 };
 use mongo_odbc_core::{MongoFields, SQL_SEARCHABLE};
-use odbc_sys::{Desc, Nullability, SmallInt, SqlReturn};
+use odbc_sys::{Desc, Nullability, SmallInt, SqlReturn, WChar};
 use std::sync::RwLock;
 
 mod unit {
@@ -62,7 +62,7 @@ mod unit {
                             .unwrap()[0]
                     ),
                 );
-                let _ = Box::from_raw(char_buffer);
+                let _ = Box::from_raw(char_buffer as *mut WChar);
             }
         }
     }
@@ -123,7 +123,7 @@ mod unit {
                             .unwrap()[0]
                     ),
                 );
-                let _ = Box::from_raw(char_buffer);
+                let _ = Box::from_raw(char_buffer as *mut WChar);
             }
         }
     }
@@ -169,7 +169,7 @@ mod unit {
                         .unwrap()[0]
                 ),
             );
-            let _ = Box::from_raw(name_buffer);
+            let _ = Box::from_raw(name_buffer as *mut WChar);
         }
     }
 
@@ -229,7 +229,7 @@ mod unit {
                             .unwrap()[0]
                     ),
                 );
-                let _ = Box::from_raw(char_buffer);
+                let _ = Box::from_raw(char_buffer as *mut WChar);
             }
         }
     }
@@ -266,8 +266,7 @@ mod unit {
                 );
                 assert_eq!(
                     format!(
-                        "[MongoDB][API] The field index {} is out of bounds",
-                        col_index,
+                        "[MongoDB][API] The field index {col_index} is out of bounds",
                     ),
                     format!(
                         "{}",
@@ -279,7 +278,7 @@ mod unit {
                             .unwrap()[0]
                     )
                 );
-                let _ = Box::from_raw(name_buffer);
+                let _ = Box::from_raw(name_buffer as *mut WChar);
             }
         }
     }
@@ -317,8 +316,7 @@ mod unit {
                     );
                     assert_eq!(
                         format!(
-                            "[MongoDB][API] The field index {} is out of bounds",
-                            col_index,
+                            "[MongoDB][API] The field index {col_index} is out of bounds",
                         ),
                         format!(
                             "{}",
@@ -330,7 +328,7 @@ mod unit {
                                 .unwrap()[0]
                         )
                     );
-                    let _ = Box::from_raw(char_buffer);
+                    let _ = Box::from_raw(char_buffer as *mut WChar);
                 }
             }
         }
@@ -381,7 +379,7 @@ mod unit {
                         *out_length as usize
                     )
                 );
-                let _ = Box::from_raw(char_buffer);
+                let _ = Box::from_raw(char_buffer as *mut WChar);
             }
         }
     }
@@ -431,7 +429,7 @@ mod unit {
                     )
                 );
                 assert_eq!(expected, *numeric_attr_ptr);
-                let _ = Box::from_raw(char_buffer);
+                let _ = Box::from_raw(char_buffer as *mut WChar);
             }
         }
     }
@@ -484,7 +482,7 @@ mod unit {
                     *out_name_length as usize
                 )
             );
-            let _ = Box::from_raw(name_buffer);
+            let _ = Box::from_raw(name_buffer as *mut WChar);
         }
     }
 }

--- a/odbc/src/api/col_attr_describe_tests.rs
+++ b/odbc/src/api/col_attr_describe_tests.rs
@@ -265,9 +265,7 @@ mod unit {
                     )
                 );
                 assert_eq!(
-                    format!(
-                        "[MongoDB][API] The field index {col_index} is out of bounds",
-                    ),
+                    format!("[MongoDB][API] The field index {col_index} is out of bounds",),
                     format!(
                         "{}",
                         (*stmt_handle)
@@ -315,9 +313,7 @@ mod unit {
                         )
                     );
                     assert_eq!(
-                        format!(
-                            "[MongoDB][API] The field index {col_index} is out of bounds",
-                        ),
+                        format!("[MongoDB][API] The field index {col_index} is out of bounds",),
                         format!(
                             "{}",
                             (*mongo_handle)

--- a/odbc/src/api/connect_attr_tests.rs
+++ b/odbc/src/api/connect_attr_tests.rs
@@ -55,7 +55,7 @@ mod unit {
                     $(assert_eq!($expected_length, *out_length);)?
                     $(assert_eq!($expected_value, $actual_value_modifier(value_ptr, *out_length as usize));)?
 
-                    let _ = Box::from_raw(value_ptr);
+                    let _ = Box::from_raw(value_ptr as *mut UInteger);
                 }
             }
         };
@@ -246,7 +246,7 @@ mod unit {
             ODBCError::UnsupportedConnectionAttribute(actual_attr) => {
                 assert_eq!(connection_attribute_to_string(attr), *actual_attr)
             }
-            _ => panic!("unexpected err: {:?}", actual_err),
+            _ => panic!("unexpected err: {actual_err:?}"),
         }
     }
 }

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -915,7 +915,7 @@ pub unsafe fn format_bson_data(
             data,
         ),
         other => {
-            mongo_handle.add_diag_info(ODBCError::UnimplementedDataType(format!("{:?}", other)));
+            mongo_handle.add_diag_info(ODBCError::UnimplementedDataType(format!("{other:?}")));
             SqlReturn::ERROR
         }
     }
@@ -1363,7 +1363,7 @@ pub mod isize_len {
 /// unsupported functions.
 ///
 pub fn unsupported_function(handle: &mut MongoHandle, name: &'static str) -> SqlReturn {
-    dbg_write!(format!("Unsupported Function: {}, SQLReturn = ERROR", name));
+    dbg_write!(format!("Unsupported Function: {name}, SQLReturn = ERROR"));
     handle.clear_diagnostics();
     handle.add_diag_info(ODBCError::Unimplemented(name));
     SqlReturn::ERROR

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -18,7 +18,7 @@ use mongo_odbc_core::{
     },
     mock_query::MongoQuery,
 };
-use odbc_sys::{Date, Nullability, SqlReturn, Time, Timestamp};
+use odbc_sys::{Date, Nullability, SqlReturn, Time, Timestamp, WChar};
 
 const ARRAY_COL: u16 = 1;
 const BIN_COL: u16 = 2;
@@ -276,8 +276,8 @@ mod unit {
                         .unwrap()[0]
                 ),
             );
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -312,8 +312,8 @@ mod unit {
             assert_eq!(SqlReturn::SUCCESS, SQLFetch(stmt_handle as *mut _,));
             assert_eq!(SqlReturn::NO_DATA, SQLFetch(stmt_handle as *mut _,));
             assert_eq!(SqlReturn::NO_DATA, SQLMoreResults(stmt_handle as *mut _,));
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -361,9 +361,9 @@ mod unit {
                         .unwrap()[0],
                 ),
             );
-            let _ = Box::from_raw(char_buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(char_buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -472,9 +472,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(char_buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(char_buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -519,8 +519,7 @@ mod unit {
                     if code == SqlReturn::SUCCESS_WITH_INFO {
                         assert_eq!(
                             format!(
-                                "[MongoDB][API] Buffer size \"{}\" not large enough for data",
-                                buffer_length
+                                "[MongoDB][API] Buffer size \"{buffer_length}\" not large enough for data"
                             ),
                             format!(
                                 "{}",
@@ -562,9 +561,9 @@ mod unit {
                 str_val_test(UNICODE_COL, 5, "个中文句子", SqlReturn::SUCCESS);
                 str_val_test(UNICODE_COL, 0, "", SqlReturn::NO_DATA);
             }
-            let _ = Box::from_raw(char_buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(char_buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -645,9 +644,9 @@ mod unit {
                     SqlReturn::SUCCESS,
                 );
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -703,9 +702,9 @@ mod unit {
                 str_val_test(ARRAY_COL, 4, "3\"}]", SqlReturn::SUCCESS);
                 str_val_test(ARRAY_COL, 0, "", SqlReturn::NO_DATA);
             }
-            let _ = Box::from_raw(char_buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(char_buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -835,9 +834,9 @@ mod unit {
                 null_val_test(UNDEFINED_COL);
             }
 
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -903,9 +902,9 @@ mod unit {
                 bin_val_test(BIN_COL, 1, &[42u8], SqlReturn::SUCCESS);
                 bin_val_test(BIN_COL, 0, &[], SqlReturn::NO_DATA);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1014,9 +1013,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(char_buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(char_buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1209,9 +1208,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1402,9 +1401,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1601,9 +1600,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1794,9 +1793,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -1993,9 +1992,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -2179,9 +2178,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -2365,9 +2364,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -2576,9 +2575,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -2780,9 +2779,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 
@@ -2983,9 +2982,9 @@ mod unit {
                 null_val_test(NULL_COL);
                 null_val_test(UNDEFINED_COL);
             }
-            let _ = Box::from_raw(buffer);
-            let _ = Box::from_raw(conn);
-            let _ = Box::from_raw(env);
+            let _ = Box::from_raw(buffer as *mut WChar);
+            let _ = Box::from_raw(conn as *mut WChar);
+            let _ = Box::from_raw(env as *mut WChar);
         }
     }
 }

--- a/odbc/src/api/diag.rs
+++ b/odbc/src/api/diag.rs
@@ -19,7 +19,7 @@ pub unsafe fn set_sql_state(sql_state: &str, output_ptr: *mut Char) {
     if output_ptr.is_null() {
         return;
     }
-    let sql_state = &format!("{}\0", sql_state);
+    let sql_state = &format!("{sql_state}\0");
     let state_u8 = sql_state.bytes().collect::<Vec<u8>>();
     copy_nonoverlapping(state_u8.as_ptr(), output_ptr, 6);
 }
@@ -34,7 +34,7 @@ pub unsafe fn set_sql_statew(sql_state: &str, output_ptr: *mut WChar) {
     if output_ptr.is_null() {
         return;
     }
-    let sql_state = &format!("{}\0", sql_state);
+    let sql_state = &format!("{sql_state}\0");
     let state_u16 = sql_state.encode_utf16().collect::<Vec<u16>>();
     copy_nonoverlapping(state_u16.as_ptr(), output_ptr, 6);
 }
@@ -58,7 +58,7 @@ pub unsafe fn get_diag_rec(
         *native_error_ptr = error.get_native_err_code();
     }
     set_sql_state(error.get_sql_state(), state);
-    let message = format!("{}", error);
+    let message = format!("{error}");
     i16_len::set_output_string(
         &message,
         message_text,
@@ -86,7 +86,7 @@ pub unsafe fn get_diag_recw(
         *native_error_ptr = error.get_native_err_code();
     }
     set_sql_statew(error.get_sql_state(), state);
-    let message = format!("{}", error);
+    let message = format!("{error}");
     i16_len::set_output_wstring(
         &message,
         message_text,
@@ -169,7 +169,7 @@ pub unsafe fn get_diag_field(
                         std::ptr::null_mut::<i16>(),
                     ),
                     DiagType::SQL_DIAG_MESSAGE_TEXT => {
-                        let message = format!("{}", error);
+                        let message = format!("{error}");
                         match is_wstring {
                             true => i16_len::set_output_wstring(
                                 &message,

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3883,11 +3883,11 @@ fn sql_tables(
     table_t: &str,
 ) -> Result<Box<dyn MongoStatement>> {
     match (catalog, schema, table, table_t) {
-        (SQL_ALL_CATALOGS, "", "", _) => Ok(Box::new(MongoDatabases::list_all_catalogs(
+        (SQL_ALL_CATALOGS, "", "", "") => Ok(Box::new(MongoDatabases::list_all_catalogs(
             mongo_connection,
             Some(query_timeout),
         ))),
-        ("", SQL_ALL_SCHEMAS, "", _) => Ok(Box::new(MongoCollections::all_schemas())),
+        ("", SQL_ALL_SCHEMAS, "", "") => Ok(Box::new(MongoCollections::all_schemas())),
         ("", "", "", SQL_ALL_TABLE_TYPES) => Ok(Box::new(MongoTableTypes::all_table_types())),
         _ => Ok(Box::new(MongoCollections::list_tables(
             mongo_connection,

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -48,7 +48,7 @@ pub fn trace_call_and_outcome(function_name: &str, sql_return: &SqlReturn) -> St
         SqlReturn::STILL_EXECUTING => "STILL_EXECUTING",
         _ => "unknown sql_return",
     };
-    format!("{}, SQLReturn = {}", function_name, outcome)
+    format!("{function_name}, SQLReturn = {outcome}")
 }
 
 macro_rules! must_be_valid {
@@ -538,8 +538,7 @@ pub unsafe extern "C" fn SQLColAttributeW(
                     let mongo_handle = MongoHandleRef::from(statement_handle);
                     let _ = must_be_valid!((*mongo_handle).as_statement());
                     mongo_handle.add_diag_info(ODBCError::UnsupportedFieldDescriptor(format!(
-                        "{:?}",
-                        desc
+                        "{desc:?}"
                     )));
                     SqlReturn::ERROR
                 }
@@ -1024,8 +1023,7 @@ pub unsafe extern "C" fn SQLDriverConnect(
             // SQL_NO_PROMPT is the only option supported for DriverCompletion
             if driver_completion != DriverConnectOption::NoPrompt {
                 conn_handle.add_diag_info(ODBCError::UnsupportedDriverConnectOption(format!(
-                    "{:?}",
-                    driver_completion
+                    "{driver_completion:?}"
                 )));
                 return SqlReturn::ERROR;
             }
@@ -1077,8 +1075,7 @@ pub unsafe extern "C" fn SQLDriverConnectW(
             // SQL_NO_PROMPT is the only option supported for DriverCompletion
             if driver_completion != DriverConnectOption::NoPrompt {
                 conn_handle.add_diag_info(ODBCError::UnsupportedDriverConnectOption(format!(
-                    "{:?}",
-                    driver_completion
+                    "{driver_completion:?}"
                 )));
                 return SqlReturn::ERROR;
             }

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -537,9 +537,8 @@ pub unsafe extern "C" fn SQLColAttributeW(
                 | Desc::RowVer) => {
                     let mongo_handle = MongoHandleRef::from(statement_handle);
                     let _ = must_be_valid!((*mongo_handle).as_statement());
-                    mongo_handle.add_diag_info(ODBCError::UnsupportedFieldDescriptor(format!(
-                        "{desc:?}"
-                    )));
+                    mongo_handle
+                        .add_diag_info(ODBCError::UnsupportedFieldDescriptor(format!("{desc:?}")));
                     SqlReturn::ERROR
                 }
             }

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -54,7 +54,7 @@ macro_rules! test_get_info {
                     _ => ()
                 }
 
-                let _ = Box::from_raw(value_ptr);
+                let _ = Box::from_raw(value_ptr as *mut USmallInt);
             }
         }
     }

--- a/resources/integration_test/tests/functions.yml
+++ b/resources/integration_test/tests/functions.yml
@@ -1,23 +1,4 @@
 tests:
-  - description: SQLTablesW function get all catalogs
-    test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "", 0 ]
-    db: integration_test
-    expected_result:
-      - ["db2", null, null, null, ""]
-      - ["integration_test", null, null, null, ""]
-      - ["integration_test_2", null, null, null, ""]
-    expected_bson_type: ["string", "string", "string", "string", "string"]
-    expected_case_sensitive: [ "", "", "", "", "" ]
-    expected_catalog_name: [ "", "", "", "", "" ]
-    expected_column_name: ["TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS"]
-    expected_display_size: [0, 0, 0, 0, 0]
-    expected_length: [0, 0, 0, 0, 0]
-    expected_is_searchable: [3, 3, 3, 3, 3]
-    expected_is_unsigned: [1, 1, 1, 1, 1]
-    expected_sql_type: [12, 12, 12, 12, 12]
-    expected_precision: [0, 0, 0, 0, 0]
-    expected_scale: [0, 0, 0, 0, 0]
-    expected_nullability: [0, 1, 1, 1, 1]
   - description: SQLForeignKeysW function get all the foreign keys (there are none)
     test_definition: [ "sqlforeignkeysw", "", 0, "", 0, "", 0, "", 0, "", 0, "", 0 ]
     db: integration_test

--- a/resources/integration_test/tests/sqltables.yml
+++ b/resources/integration_test/tests/sqltables.yml
@@ -1,0 +1,29 @@
+tests:
+  - description: SQLTablesW all catalogs with TableType
+    test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "TABLE,VIEW", 10 ]
+    db: integration_test
+    expected_result:
+      - [ "integration_test", null, "example", "TABLE", "" ]
+      - [ "integration_test", null, "foo", "TABLE", "" ]
+      - [ "integration_test", null, "baz", "VIEW", "" ]
+      - [ "integration_test_2", null, "example_2", "TABLE", "" ]
+
+  - description: SQLTablesW function get all catalogs
+    test_definition: [ "sqltablesw", "%", 1, "", 0, "", 0, "", 0 ]
+    db: integration_test
+    expected_result:
+      - [ "db2", null, null, null, "" ]
+      - [ "integration_test", null, null, null, "" ]
+      - [ "integration_test_2", null, null, null, "" ]
+    expected_bson_type: [ "string", "string", "string", "string", "string" ]
+    expected_case_sensitive: [ "", "", "", "", "" ]
+    expected_catalog_name: [ "", "", "", "", "" ]
+    expected_column_name: [ "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS" ]
+    expected_display_size: [ 0, 0, 0, 0, 0 ]
+    expected_length: [ 0, 0, 0, 0, 0 ]
+    expected_is_searchable: [ 3, 3, 3, 3, 3 ]
+    expected_is_unsigned: [ 1, 1, 1, 1, 1 ]
+    expected_sql_type: [ 12, 12, 12, 12, 12 ]
+    expected_precision: [ 0, 0, 0, 0, 0 ]
+    expected_scale: [ 0, 0, 0, 0, 0 ]
+    expected_nullability: [ 0, 1, 1, 1, 1 ]


### PR DESCRIPTION
This change fixes an issue seen in Power BI where no tables were being listed with the call:
```
SQLTablesW("%", 1, null, 0, null, 0, "TABLE,VIEW", 10)
```
Added a result set test to verify the sqltables call. 

There are quite a few clippy errors due to a change in Rust allowing variables in the format! string.  Will work on addressing that. 