### PR TITLE
SQL-1373: Pin ADF version

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -827,11 +827,11 @@ functions:
           cat setup/iodbcinst.ini
           echo "-------------------------"
           echo "----- DSN Setup -----"
-          sed -i "s,%DRIVER_LIB_PATH%,$DRIVER_LIB_PATH,g" setup/iodbc.ini
-          sed -i "s,%ADF_TEST_DB%,${adf_test_local_db},g" setup/iodbc.ini
-          sed -i "s,%ADF_TEST_USER%,${adf_test_local_user},g" setup/iodbc.ini
-          sed -i "s,%ADF_TEST_PWD%,${adf_test_local_pwd},g" setup/iodbc.ini
-          sed -i "s,%ADF_TEST_HOST%,${adf_test_host},g" setup/iodbc.ini
+          sed -i.bu "s,%DRIVER_LIB_PATH%,$DRIVER_LIB_PATH,g" setup/iodbc.ini
+          sed -i.bu "s,%ADF_TEST_DB%,${adf_test_local_db},g" setup/iodbc.ini
+          sed -i.bu "s,%ADF_TEST_USER%,${adf_test_local_user},g" setup/iodbc.ini
+          sed -i.bu "s,%ADF_TEST_PWD%,${adf_test_local_pwd},g" setup/iodbc.ini
+          sed -i.bu "s,%ADF_TEST_HOST%,${adf_test_host},g" setup/iodbc.ini
           echo "---- END DSN Setup ----"
 
           cat <<EOT >> expansions.yml

--- a/odbc/src/api/util.rs
+++ b/odbc/src/api/util.rs
@@ -84,7 +84,7 @@ pub(crate) fn statement_attribute_to_string(attr: StatementAttribute) -> String 
 }
 
 pub(crate) fn get_driver_path() -> String {
-    let mut buffer = [0u16; 1024];
+    let mut buffer = [0; 1024];
     unsafe {
         SQLGetPrivateProfileStringW(
             to_widechar_ptr(DRIVER_NAME).0,

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -291,8 +291,9 @@ if [[ $? -ne 0 ]]; then
             git clone $MONGOHOUSE_URI $MONGOHOUSE_DIR
         fi
         cd $MONGOHOUSE_DIR
-        git pull $MONGOHOUSE_URI
-
+        # for now, we checkout a specific working commit of ADF
+        # TODO SQL-1374: Find a better long term solution
+        git checkout 247a246
         export GOPRIVATE=github.com/10gen
         $GO mod download
     fi

--- a/setup/iodbc.ini
+++ b/setup/iodbc.ini
@@ -6,4 +6,4 @@ Driver = %DRIVER_LIB_PATH%/libatsql.dylib
 Database = %ADF_TEST_DB%
 User = %ADF_TEST_USER%
 Password = %ADF_TEST_PWD%
-Uri = %ADF_TEST_HOST% 
+Uri = mongodb://localhost:27017

--- a/shared_sql_utils/src/dsn.rs
+++ b/shared_sql_utils/src/dsn.rs
@@ -136,7 +136,7 @@ impl Dsn {
         // All odbc implementations (windows, unixodbc, iODBC) return the available
         // keys in a DSN as a null-terminated string of null-terminated strings.
         let dsn_keys = if cfg!(not(target_os = "linux")) {
-            let wbuf = &mut [0u16; 1024];
+            let wbuf = &mut [0; 1024];
             unsafe {
                 SQLGetPrivateProfileStringW(
                     to_widechar_ptr(&self.dsn).0,
@@ -163,7 +163,7 @@ impl Dsn {
             }
             unsafe { parse_attribute_string_a(abuf.as_mut_ptr()) }
         };
-        let buffer = &mut [0u16; 1024];
+        let buffer = &mut [0; 1024];
         dsn_keys
             .split(';')
             .filter(|s| !s.is_empty())


### PR DESCRIPTION
This pins the ADF version. Ignore until we're sure the tests are actually passing (using the PR to test).