### PR TITLE
add signing tasks as part of snapshot

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1472,6 +1472,10 @@ tasks:
         variant: "*"
       - name: asan-integration-test
         variant: "*"
+      - name: windows-sign
+        variant: "windows-64"
+      - name: ubuntu-sign
+        variant: "ubuntu2204"
     commands:
       - func: "upload release"
       - func: "upload debug"


### PR DESCRIPTION
Short one, just updating the snapshot task so we don't get a "system failed" when manually running it.