### PR TITLE
SQL-1170: Resolve BsonTypeInfo

### DIFF
--- a/core/src/bson_type_info.rs
+++ b/core/src/bson_type_info.rs
@@ -1,7 +1,7 @@
 use crate::definitions::SqlDataType;
 
 #[non_exhaustive]
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct BsonTypeInfo {
     pub type_name: &'static str,
     pub sql_type: SqlDataType,

--- a/core/src/json_schema.rs
+++ b/core/src/json_schema.rs
@@ -252,7 +252,7 @@ pub mod simplified {
     impl From<Atomic> for BsonTypeInfo {
         fn from(a: Atomic) -> Self {
             match a {
-                Atomic::Any => BsonTypeInfo::ARRAY,
+                Atomic::Any => BsonTypeInfo::BSON,
                 Atomic::Scalar(t) => t.into(),
                 Atomic::Object(_) => BsonTypeInfo::OBJECT,
                 Atomic::Array(_) => BsonTypeInfo::ARRAY,

--- a/core/src/json_schema.rs
+++ b/core/src/json_schema.rs
@@ -249,14 +249,32 @@ pub mod simplified {
         }
     }
 
+    impl From<Atomic> for BsonTypeInfo {
+        fn from(a: Atomic) -> Self {
+            match a {
+                Atomic::Any => BsonTypeInfo::ARRAY,
+                Atomic::Scalar(t) => t.into(),
+                Atomic::Object(_) => BsonTypeInfo::OBJECT,
+                Atomic::Array(_) => BsonTypeInfo::ARRAY,
+            }
+        }
+    }
+
     impl From<Schema> for BsonTypeInfo {
         fn from(v: Schema) -> Self {
             match v {
-                Schema::Atomic(Atomic::Any) => BsonTypeInfo::BSON,
-                Schema::Atomic(Atomic::Scalar(t)) => t.into(),
-                Schema::Atomic(Atomic::Object(_)) => BsonTypeInfo::OBJECT,
-                Schema::Atomic(Atomic::Array(_)) => BsonTypeInfo::ARRAY,
-                Schema::AnyOf(_) => BsonTypeInfo::BSON,
+                Schema::Atomic(a) => a.into(),
+                Schema::AnyOf(b) => (b.len() == 2)
+                    .then(|| {
+                        let atomics = b
+                            .into_iter()
+                            .filter(|a| !matches!(a, Atomic::Scalar(BsonTypeName::Null)))
+                            .collect::<Vec<Atomic>>();
+                        (atomics.len() == 1)
+                            .then(|| atomics.first().unwrap().to_owned().into())
+                            .unwrap_or(BsonTypeInfo::BSON)
+                    })
+                    .unwrap(),
             }
         }
     }
@@ -526,5 +544,53 @@ mod unit {
                 ..Default::default()
             }
         );
+    }
+    mod bson_type_info {
+        use crate::{
+            bson_type_info::BsonTypeInfo,
+            json_schema::{self, simplified, BsonType, BsonTypeName},
+        };
+
+        #[test]
+        fn simplified_schemas_when_any_of_has_two_elements_but_one_is_null() {
+            let input_schema = json_schema::Schema {
+                any_of: Some(vec![
+                    json_schema::Schema {
+                        bson_type: Some(BsonType::Single(BsonTypeName::Int)),
+                        ..Default::default()
+                    },
+                    json_schema::Schema {
+                        bson_type: Some(BsonType::Single(BsonTypeName::Null)),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            };
+
+            let input = simplified::Schema::try_from(input_schema).unwrap();
+
+            assert_eq!(BsonTypeInfo::INT, BsonTypeInfo::from(input));
+        }
+
+        #[test]
+        fn simplified_schemas_with_multiple_non_null_elements() {
+            let input_schema = json_schema::Schema {
+                any_of: Some(vec![
+                    json_schema::Schema {
+                        bson_type: Some(BsonType::Single(BsonTypeName::Int)),
+                        ..Default::default()
+                    },
+                    json_schema::Schema {
+                        bson_type: Some(BsonType::Single(BsonTypeName::String)),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            };
+
+            let input = simplified::Schema::try_from(input_schema).unwrap();
+
+            assert_eq!(BsonTypeInfo::BSON, BsonTypeInfo::from(input));
+        }
     }
 }

--- a/core/src/json_schema.rs
+++ b/core/src/json_schema.rs
@@ -274,7 +274,7 @@ pub mod simplified {
                             .then(|| atomics.first().unwrap().to_owned().into())
                             .unwrap_or(BsonTypeInfo::BSON)
                     })
-                    .unwrap(),
+                    .unwrap_or(BsonTypeInfo::BSON),
             }
         }
     }

--- a/core/src/json_schema.rs
+++ b/core/src/json_schema.rs
@@ -552,7 +552,7 @@ mod unit {
         };
 
         #[test]
-        fn simplified_schemas_when_any_of_has_two_elements_but_one_is_null() {
+        fn any_of_has_two_elements_but_one_is_null_resolves_to_concrete_bson_type_info() {
             let input_schema = json_schema::Schema {
                 any_of: Some(vec![
                     json_schema::Schema {
@@ -573,7 +573,7 @@ mod unit {
         }
 
         #[test]
-        fn simplified_schemas_with_multiple_non_null_elements() {
+        fn any_of_with_multiple_non_null_elements_is_not_concrete_bson_type_info() {
             let input_schema = json_schema::Schema {
                 any_of: Some(vec![
                     json_schema::Schema {


### PR DESCRIPTION
This PR resolves BsonTypeInfo for columns where the types are `AnyOf(Null, <other concrete>)`. I added two tests for both paths.