### PR TITLE
SQL-1149: provide feedback when SQLColumns schema deserialization fails

### DIFF
--- a/core/src/collections.rs
+++ b/core/src/collections.rs
@@ -138,10 +138,10 @@ impl MongoStatement for MongoCollections {
     // Move the cursor to the next CollectionSpecification.
     // When cursor is exhausted move to next database in list
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<(bool, Option<Error>)> {
         if self.current_database_index.is_none() {
             if self.collections_for_db_list.is_empty() {
-                return Ok(false);
+                return Ok((false, None));
             }
             self.current_database_index = Some(0);
         }
@@ -177,13 +177,13 @@ impl MongoStatement for MongoCollections {
                 {
                     // Cursor advance succeeded and the collection matches the filters, update current CollectionSpecification
                     self.current_collection = Some(collection);
-                    return Ok(true);
+                    return Ok((true, None));
                 }
             }
 
             self.current_database_index = Some(self.current_database_index.unwrap() + 1);
             if self.current_database_index.unwrap() >= self.collections_for_db_list.len() {
-                return Ok(false);
+                return Ok((false, None));
             }
         }
     }

--- a/core/src/databases.rs
+++ b/core/src/databases.rs
@@ -220,9 +220,9 @@ impl MongoDatabases {
 impl MongoStatement for MongoDatabases {
     // Increment current_db_index.
     // Return true if current_db_index index is <= for databases_names.length.
-    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<(bool, Option<Error>)> {
         self.current_db_index += 1;
-        Ok(self.current_db_index <= self.database_names.len())
+        Ok((self.current_db_index <= self.database_names.len(), None))
     }
 
     // Get the BSON value for the value at the given colIndex on the current row.

--- a/core/src/fields.rs
+++ b/core/src/fields.rs
@@ -532,8 +532,10 @@ impl MongoFields {
                         bson::from_document(db.run_command(get_schema_cmd, None).unwrap())
                             .map_err(Error::BsonDeserialization);
                     if let Err(error) = current_col_metadata_response {
-                        // If there is an Error while deserialization the schema, we don't show the column
-                        e = Some(error);
+                        // If there is an Error while deserializing the schema, we don't show the column
+                        if e.is_none() {
+                            e = Some(error);
+                        }
                         continue;
                     }
                     let current_col_metadata_response = current_col_metadata_response.unwrap();

--- a/core/src/mock_query.rs
+++ b/core/src/mock_query.rs
@@ -26,7 +26,7 @@ impl MongoQuery {
 impl MongoStatement for MongoQuery {
     // Move the current index to the next Document in the Vec.
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<(bool, Option<Error>)> {
         if let Some(current) = self.current {
             self.current = Some(current + 1);
         } else {
@@ -34,9 +34,9 @@ impl MongoStatement for MongoQuery {
         }
         let current = self.current.unwrap();
         if current < self.resultset.len() {
-            return Ok(true);
+            return Ok((true, None));
         }
-        Ok(false)
+        Ok((false, None))
     }
 
     // Get the BSON value for the cell at the given colIndex on the current row.

--- a/core/src/stmt.rs
+++ b/core/src/stmt.rs
@@ -8,7 +8,8 @@ use std::fmt::Debug;
 pub trait MongoStatement: Debug {
     // Move the cursor to the next item.
     // Return true if moving was successful, false otherwise.
-    fn next(&mut self, mongo_connection: Option<&MongoConnection>) -> Result<bool>;
+    fn next(&mut self, mongo_connection: Option<&MongoConnection>)
+        -> Result<(bool, Option<Error>)>;
     // Get the BSON value for the cell at the given colIndex on the current row.
     // Fails if the first row has not been retrieved (next must be called at least once before getValue).
     fn get_value(&self, col_index: u16) -> Result<Option<Bson>>;
@@ -31,8 +32,11 @@ pub struct EmptyStatement {
 }
 
 impl MongoStatement for EmptyStatement {
-    fn next(&mut self, _mongo_connection: Option<&MongoConnection>) -> Result<bool> {
-        Ok(false)
+    fn next(
+        &mut self,
+        _mongo_connection: Option<&MongoConnection>,
+    ) -> Result<(bool, Option<Error>)> {
+        Ok((false, None))
     }
 
     fn get_value(&self, _col_index: u16) -> Result<Option<Bson>> {
@@ -77,7 +81,7 @@ mod unit {
             "TABLE_CAT",
             test_empty.get_col_metadata(1).unwrap().col_name
         );
-        assert!(!test_empty.next(None).unwrap());
+        assert!(!test_empty.next(None).unwrap().0);
         assert!(test_empty.get_value(1).is_err());
     }
 }

--- a/core/src/table_types.rs
+++ b/core/src/table_types.rs
@@ -27,9 +27,9 @@ impl MongoTableTypes {
 impl MongoStatement for MongoTableTypes {
     // Increment current_table_type_index.
     // Return true if current_table_type_index index is <= for table_type.length.
-    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<(bool, Option<Error>)> {
         self.current_table_type_index += 1;
-        Ok(self.current_table_type_index <= self.table_type.len())
+        Ok((self.current_table_type_index <= self.table_type.len(), None))
     }
 
     // Get the BSON value for the value at the given colIndex on the current row.

--- a/core/src/type_info.rs
+++ b/core/src/type_info.rs
@@ -187,7 +187,7 @@ impl MongoTypesInfo {
 impl MongoStatement for MongoTypesInfo {
     // iterate through the list, searching for the next "valid" data type.
     // a type is valid if its sql type matches the desired sql type, or if we are getting all types.
-    fn next(&mut self, _: Option<&MongoConnection>) -> Result<bool> {
+    fn next(&mut self, _: Option<&MongoConnection>) -> Result<(bool, Option<Error>)> {
         loop {
             self.current_type_index += 1;
             if self.current_type_index > DATA_TYPES.len()
@@ -197,7 +197,7 @@ impl MongoStatement for MongoTypesInfo {
                 break;
             }
         }
-        Ok(self.current_type_index <= DATA_TYPES.len())
+        Ok((self.current_type_index <= DATA_TYPES.len(), None))
     }
 
     // Get the BSON value for the cell at the given colIndex on the current row.

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -743,7 +743,7 @@ fn get_column_count(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Resu
 fn fetch_row(stmt: &Statement<Allocated, NoResult, AutocommitOn>) -> Result<bool> {
     unsafe {
         match odbc_sys::SQLFetch(stmt.handle() as HStmt) {
-            SqlReturn::SUCCESS => Ok(true),
+            SqlReturn::SUCCESS | SqlReturn::SUCCESS_WITH_INFO => Ok(true),
             SqlReturn::NO_DATA => Ok(false),
             sql_return => Err(Error::OdbcFunctionFailed(
                 "SQLFetch".to_string(),

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1367,7 +1367,7 @@ pub unsafe extern "C" fn SQLFetch(statement_handle: HStmt) -> SqlReturn {
                     stmt.errors.write().unwrap().push(e.into());
                     return SqlReturn::ERROR;
                 }
-                Ok(b) => {
+                Ok((b, _)) => {
                     let mut stmt_attrs = stmt.attributes.write().unwrap();
                     if !b {
                         stmt_attrs.row_index_is_valid = false;


### PR DESCRIPTION
The largest portion of this PR is updating the result set to return Results as `Result<(bool, Option<Error>)>` for the sake of consuming errors the ODBC functions. I only focussed on one facet, `SQLColumns` deserialization, though other areas of future work are documented in [SQL-1198](https://jira.mongodb.org/browse/SQL-1198), which should be updated when this PR is merged. 

In the `MongoFields` functions I only kept track of the first error that was hit. This is an open question of what ideal behavior is (should we store a vector, eg?). My working assumption was that tools, upon getting `SUCCESS_WITH_INFO`, may just try to get the most recent diagnostic (and thus, keeping track of a list would not be useful). I wanted to flag this in case that is untrue, or we should try to keep track of all errors.