### PR TITLE
SQL-1337: Fix for Power BI error 'table has no visible columns'

### DIFF
--- a/core/src/json_schema.rs
+++ b/core/src/json_schema.rs
@@ -263,7 +263,7 @@ pub mod simplified {
                     bson_type: None,
                     properties: None,
                     required: None,
-                    additional_properties: None,
+                    additional_properties: None | Some(false),
                     items: None,
                     any_of: None,
                 } => Ok(Atomic::Scalar(BsonTypeName::Any)),
@@ -823,6 +823,16 @@ mod unit {
             variant = Schema,
             expected = Ok(Schema::Atomic(Atomic::Scalar(BsonTypeName::Any))),
             input = json_schema::Schema::default()
+        );
+
+        try_from_test!(
+            bson_type_none_and_additional_properties_false_results_in_any,
+            variant = Schema,
+            expected = Ok(Schema::Atomic(Atomic::Scalar(BsonTypeName::Any))),
+            input = json_schema::Schema {
+                additional_properties: Some(false),
+                ..Default::default()
+            }
         );
 
         try_from_test!(


### PR DESCRIPTION
The generated schema for a row with an empty array has no bsonType specified, it also has ` "additionalProperties": false`.  
This change takes into account the possible additionalProperties: false to avoid returning an error and instead return a `BsonTypeName::Any`.

```
{ "_id" : 0, "entry" : [ ] }
{ "_id" : 1, "entry" : [ ] }
```
Schema:
```
{  "bsonType": [ "object" ],
  "properties": {
    "_id": { "bsonType": [ "double"],  "additionalProperties": false},
    "entry": {
      "bsonType": [ "array"],
      "items": {
        "additionalProperties": false
      },
      "additionalProperties": false
    }
  },
  "additionalProperties": false}
```
We currently don't log an error when this happens, there is an [existing PR](https://github.com/mongodb/mongo-odbc-driver/pull/92) to add the error message so I did not include one here.