### PR TITLE
SQL-1296: Add the version informations to the Windows DLL

### DIFF
--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -44,3 +44,6 @@ thiserror = "1"
 [lib]
 name = "mongoodbc"
 crate-type = ["cdylib", "lib"]
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"

--- a/odbc/build.rs
+++ b/odbc/build.rs
@@ -1,0 +1,16 @@
+#[cfg(windows)]
+extern crate winres;
+
+#[cfg(windows)]
+fn main() {
+    // the default for winres is to parse the version number from the neighboring Cargo.toml
+    let mut res = winres::WindowsResource::new();
+    res.set_version_info(winres::VersionInfo::FILETYPE, 2); // Dll file
+    res.set("CompanyName", "MongoDB Inc.");
+
+    // compile will write the rc file, and enable the cargo linker to link the compiled resource file
+    res.compile().unwrap();
+}
+
+#[cfg(not(windows))]
+fn main() {}


### PR DESCRIPTION
Adds product/version info, company name, and file names to mongoodbc.dll. A couple things to note:
1. the ticket mentions not necessarily using the `winres` crate as is. The current implementation does, as the crate is fairly lightweight, and covers what we are looking for out of the box. I also tried implementing this without the cate, but it requires some shared logic and/or hardcoding of paths.
2. relatedly, this does not use a template RC file, as generating one
 with `winres` was only a few lines of code and executes quickly. However, with or without winres we could use a template to seed the values if desired.

Attached are a couple screenshots demonstrating the behavior of building using this branch:

![Screenshot 2023-03-17 at 2 28 21 PM](https://user-images.githubusercontent.com/29063412/226063861-e82cdb97-5785-47c6-a5ab-224aa6cec1a0.png)
![Screenshot 2023-03-17 at 2 28 35 PM](https://user-images.githubusercontent.com/29063412/226063869-b25b28f3-ea8f-431b-9243-7a20f039c182.png)
