### PR TITLE
SQL-1190: Add error messages to trace

### DIFF
--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3558,7 +3558,6 @@ pub unsafe extern "C" fn SQLSetEnvAttrW(
     );
 }
 
-#[named]
 unsafe fn sql_set_env_attrw_helper(
     env_handle: &mut MongoHandle,
     attribute: EnvironmentAttribute,
@@ -3573,9 +3572,10 @@ unsafe fn sql_set_env_attrw_helper(
                     SqlReturn::SUCCESS
                 }
                 None => {
-                    add_diag_info!(
+                    add_diag_with_function!(
                         env_handle,
-                        ODBCError::InvalidAttrValue("SQL_ATTR_ODBC_VERSION")
+                        ODBCError::InvalidAttrValue("SQL_ATTR_ODBC_VERSION"),
+                        "SQLSetEnvAttrW"
                     );
                     SqlReturn::ERROR
                 }
@@ -3585,7 +3585,11 @@ unsafe fn sql_set_env_attrw_helper(
             match FromPrimitive::from_i32(value_ptr as i32) {
                 Some(SqlBool::True) => SqlReturn::SUCCESS,
                 _ => {
-                    add_diag_info!(env_handle, ODBCError::Unimplemented("OUTPUT_NTS=SQL_FALSE"));
+                    add_diag_with_function!(
+                        env_handle,
+                        ODBCError::Unimplemented("OUTPUT_NTS=SQL_FALSE"),
+                        "SQLSetEnvAttrW"
+                    );
                     SqlReturn::ERROR
                 }
             }

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1664,7 +1664,7 @@ unsafe fn sql_get_connect_attrw_helper(
     };
 
     if let Some(e) = err {
-        add_diag_with_function!(conn_handle, e.clone(), "SQLGetConnectAttrW");
+        add_diag_with_function!(conn_handle, e, "SQLGetConnectAttrW");
     }
     sql_return
 }
@@ -1794,7 +1794,7 @@ unsafe fn sql_get_data_helper(
         }
     }
     if let Some(e) = error {
-        add_diag_with_function!(mongo_handle, e.clone(), "SQLGetData");
+        add_diag_with_function!(mongo_handle, e, "SQLGetData");
         return SqlReturn::ERROR;
     }
     crate::api::data::format_bson_data(
@@ -2676,7 +2676,7 @@ unsafe fn sql_get_infow_helper(
     };
 
     if let Some(error) = err {
-        add_diag_with_function!(conn_handle, error.clone(), "SQLGetInfoW");
+        add_diag_with_function!(conn_handle, error, "SQLGetInfoW");
     }
     sql_return
 }
@@ -2926,7 +2926,7 @@ unsafe fn sql_get_stmt_attrw_helper(
     };
 
     if let Some(error) = err {
-        add_diag_with_function!(stmt_handle, error.clone(), "SQLGetStmtAttrW");
+        add_diag_with_function!(stmt_handle, error, "SQLGetStmtAttrW");
     }
     sql_return
 }
@@ -3409,7 +3409,7 @@ unsafe fn set_connect_attrw_helper(
     };
 
     if let Some(error) = err {
-        add_diag_with_function!(conn_handle, error.clone(), "SQLSetConnectAttrW");
+        add_diag_with_function!(conn_handle, error, "SQLSetConnectAttrW");
     }
     sql_return
 }

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -26,7 +26,6 @@ use odbc_sys::{
     Char, Desc, DriverConnectOption, HDbc, HDesc, HEnv, HStmt, HWnd, Handle, HandleType, Integer,
     Len, Nullability, Pointer, RetCode, SmallInt, SqlReturn, ULen, USmallInt,
 };
