### PR TITLE
SQL-1413: Copy signed msi to local folder instead of unsigned

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -513,7 +513,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc-signed.msi
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/mongoodbc-signed.msi
         local_file: mongosql-odbc-driver/installer/msi/mongoodbc-signed.msi
         bucket: mciuploads
         permissions: public-read
@@ -524,7 +524,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz.sig
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz.sig
         local_file: mongosql-odbc-driver/installer/tgz/mongoodbc.tar.gz.sig
         bucket: mciuploads
         permissions: public-read
@@ -535,7 +535,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc-signed.msi
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/mongoodbc-signed.msi
         local_file: mongosql-odbc-driver/release/mongoodbc-signed.msi
         bucket: mciuploads
     - command: s3.put
@@ -551,7 +551,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsql.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsql.dll
         local_file: mongosql-odbc-driver/release/atsql.dll
         bucket: mciuploads
     - command: s3.put
@@ -567,7 +567,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsqls.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsqls.dll
         local_file: mongosql-odbc-driver/release/atsqls.dll
         bucket: mciuploads
     - command: s3.put
@@ -583,7 +583,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsql.pdb
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsql.pdb
         local_file: mongosql-odbc-driver/release/atsql.pdb
         bucket: mciuploads
     - command: s3.put
@@ -599,7 +599,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz
         local_file: mongosql-odbc-driver/target/release/mongoodbc.tar.gz
         bucket: mciuploads
         permissions: public-read
@@ -617,7 +617,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz.sig
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz.sig
         local_file: mongosql-odbc-driver/target/release/mongoodbc.tar.gz.sig
         bucket: mciuploads
         permissions: public-read
@@ -635,7 +635,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/libatsql.so
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/libatsql.so
         local_file: mongosql-odbc-driver/target/release/libatsql.so
         bucket: mciuploads
         permissions: public-read
@@ -655,7 +655,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/atsql.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/debug/atsql.dll
         local_file: mongosql-odbc-driver/debug/atsql.dll
         bucket: mciuploads
     - command: s3.put
@@ -671,7 +671,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/atsqls.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/debug/atsqls.dll
         local_file: mongosql-odbc-driver/debug/atsqls.dll
         bucket: mciuploads
     - command: s3.put
@@ -703,7 +703,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/libatsql.so
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/debug/libatsql.so
         local_file: mongosql-odbc-driver/target/debug/libatsql.so
         bucket: mciuploads
         permissions: public-read

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -513,7 +513,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/mongoodbc-signed.msi
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc-signed.msi
         local_file: mongosql-odbc-driver/installer/msi/mongoodbc-signed.msi
         bucket: mciuploads
         permissions: public-read
@@ -524,7 +524,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz.sig
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz.sig
         local_file: mongosql-odbc-driver/installer/tgz/mongoodbc.tar.gz.sig
         bucket: mciuploads
         permissions: public-read
@@ -535,7 +535,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/mongoodbc.msi
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc-signed.msi
         local_file: mongosql-odbc-driver/release/mongoodbc-signed.msi
         bucket: mciuploads
     - command: s3.put
@@ -551,7 +551,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsql.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsql.dll
         local_file: mongosql-odbc-driver/release/atsql.dll
         bucket: mciuploads
     - command: s3.put
@@ -567,7 +567,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsqls.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsqls.dll
         local_file: mongosql-odbc-driver/release/atsqls.dll
         bucket: mciuploads
     - command: s3.put
@@ -583,7 +583,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/atsql.pdb
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/atsql.pdb
         local_file: mongosql-odbc-driver/release/atsql.pdb
         bucket: mciuploads
     - command: s3.put
@@ -599,7 +599,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz
         local_file: mongosql-odbc-driver/target/release/mongoodbc.tar.gz
         bucket: mciuploads
         permissions: public-read
@@ -617,7 +617,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz.sig
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.tar.gz.sig
         local_file: mongosql-odbc-driver/target/release/mongoodbc.tar.gz.sig
         bucket: mciuploads
         permissions: public-read
@@ -635,7 +635,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/libatsql.so
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/libatsql.so
         local_file: mongosql-odbc-driver/target/release/libatsql.so
         bucket: mciuploads
         permissions: public-read
@@ -655,7 +655,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/debug/atsql.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/atsql.dll
         local_file: mongosql-odbc-driver/debug/atsql.dll
         bucket: mciuploads
     - command: s3.put
@@ -671,7 +671,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/debug/atsqls.dll
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/atsqls.dll
         local_file: mongosql-odbc-driver/debug/atsqls.dll
         bucket: mciuploads
     - command: s3.put
@@ -703,7 +703,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/debug/libatsql.so
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/debug/libatsql.so
         local_file: mongosql-odbc-driver/target/debug/libatsql.so
         bucket: mciuploads
         permissions: public-read


### PR DESCRIPTION
I also changed hard-coded variant names to use ${build_variant} for copying to/from the mciuploads bucket because we had a bit of both and this could potentially become a problem if/when we change variant.