### PR TITLE
SQL-1310: Add release targets for ODBC on macos

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,6 +72,14 @@ Check that the released files, library and symbols, are available at the followi
   - Release build
     - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/ubuntu2204/${release_version}/release/libatsql.so`  
     - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/ubuntu2204/${release_version}/release/mongoodbc.tar.gz`
+- Macos
+  - Release build
+    - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/macos/${release_version}/mongoodbc.dmg`
+    - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/macos/${release_version}/libatsql.dylib`
+- Macos-ARM
+  - Release build
+    - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/macos-arm/${release_version}/mongoodbc.dmg`
+    - `https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongosql-odbc-driver/macos-arm/${release_version}/libatsql.dylib`
 
 ##### Verify that the driver works with PowerBI
 Download and install the driver file.

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -275,14 +275,13 @@ functions:
         key_id: ${key_id}
         secret: ${secret}
         service_url: ${service_url}
-        client_binary: darwin_amd64/macnotary
-        local_zip_file: macos-mongo-odbc.zip
-        output_zip_file: macos-mongo-odbc-signed.zip
+        client_binary: mongosql-odbc-driver/darwin_amd64/macnotary
+        local_zip_file: mongosql-odbc-driver/macos-mongo-odbc.zip
+        output_zip_file: mongosql-odbc-driver/macos-mongo-odbc-signed.zip
         artifact_type: binary
         verify: true
         notarize: true
         bundle_id: com.mongodb.mongoodbc
-        working_directory: mongosql-odbc-driver
     - command: shell.exec
       type: test
       params:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -40,6 +40,22 @@ functions:
         local_file: mongosql-odbc-driver/installer/tgz/mongoodbc.tar.gz
         bucket: mciuploads
 
+  "fetch for macos sign":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/mongoodbc.dmg
+        local_file: mongosql-odbc-driver/installer/dmg/mongoodbc.dmg
+        bucket: mciuploads
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/release/libatsql.dylib
+        local_file: mongosql-odbc-driver/target/release/libatsql.dylib
+        bucket: mciuploads
+
   "fetch source":
     - command: git.get_project
       params:
@@ -69,11 +85,15 @@ functions:
           RELEASE_VERSION: "$RELEASE_VERSION"
           WINDOWS_INSTALLER_PATH: "mongosql-odbc-driver/windows/$RELEASE_VERSION/release/mongoodbc.msi"
           UBUNTU2204_INSTALLER_PATH: "mongosql-odbc-driver/ubuntu2204/$RELEASE_VERSION/release/mongoodbc.tar.gz"
+          MACOS_INSTALLER_PATH: "mongosql-odbc-driver/macos/$RELEASE_VERSION/release/mongoodbc.dmg"
+          MACOS_ARM_INSTALLER_PATH: "mongosql-odbc-driver/macos-arm/$RELEASE_VERSION/release/mongoodbc.dmg"
           prepare_shell: |
             set -o errexit
             export RELEASE_VERSION="$RELEASE_VERSION"
             export WINDOWS_INSTALLER_PATH="$WINDOWS_INSTALLER_PATH"
             export UBUNTU2204_INSTALLER_PATH="$UBUNTU2204_INSTALLER_PATH"
+            export MACOS_INSTALLER_PATH="$MACOS_INSTALLER_PATH"
+            export MACOS_ARM_INSTALLER_PATH="$MACOS_ARM_INSTALLER_PATH"
             export PATH="$PATH"
             export CARGO_NET_GIT_FETCH_WITH_CLI="$CARGO_NET_GIT_FETCH_WITH_CLI"
             git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
@@ -236,6 +256,43 @@ functions:
               --comment "Evergreen Automatic Signing (Atlas SQL ODBC) - ${version_id} - ${build_variant}" \
               --notary-url "${notary_client_url}" \
               mongoodbc.tar.gz
+
+  "sign macos":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}
+          curl -LO https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.3.3/darwin_amd64.zip
+          unzip -o darwin_amd64.zip
+          chmod 0755 ./darwin_amd64/macnotary
+          ./darwin_amd64/macnotary -v
+          zip macos-mongo-odbc.zip installer/dmg/mongoodbc.dmg target/release/libatsql.dylib
+    - command: mac.sign
+      params:
+        key_id: ${key_id}
+        secret: ${secret}
+        service_url: ${service_url}
+        client_binary: darwin_amd64/macnotary
+        local_zip_file: macos-mongo-odbc.zip
+        output_zip_file: macos-mongo-odbc-signed.zip
+        artifact_type: binary
+        verify: true
+        notarize: true
+        bundle_id: com.mongodb.mongoodbc
+        working_directory: mongosql-odbc-driver
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}
+          unzip -o macos-mongo-odbc-signed.zip
+          mv mongoodbc.dmg mongoodbc-signed.dmg
+          mv libatsql.dylib libatsql-signed.dylib
 
   "compile release":
     - command: shell.exec
@@ -444,6 +501,7 @@ functions:
       params:
         build_variants:
           - macos
+          - macos-arm
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/target/release/libatsql.dylib
@@ -455,6 +513,7 @@ functions:
       params:
         build_variants:
           - macos
+          - macos-arm
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/installer/dmg/mongoodbc.dmg
@@ -527,6 +586,26 @@ functions:
         aws_secret: ${aws_secret}
         remote_file: mongosql-odbc-driver/artifacts/${version_id}/ubuntu2204/release/mongoodbc.tar.gz.sig
         local_file: mongosql-odbc-driver/installer/tgz/mongoodbc.tar.gz.sig
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
+
+  "upload signed macos artifacts":
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/{buildvariant}/release/mongoodbc-signed.dmg
+        local_file: mongosql-odbc-driver/mongoodbc-signed.dmg
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/{buildvariant}/release/libatsql-signed.dylib
+        local_file: mongosql-odbc-driver/libatsql-signed.dylib
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
@@ -647,6 +726,74 @@ functions:
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/target/release/libatsql.so
         remote_file: mongosql-odbc-driver/ubuntu2204/${RELEASE_VERSION}/release/libatsql.so
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/macos/release/libatsql-signed.dylib
+        local_file: mongosql-odbc-driver/target/release/libatsql-signed.dylib
+        bucket: mciuploads
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/target/release/libatsql-signed.dylib
+        remote_file: mongosql-odbc-driver/macos/${RELEASE_VERSION}/libatsql.dylib
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/macos/release/mongoodbc-signed.dmg
+        local_file: mongosql-odbc-driver/target/release/mongoodbc-signed.dmg
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/target/release/mongoodbc-signed.dmg
+        remote_file: ${MACOS_INSTALLER_PATH}
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/macos-arm/release/libatsql-signed.dylib
+        local_file: mongosql-odbc-driver/target/release/libatsql-signed.dylib
+        bucket: mciuploads
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/target/release/libatsql-signed.dylib
+        remote_file: mongosql-odbc-driver/macos-arm/${RELEASE_VERSION}/libatsql.dylib
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/macos-arm/release/mongoodbc-signed.dmg
+        local_file: mongosql-odbc-driver/target/release/mongoodbc-signed.dmg
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/target/release/mongoodbc-signed.dmg
+        remote_file: ${MACOS_ARM_INSTALLER_PATH}
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -1310,6 +1457,8 @@ functions:
           sed -i 's@{RELEASE_VERSION}@'${RELEASE_VERSION}'@' mongo-odbc-downloads_template.json
           sed -i 's@{WINDOWS_INSTALLER_PATH}@'${WINDOWS_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
           sed -i 's@{UBUNTU2204_INSTALLER_PATH}@'${UBUNTU2204_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
+          sed -i 's@{MACOS_INSTALLER_PATH}@'${MACOS_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
+          sed -i 's@{MACOS_ARM_INSTALLER_PATH}@'${MACOS_ARM_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
           echo "--------- New release object ----------------"
           cat mongo-odbc-downloads_template.json
           echo "---------------------------------------------"
@@ -1458,6 +1607,14 @@ tasks:
       - func: "fetch for ubuntu sign"
       - func: "sign ubuntu"
       - func: "upload ubuntu sig file"
+
+  - name: macos-sign
+    depends_on:
+      - name: compile-macos
+    commands:
+      - func: "fetch for macos sign"
+      - func: "sign macos"
+      - func: "upload signed macos artifacts"
 
   - name: macos-unit-test
     commands:
@@ -1640,6 +1797,8 @@ buildvariants:
       - name: macos-unit-test
       - name: macos-integration-test
       - name: macos-result-set-test
+      - name: macos-sign
+        run_on: macos-1014-codesign
 
   - name: macos-arm
     display_name: "macOS 11.0 ARM 64"
@@ -1650,6 +1809,8 @@ buildvariants:
       - name: macos-unit-test
       - name: macos-integration-test
       - name: macos-result-set-test
+      - name: macos-sign
+        run_on: macos-1014-codesign
 
   - name: release
     display_name: "Release"

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -257,6 +257,20 @@ functions:
               --notary-url "${notary_client_url}" \
               mongoodbc.tar.gz
 
+  "install macnotary":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}
+          MACNOTARY_VERSION=3.8.1
+          curl -LO https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v$MACNOTARY_VERSION/darwin_amd64.zip
+          unzip -o darwin_amd64.zip
+          chmod 0755 ./darwin_amd64/macnotary
+          ./darwin_amd64/macnotary -v  
+
   "sign macos":
     - command: shell.exec
       type: test
@@ -265,10 +279,6 @@ functions:
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
-          curl -LO https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.3.3/darwin_amd64.zip
-          unzip -o darwin_amd64.zip
-          chmod 0755 ./darwin_amd64/macnotary
-          ./darwin_amd64/macnotary -v
           zip macos-mongo-odbc.zip installer/dmg/mongoodbc.dmg target/release/libatsql.dylib
     - command: mac.sign
       params:
@@ -290,8 +300,8 @@ functions:
         script: |
           ${prepare_shell}
           unzip -o macos-mongo-odbc-signed.zip
-          mv mongoodbc.dmg mongoodbc-signed.dmg
-          mv libatsql.dylib libatsql-signed.dylib
+          mv installer/dmg/mongoodbc.dmg mongoodbc-signed.dmg
+          mv target/release/libatsql.dylib libatsql-signed.dylib
 
   "compile release":
     - command: shell.exec
@@ -418,16 +428,58 @@ functions:
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
-          cp target/release/*.dylib installer/dmg
-          cp target/release/macos_postinstall installer/dmg
-          cd installer/dmg
+          # Sign the postinstall executable prior to creating dmg, needed for notarizing
+          zip -r unsigned-target.zip target/release/macos_postinstall \
+                              target/release/libatsql.dylib
+    - command: mac.sign
+      params:
+        key_id: ${key_id}
+        secret: ${secret}
+        service_url: ${service_url}
+        client_binary: mongosql-odbc-driver/darwin_amd64/macnotary
+        local_zip_file: mongosql-odbc-driver/unsigned-target.zip
+        output_zip_file: mongosql-odbc-driver/signed-target.zip
+        artifact_type: binary
+        verify: true
+        notarize: false
+    - command: shell.exec
+      params:
+        add_expansions_to_env: true
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}  
           if [ "$RELEASE_VERSION" == "snapshot" ]; then
               MINOR_VERSION="0.1"
           else
               MINOR_VERSION=$(echo "$RELEASE_VERSION" | sed 's|\([0-9]\+[.][0-9]\+\)[.][0-9]\+|\1|')
           fi
+          
+          ditto -x -k $PWD/signed-target.zip .
+          cp target/release/*.dylib installer/dmg
+          cp target/release/macos_postinstall installer/dmg
+          cd installer/dmg
           ./build-dmg.sh "$MINOR_VERSION"
-
+          zip -rv ../../mongoodbc-pkg-unsigned.zip mongoodbc.pkg
+          cd ../..
+          
+          # pkg file needs to be signed separately before packaged in dmg file
+          # mac.sign evergreen task does not yet support the ArtifactType `pkg`
+          # Working around that by calling via command line
+          ./darwin_amd64/macnotary -o mongoodbc-pkg-signed.zip -f mongoodbc-pkg-unsigned.zip -m sign  \
+             -u https://dev.macos-notary.build.10gen.cc/api -t pkg -o mongoodbc-pkg-signed.zip \
+             -k $key_id -s $secret
+    - command: shell.exec
+      params:
+        add_expansions_to_env: true
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}   
+          ditto -x -k mongoodbc-pkg-signed.zip installer/dmg/dmg-contents/ 
+          cd installer/dmg
+          
+          hdiutil create -fs HFS+ -srcfolder dmg-contents -volname mongoodbc mongoodbc.dmg
 
   "mciuploads release artifacts":
     - command: s3.put
@@ -1529,6 +1581,7 @@ tasks:
       - func: "set packages version"
       - func: "check packages version"
       - func: "compile macos release"
+      - func: "install macnotary"
       - func: "build dmg"
       - func: "mciuploads release artifacts"
 
@@ -1612,6 +1665,7 @@ tasks:
       - name: compile-macos
     commands:
       - func: "fetch for macos sign"
+      - func: "install macnotary"
       - func: "sign macos"
       - func: "upload signed macos artifacts"
 
@@ -1797,7 +1851,6 @@ buildvariants:
       - name: macos-integration-test
       - name: macos-result-set-test
       - name: macos-sign
-        run_on: macos-1014-codesign
 
   - name: macos-arm
     display_name: "macOS 11.0 ARM 64"
@@ -1809,7 +1862,6 @@ buildvariants:
       - name: macos-integration-test
       - name: macos-result-set-test
       - name: macos-sign
-        run_on: macos-1014-codesign
 
   - name: release
     display_name: "Release"

--- a/installer/dmg/build-dmg.sh
+++ b/installer/dmg/build-dmg.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 rm ./*.dmg || true
 rm dmg-contents/*.pkg || true
@@ -26,6 +27,3 @@ productbuild --distribution distribution.xml \
 	--package-path . \
 	"$PRODUCT"
 
-mv "$PRODUCT" dmg-contents/
-
-hdiutil create -fs HFS+ -srcfolder dmg-contents -volname mongoodbc mongoodbc.dmg

--- a/resources/download-center/mongo-odbc-downloads_template.json
+++ b/resources/download-center/mongo-odbc-downloads_template.json
@@ -8,6 +8,14 @@
         {
           "name": "Ubuntu 22.04 (x86_64)",
           "download_link": "https://translators-connectors-releases.s3.amazonaws.com/{UBUNTU2204_INSTALLER_PATH}"
+        },
+        {
+          "name": "MacOS",
+          "download_link": "https://translators-connectors-releases.s3.amazonaws.com/{MACOS_INSTALLER_PATH}"
+        },
+        {
+          "name": "MacOS ARM",
+          "download_link": "https://translators-connectors-releases.s3.amazonaws.com/{MACOS_ARM_INSTALLER_PATH}"
         }
       ]
     }


### PR DESCRIPTION
Added signing using the `mac.sign` evergreen task. 

Requested credentials [from the BUILD](https://jira.mongodb.org/browse/BUILD-17328) team for $key_id and $secret values.  I will add them to our project and fully test the signing for this patch prior to merging. 

Added the installer path to `mongo-odbc-downloads_template.json`. 