-use std::borrow::BorrowMut;
 use std::ptr::null_mut;
 use std::{collections::HashMap, mem::size_of, panic, sync::mpsc};
 use widechar::WideChar;

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -94,7 +94,7 @@ unsafe fn modify_u16_value(value_ptr: Pointer, _: usize) -> u16 {
 }
 
 mod unit {
-    use crate::util::format_driver_version;
+    use crate::util::format_version;
 
     use super::*;
     use constants::{DBMS_NAME, DRIVER_NAME, ODBC_VERSION};
@@ -117,7 +117,7 @@ mod unit {
         expected_sql_return = SqlReturn::SUCCESS,
         buffer_length = 11 * size_of::<WideChar>() as i16,
         expected_length = 10 * size_of::<WideChar>() as i16,
-        expected_value = format_driver_version(
+        expected_value = format_version(
             env!("CARGO_PKG_VERSION_MAJOR"),
             env!("CARGO_PKG_VERSION_MINOR"),
             env!("CARGO_PKG_VERSION_PATCH"),

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -94,7 +94,7 @@ unsafe fn modify_u16_value(value_ptr: Pointer, _: usize) -> u16 {
 }
 
 mod unit {
-    use crate::util::format_version;
+    use crate::util::format_driver_version;
 
     use super::*;
     use constants::{DBMS_NAME, DRIVER_NAME, ODBC_VERSION};
@@ -117,7 +117,7 @@ mod unit {
         expected_sql_return = SqlReturn::SUCCESS,
         buffer_length = 11 * size_of::<WideChar>() as i16,
         expected_length = 10 * size_of::<WideChar>() as i16,
-        expected_value = format_version(
+        expected_value = format_driver_version(
             env!("CARGO_PKG_VERSION_MAJOR"),
             env!("CARGO_PKG_VERSION_MINOR"),
             env!("CARGO_PKG_VERSION_PATCH"),

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -78,6 +78,6 @@ macro_rules! add_diag_with_function {
     ($handle:expr, $error:expr, $fct_name:expr) => {
         let err = $error;
         trace_odbc!($handle, format!("{err}"), $fct_name);
-        $handle.add_diag_info($error);
+        $handle.add_diag_info(err);
     };
 }

--- a/odbc/src/api/mod.rs
+++ b/odbc/src/api/mod.rs
@@ -3,13 +3,11 @@ pub(crate) mod diag;
 pub(crate) mod errors;
 mod functions;
 pub use functions::*;
-mod data;
-pub(crate) mod util;
-
 #[cfg(test)]
 mod col_attr_describe_tests;
 #[cfg(test)]
 mod connect_attr_tests;
+mod data;
 #[cfg(test)]
 mod data_tests;
 #[cfg(test)]
@@ -26,6 +24,7 @@ mod get_type_info_tests;
 mod panic_safe_exec_tests;
 #[cfg(test)]
 mod stmt_attr_tests;
+pub(crate) mod util;
 
 #[macro_export]
 macro_rules! map {
@@ -47,4 +46,38 @@ macro_rules! set {
 			},)*
 		].into_iter())
 	};
+}
+
+///
+/// Adds a line in the trace formatted like this [{handle info}]{function name} - "{message to log}"]
+/// The handle info provide the address of the current handle and it's parent handle.
+/// For example for a connection handle : [Env_0x131904740][Conn_0x131805040]
+///
+#[macro_export]
+macro_rules! trace_odbc {
+    ($info:expr, $fct_name:expr) => {
+        // No handle have been allocated yet
+        let message = format!("{}:: {}", $fct_name, $info);
+        dbg_write!(message);
+    };
+    ($mongo_handle:expr, $info:expr, $fct_name:expr) => {
+        let handle_info = $mongo_handle.get_handle_info();
+        let message = format!("{handle_info} {}:: {}", $fct_name, $info);
+        dbg_write!(message);
+    };
+}
+
+///
+/// Using the given handle, error and function name, it will:
+///  - Add the error information in the trace.
+///    For example : 2023-02-08T17:14:05.383-08:00 odbc/src/api/functions.rs:1151 - [Env_0x130f04740][Conn_0x131a04d40][SQLDriverConnectW] - "[MongoDB][API] Missing property "Driver" or "DSN" in connection string"
+///  - Add the diagnostic record to the handle
+///
+#[macro_export]
+macro_rules! add_diag_with_function {
+    ($handle:expr, $error:expr, $fct_name:expr) => {
+        let err = $error;
+        trace_odbc!($handle, format!("{err}"), $fct_name);
+        $handle.add_diag_info($error);
+    };
 }

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -85,11 +85,16 @@ pub(crate) fn format_driver_version() -> String {
     let version_major = env!("CARGO_PKG_VERSION_MAJOR");
     let version_minor = env!("CARGO_PKG_VERSION_MINOR");
     let version_patch = env!("CARGO_PKG_VERSION_PATCH");
+
+    format_version(version_major, version_minor, version_patch)
+}
+
+pub(crate) fn format_version(major: &str, minor: &str, patch: &str) -> String {
     format!(
         "{}.{}.{}",
-        format_version_part(version_major, 2),
-        format_version_part(version_minor, 2),
-        format_version_part(version_patch, 4)
+        format_version_part(major, 2),
+        format_version_part(minor, 2),
+        format_version_part(patch, 4)
     )
 }
 
@@ -102,7 +107,7 @@ fn format_version_part(part: &str, len: usize) -> String {
 
 mod unit {
     #[cfg(test)]
-    use super::format_driver_version;
+    use super::format_version;
 
     macro_rules! format_version_test {
         ($func_name:ident, expected = $expected:expr, major = $major:expr, minor = $minor:expr, patch = $patch:expr) => {

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -78,12 +78,18 @@ pub(crate) fn statement_attribute_to_string(attr: StatementAttribute) -> String 
     }
 }
 
-pub(crate) fn format_version(major: &str, minor: &str, patch: &str) -> String {
+pub(crate) fn format_driver_version() -> String {
+    // The driver version can be obtained from the Cargo.toml file.
+    // The env! macro call below gets the version from the Cargo file
+    // at compile time.
+    let version_major = env!("CARGO_PKG_VERSION_MAJOR");
+    let version_minor = env!("CARGO_PKG_VERSION_MINOR");
+    let version_patch = env!("CARGO_PKG_VERSION_PATCH");
     format!(
         "{}.{}.{}",
-        format_version_part(major, 2),
-        format_version_part(minor, 2),
-        format_version_part(patch, 4)
+        format_version_part(version_major, 2),
+        format_version_part(version_minor, 2),
+        format_version_part(version_patch, 4)
     )
 }
 
@@ -96,7 +102,7 @@ fn format_version_part(part: &str, len: usize) -> String {
 
 mod unit {
     #[cfg(test)]
-    use super::format_version;
+    use super::format_driver_version;
 
     macro_rules! format_version_test {
         ($func_name:ident, expected = $expected:expr, major = $major:expr, minor = $minor:expr, patch = $patch:expr) => {

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -83,19 +83,18 @@ impl MongoHandle {
     /// Generate a String containing the current handle and its parents address.
     ///
     pub(crate) unsafe fn get_handle_info(&mut self) -> String {
-        let mut handle = self;
         let mut handle_info = String::new();
+        let mut handle = self;
         loop {
+            let handle_ptr: *mut MongoHandle = handle;
             match handle {
                 MongoHandle::Env(e) => {
-                    let ptr = Box::into_raw(Box::new(e)) as *mut _;
-                    handle_info = format!("[Env_{:?}]{handle_info}", ptr);
+                    handle_info = format!("[Env_{:?}]{handle_info}", handle_ptr);
                     return handle_info;
                 }
                 MongoHandle::Connection(c) => {
                     let env = c.env;
-                    let ptr = Box::into_raw(Box::new(c)) as *mut _;
-                    handle_info = format!("[Conn_{:?}]{handle_info}", ptr);
+                    handle_info = format!("[Conn_{:?}]{handle_info}", handle_ptr);
                     if env.is_null() {
                         return handle_info;
                     }
@@ -103,8 +102,7 @@ impl MongoHandle {
                 }
                 MongoHandle::Statement(s) => {
                     let conn = s.connection;
-                    let ptr = Box::into_raw(Box::new(s)) as *mut _;
-                    handle_info = format!("[Stmt_{:?}]{handle_info}", ptr);
+                    handle_info = format!("[Stmt_{:?}]{handle_info}", handle_ptr);
                     if conn.is_null() {
                         return handle_info;
                     }
@@ -112,8 +110,7 @@ impl MongoHandle {
                 }
                 MongoHandle::Descriptor(d) => {
                     let conn = d.connection;
-                    let ptr = Box::into_raw(Box::new(d)) as *mut _;
-                    handle_info = format!("[Desc_{:?}]{handle_info}", ptr);
+                    handle_info = format!("[Desc_{:?}]{handle_info}", handle_ptr);
                     if conn.is_null() {
                         return handle_info;
                     }

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -88,7 +88,7 @@ impl MongoHandle {
         loop {
             let handle_ptr: *mut MongoHandle = handle;
             match handle {
-                MongoHandle::Env(e) => {
+                MongoHandle::Env(_) => {
                     handle_info = format!("[Env_{:?}]{handle_info}", handle_ptr);
                     return handle_info;
                 }


### PR DESCRIPTION
I did a bit of refactoring to get the handle info and function name more easily in the trace.
The trace now look like this. It allows filtering per handle or function name.
```
2023-02-09T16:44:30.298-08:00 odbc/src/api/functions.rs:1470 - [Env_0x16d1c1fd0][Conn_0x16d1c21e0][Desc_0x144e05570] SQLFreeHandle:: Freeing handle 0x144e05570
2023-02-09T16:44:30.298-08:00 odbc/src/api/functions.rs:1475 - SQLFreeHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.726-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.736-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.736-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - [Env_0x1436052b0] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - [Env_0x143604e30] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - [Env_0x143604fb0] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.737-08:00 odbc/src/api/functions.rs:203 - [Env_0x143605130] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:203 - SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:203 - [Env_0x1437066d0] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:1139 - [Env_0x1437066d0][Conn_0x144904380] SQLDriverConnectW:: [MongoDB][API] The driver connect option Complete is not supported
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:1139 - [Env_0x143605130][Conn_0x144a04080] SQLDriverConnectW:: [MongoDB][API] The driver connect option CompleteRequired is not supported
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:1139 - [Env_0x1436052b0][Conn_0x144904200] SQLDriverConnectW:: [MongoDB][API] The driver connect option Prompt is not supported
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:1134 - [Env_0x1436052b0][Conn_0x144904200] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.738-08:00 odbc/src/api/functions.rs:1134 - [Env_0x143605130][Conn_0x144a04080] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.739-08:00 odbc/src/api/functions.rs:1134 - [Env_0x1437066d0][Conn_0x144904380] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.739-08:00 odbc/src/api/functions.rs:203 - [Env_0x143604cb0] SQLAllocHandle:: SQLReturn = SUCCESS
2023-02-09T19:21:53.739-08:00 odbc/src/api/functions.rs:2099 - [Env_0x1436052b0][Conn_0x144904200] SQLGetDiagRecW:: SQLReturn = SUCCESS
2023-02-09T19:21:53.739-08:00 odbc/src/api/functions.rs:2099 - [Env_0x143605130][Conn_0x144a04080] SQLGetDiagRecW:: SQLReturn = SUCCESS
2023-02-09T19:21:53.739-08:00 odbc/src/api/functions.rs:2099 - [Env_0x1437066d0][Conn_0x144904380] SQLGetDiagRecW:: SQLReturn = SUCCESS
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:1149 - [Env_0x143604fb0][Conn_0x144904080] SQLDriverConnectW:: [MongoDB][Core] Invalid Uri: One of ["uid", "user"] is required for a valid Mongo ODBC Uri
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:1149 - [Env_0x143604e30][Conn_0x144804080] SQLDriverConnectW:: [MongoDB][Core] Invalid Uri: One of ["password", "pwd"] is required for a valid Mongo ODBC Uri
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:1134 - [Env_0x143604fb0][Conn_0x144904080] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:1134 - [Env_0x143604e30][Conn_0x144804080] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:2099 - [Env_0x143604fb0][Conn_0x144904080] SQLGetDiagRecW:: SQLReturn = SUCCESS
2023-02-09T19:21:53.745-08:00 odbc/src/api/functions.rs:2099 - [Env_0x143604e30][Conn_0x144804080] SQLGetDiagRecW:: SQLReturn = SUCCESS
2023-02-09T19:21:53.746-08:00 odbc/src/api/functions.rs:1149 - [Env_0x143604cb0][Conn_0x144a04200] SQLDriverConnectW:: [MongoDB][API] Missing property "Driver" or "DSN" in connection string
2023-02-09T19:21:53.746-08:00 odbc/src/api/functions.rs:1134 - [Env_0x143604cb0][Conn_0x144a04200] SQLDriverConnectW:: SQLReturn = ERROR
2023-02-09T19:21:53.746-08:00 odbc/src/api/functions.rs:2099 - [Env_0x143604cb0][Conn_0x144a04200] SQLGetDiagRecW:: SQLReturn = SUCCESS
```