### PR TITLE
SQL-1261: Tag triggered release - Live trial error fixing

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -51,7 +51,7 @@ functions:
           release_version: "$release_version"
           prepare_shell: |
             set -o errexit
-            export release_version="$release_version"
+            export RELEASE_VERSION="$release_version"
             export PATH="$PATH"
             export CARGO_NET_GIT_FETCH_WITH_CLI="$CARGO_NET_GIT_FETCH_WITH_CLI"
             git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
@@ -151,7 +151,7 @@ functions:
           #no-op when not triggered by a tag
           if [[ "${triggered_by_git_tag}" == "" ]]; then
             cargo install cargo-edit
-            cargo set-version ${release-version}
+            cargo set-version $RELEASE_VERSION
           fi
 
   "compile release":
@@ -168,7 +168,7 @@ functions:
           if [[ "${triggered_by_git_tag}" == "" ]]; then
             EXPECTED_RELEASE_VERSION="0.0.0"
           else
-            EXPECTED_RELEASE_VERSION="${release-version}"
+            EXPECTED_RELEASE_VERSION="$RELEASE_VERSION
           fi
           if [[ "$CARGO_PKGS_VERSION" != "$EXPECTED_RELEASE_VERSION" ]]; then
             echo "Expected version $EXPECTED_RELEASE_VERSION got $CARGO_PKGS_VERSION"
@@ -195,7 +195,7 @@ functions:
           if [[ "${triggered_by_git_tag}" == "" ]]; then
             EXPECTED_RELEASE_VERSION="0.0.0"
           else
-            EXPECTED_RELEASE_VERSION="${release-version}"
+            EXPECTED_RELEASE_VERSION="$RELEASE_VERSION"
           fi
           if [[ "$CARGO_PKGS_VERSION" != "$EXPECTED_RELEASE_VERSION" ]]; then
             echo "Expected version $EXPECTED_RELEASE_VERSION got $CARGO_PKGS_VERSION"

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -149,7 +149,7 @@ functions:
         script: |
           ${prepare_shell}
           #no-op when not triggered by a tag
-          if [[ "${triggered_by_git_tag}" == "" ]]; then
+          if [[ "${triggered_by_git_tag}" != "" ]]; then
             cargo install cargo-edit
             cargo set-version $RELEASE_VERSION
           fi

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -168,7 +168,7 @@ functions:
           if [[ "${triggered_by_git_tag}" == "" ]]; then
             EXPECTED_RELEASE_VERSION="0.0.0"
           else
-            EXPECTED_RELEASE_VERSION="$RELEASE_VERSION
+            EXPECTED_RELEASE_VERSION="$RELEASE_VERSION"
           fi
           if [[ "$CARGO_PKGS_VERSION" != "$EXPECTED_RELEASE_VERSION" ]]; then
             echo "Expected version $EXPECTED_RELEASE_VERSION got $CARGO_PKGS_VERSION"
@@ -285,7 +285,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/mongoodbc.dll
-        remote_file: mongosql-odbc-driver/windows/${release_version}/release/mongoodbc.dll
+        remote_file: mongosql-odbc-driver/windows/${RELEASE-VERSION}/release/mongoodbc.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -301,7 +301,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/mongoodbc.pdb
-        remote_file: mongosql-odbc-driver/windows/${release_version}/release/mongoodbc.pdb
+        remote_file: mongosql-odbc-driver/windows/${RELEASE-VERSION}/release/mongoodbc.pdb
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -319,7 +319,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/debug/mongoodbc.dll
-        remote_file: mongosql-odbc-driver/windows/${release_version}/debug/mongoodbc.dll
+        remote_file: mongosql-odbc-driver/windows/${RELEASE-VERSION}/debug/mongoodbc.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -335,7 +335,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/debug/mongoodbc.pdb
-        remote_file: mongosql-odbc-driver/windows/${release_version}/debug/mongoodbc.pdb
+        remote_file: mongosql-odbc-driver/windows/${RELEASE-VERSION}/debug/mongoodbc.pdb
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream


### PR DESCRIPTION
Fixed the error on the variable named used. 
Evergreen variables are not accessible directly from a shell task, so ${release-version} is empty.