### PR TITLE
SQL-1325: Fix for Power BI showing symbols instead of readable text

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -99,6 +99,7 @@ impl IntoCData for Bson {
             _ => self.into_relaxed_extjson(),
         }
     }
+
     fn to_json(self) -> String {
         match self {
             Bson::String(s) => s,
@@ -108,26 +109,9 @@ impl IntoCData for Bson {
 
     fn to_binary(self) -> Result<Vec<u8>> {
         match self {
-            Bson::Double(f) => Ok(f.to_le_bytes().to_vec()),
             Bson::String(s) => Ok(s.into_bytes()),
-            Bson::Boolean(b) => Ok(if b { vec![1u8] } else { vec![0u8] }),
-            Bson::DateTime(d) => {
-                let dt: DateTime<Utc> = d.into();
-                let mut ret = Vec::with_capacity(16usize);
-                ret.extend(dt.year().to_le_bytes());
-                ret.extend(dt.month().to_le_bytes());
-                ret.extend(dt.day().to_le_bytes());
-                ret.extend(dt.hour().to_le_bytes());
-                ret.extend(dt.minute().to_le_bytes());
-                ret.extend(dt.second().to_le_bytes());
-                let fraction = (dt.nanosecond() as f32 * 0.000001) as u32;
-                ret.extend(fraction.to_le_bytes());
-                Ok(ret)
-            }
-            Bson::Int32(i) => Ok(i.to_le_bytes().to_vec()),
-            Bson::Int64(i) => Ok(i.to_le_bytes().to_vec()),
             Bson::Binary(b) if b.subtype != BinarySubtype::Uuid => Ok(b.bytes),
-            _ => Ok(self.to_json().into_bytes()),
+            _ => Ok(self.to_json_val().to_string().into_bytes()),
         }
     }
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -111,7 +111,7 @@ impl IntoCData for Bson {
         match self {
             Bson::String(s) => Ok(s.into_bytes()),
             Bson::Binary(b) if b.subtype != BinarySubtype::Uuid => Ok(b.bytes),
-            _ => Ok(self.to_json_val().to_string().into_bytes()),
+            _ => Ok(self.to_json().into_bytes()),
         }
     }
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -107,11 +107,7 @@ impl IntoCData for Bson {
     }
 
     fn to_binary(self) -> Result<Vec<u8>> {
-        match self {
-            Bson::String(s) => Ok(s.into_bytes()),
-            Bson::Binary(b) if b.subtype != BinarySubtype::Uuid => Ok(b.bytes),
-            _ => Ok(self.to_json().into_bytes()),
-        }
+        Ok(self.to_json().into_bytes())
     }
 
     fn to_guid(self) -> Result<Vec<u8>> {

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -99,7 +99,6 @@ impl IntoCData for Bson {
             _ => self.into_relaxed_extjson(),
         }
     }
-
     fn to_json(self) -> String {
         match self {
             Bson::String(s) => s,

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -767,18 +767,12 @@ mod unit {
 
                 bin_val_test(ARRAY_STR_VAL.0, ARRAY_STR_VAL.1.as_bytes());
                 bin_val_test(BIN_COL, &[5, 6, 42]);
-                bin_val_test(BOOL_COL, &[1]);
-                bin_val_test(
-                    DATETIME_COL,
-                    &[
-                        222, 7, 0, 0, 11, 0, 0, 0, 28, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0,
-                        0, 0, 0, 0, 0,
-                    ],
-                );
+                bin_val_test(BOOL_COL, BOOL_STR_VAL.1.as_bytes());
+                bin_val_test(DATETIME_COL, DATETIME_STR_VAL.1.as_bytes());
                 bin_val_test(DOC_STR_VAL.0, DOC_STR_VAL.1.as_bytes());
-                bin_val_test(DOUBLE_COL, &[205, 204, 204, 204, 204, 204, 244, 63]);
-                bin_val_test(I32_COL, &[1, 0, 0, 0]);
-                bin_val_test(I64_COL, &[0, 0, 0, 0, 0, 0, 0, 0]);
+                bin_val_test(DOUBLE_COL, DOUBLE_STR_VAL.1.as_bytes());
+                bin_val_test(I32_COL, I32_STR_VAL.1.as_bytes());
+                bin_val_test(I64_COL, I64_STR_VAL.1.as_bytes());
                 bin_val_test(JS_STR_VAL.0, JS_STR_VAL.1.as_bytes());
                 bin_val_test(JS_W_S_STR_VAL.0, JS_W_S_STR_VAL.1.as_bytes());
                 bin_val_test(MAXKEY_STR_VAL.0, MAXKEY_STR_VAL.1.as_bytes());

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -866,7 +866,12 @@ mod unit {
                             _ => (),
                         }
                     };
-                bin_val_test(BIN_COL, 44, &BIN_STR_VAL.1.as_bytes()[0..24], SqlReturn::SUCCESS_WITH_INFO);
+                bin_val_test(
+                    BIN_COL,
+                    44,
+                    &BIN_STR_VAL.1.as_bytes()[0..24],
+                    SqlReturn::SUCCESS_WITH_INFO,
+                );
                 assert_eq!(
                     "[MongoDB][API] Buffer size \"25\" not large enough for data".to_string(),
                     format!(
@@ -879,8 +884,18 @@ mod unit {
                             .unwrap()[0]
                     ),
                 );
-                bin_val_test(BIN_COL, 19, &BIN_STR_VAL.1.as_bytes()[25..], SqlReturn::SUCCESS);
-                bin_val_test(BIN_COL, 19, &BIN_STR_VAL.1.as_bytes()[25..], SqlReturn::SUCCESS);
+                bin_val_test(
+                    BIN_COL,
+                    19,
+                    &BIN_STR_VAL.1.as_bytes()[25..],
+                    SqlReturn::SUCCESS,
+                );
+                bin_val_test(
+                    BIN_COL,
+                    19,
+                    &BIN_STR_VAL.1.as_bytes()[25..],
+                    SqlReturn::SUCCESS,
+                );
                 bin_val_test(BIN_COL, 0, &[], SqlReturn::NO_DATA);
             }
             let _ = Box::from_raw(buffer as *mut WChar);

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -890,12 +890,6 @@ mod unit {
                     &BIN_STR_VAL.1.as_bytes()[25..],
                     SqlReturn::SUCCESS,
                 );
-                bin_val_test(
-                    BIN_COL,
-                    19,
-                    &BIN_STR_VAL.1.as_bytes()[25..],
-                    SqlReturn::SUCCESS,
-                );
                 bin_val_test(BIN_COL, 0, &[], SqlReturn::NO_DATA);
             }
             let _ = Box::from_raw(buffer as *mut WChar);

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -766,7 +766,7 @@ mod unit {
                 };
 
                 bin_val_test(ARRAY_STR_VAL.0, ARRAY_STR_VAL.1.as_bytes());
-                bin_val_test(BIN_COL, &[5, 6, 42]);
+                bin_val_test(BIN_COL, BIN_STR_VAL.1.as_bytes());
                 bin_val_test(BOOL_COL, BOOL_STR_VAL.1.as_bytes());
                 bin_val_test(DATETIME_COL, DATETIME_STR_VAL.1.as_bytes());
                 bin_val_test(DOC_STR_VAL.0, DOC_STR_VAL.1.as_bytes());
@@ -839,7 +839,7 @@ mod unit {
         unsafe {
             assert_eq!(SqlReturn::SUCCESS, SQLFetch(stmt_handle as *mut _,));
             let buffer: *mut std::ffi::c_void = Box::into_raw(Box::new([0u8; 200])) as *mut _;
-            let buffer_length: isize = 2;
+            let buffer_length: isize = 25;
             let out_len_or_ind = &mut 0;
             {
                 let mut bin_val_test =
@@ -866,10 +866,9 @@ mod unit {
                             _ => (),
                         }
                     };
-
-                bin_val_test(BIN_COL, 3, &[5u8, 6u8], SqlReturn::SUCCESS_WITH_INFO);
+                bin_val_test(BIN_COL, 44, &BIN_STR_VAL.1.as_bytes()[0..24], SqlReturn::SUCCESS_WITH_INFO);
                 assert_eq!(
-                    "[MongoDB][API] Buffer size \"2\" not large enough for data".to_string(),
+                    "[MongoDB][API] Buffer size \"25\" not large enough for data".to_string(),
                     format!(
                         "{}",
                         (*stmt_handle)
@@ -880,7 +879,8 @@ mod unit {
                             .unwrap()[0]
                     ),
                 );
-                bin_val_test(BIN_COL, 1, &[42u8], SqlReturn::SUCCESS);
+                bin_val_test(BIN_COL, 19, &BIN_STR_VAL.1.as_bytes()[25..], SqlReturn::SUCCESS);
+                bin_val_test(BIN_COL, 19, &BIN_STR_VAL.1.as_bytes()[25..], SqlReturn::SUCCESS);
                 bin_val_test(BIN_COL, 0, &[], SqlReturn::NO_DATA);
             }
             let _ = Box::from_raw(buffer as *mut WChar);


### PR DESCRIPTION
Some types were showing up as symbols in Power BI when processed with the `to_binary()` function.  This would mainly show up when the column had a type of anyof with multiple types such as Date, ObjectID, Null for example.
This PR returns those values as the JSON value which is readable in Power BI.
See [SQL-1325](https://jira.mongodb.org/browse/SQL-1325) for details and screenshots.