### PR TITLE
SQL-1300: make regex pin to start and end of string

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "mongo-odbc-core"
 version = "0.0.0"
-authors = ["Ryan Chipman <ryan@ryanchipman.com>",
+authors = [
+    "Ryan Chipman <ryan@ryanchipman.com>",
     "Natacha Bagnard <natacha.bagnard@mongodb.com>",
-    "Patrick Meredith <pmeredit@protonmail.com>"]
+    "Patrick Meredith <pmeredit@protonmail.com>",
+    "Nathan Leniz <nathan.leniz@mongodb.com>",
+]
 edition = "2021"
 
 [dependencies]

--- a/core/src/collections.rs
+++ b/core/src/collections.rs
@@ -1,5 +1,5 @@
 use crate::stmt::EmptyStatement;
-use crate::util::{table_type_filter_to_vec, to_name_regex};
+use crate::util::{is_match, table_type_filter_to_vec, to_name_regex};
 use crate::{
     bson_type_info::BsonTypeInfo,
     col_metadata::MongoColMetadata,
@@ -93,10 +93,7 @@ impl MongoCollections {
             .list_database_names(None, None)
             .unwrap()
             .iter()
-            .filter(|db_name| match &db_name_filter_regex {
-                Some(val) => val.is_match(db_name.as_str()),
-                None => true,
-            })
+            .filter(|&db_name| is_match(db_name.as_str(), &db_name_filter_regex))
             .map(|val| CollectionsForDb {
                 database_name: val.to_string(),
                 collection_list: mongo_connection


### PR DESCRIPTION
I updated our regex to pin the user pattern to the start and end of the string. This way, "downtimes" would not match "downtimestatus" , and "status" would not match "downtimestatus".

More work will need to be done to deconflict between SQL wildcard chars and allowable names in MongoDB. I've added a comment with the new ticket #