### PR TITLE
SQL-1285: SQLGetEnvAttr and SQLSetEnvAttr don't have Ansi/Wide flavors

### DIFF
--- a/odbc/src/api/env_attr_tests.rs
+++ b/odbc/src/api/env_attr_tests.rs
@@ -1,9 +1,9 @@
-use crate::{map, SQLSetEnvAttr};
 use crate::{
     api::definitions::*,
     handles::definitions::{Env, EnvState, MongoHandle},
     SQLGetDiagRecW, SQLGetEnvAttr,
 };
+use crate::{map, SQLSetEnvAttr};
 use odbc_sys::{HEnv, HandleType, Integer, Pointer, SqlReturn};
 use std::{collections::BTreeMap, ffi::c_void, mem::size_of};
 

--- a/odbc/src/api/env_attr_tests.rs
+++ b/odbc/src/api/env_attr_tests.rs
@@ -1,8 +1,8 @@
-use crate::map;
+use crate::{map, SQLSetEnvAttr};
 use crate::{
     api::definitions::*,
     handles::definitions::{Env, EnvState, MongoHandle},
-    SQLGetDiagRecW, SQLGetEnvAttr, SQLSetEnvAttr,
+    SQLGetDiagRecW, SQLGetEnvAttr,
 };
 use odbc_sys::{HEnv, HandleType, Integer, Pointer, SqlReturn};
 use std::{collections::BTreeMap, ffi::c_void, mem::size_of};
@@ -42,7 +42,7 @@ fn get_set_env_attr(
                 let value = discriminant as Pointer;
                 assert_eq!(
                     expected_return,
-                    SQLGetEnvAttr(handle as HEnv, attr, value, 0, string_length_ptr)
+                    SQLSetEnvAttr(handle as HEnv, attr, value, 0)
                 );
                 assert_eq!(
                     SqlReturn::SUCCESS,
@@ -162,7 +162,6 @@ mod unit {
     #[test]
     fn test_optional_value_changed() {
         use cstr::WideChar;
-        let string_length_ptr = &mut 0;
         unsafe {
             let handle: *mut _ = &mut MongoHandle::Env(Env::with_state(
                 EnvState::Allocated,
@@ -170,12 +169,11 @@ mod unit {
             ));
             assert_eq!(
                 SqlReturn::SUCCESS_WITH_INFO,
-                SQLGetEnvAttr(
+                SQLSetEnvAttrW(
                     handle as HEnv,
                     EnvironmentAttribute::SQL_ATTR_CP_MATCH as i32,
                     CpMatch::Relaxed as i32 as Pointer,
-                    0,
-                    string_length_ptr
+                    0
                 )
             );
 

--- a/odbc/src/api/env_attr_tests.rs
+++ b/odbc/src/api/env_attr_tests.rs
@@ -2,7 +2,7 @@ use crate::map;
 use crate::{
     api::definitions::*,
     handles::definitions::{Env, EnvState, MongoHandle},
-    SQLGetDiagRecW, SQLGetEnvAttrW, SQLSetEnvAttrW,
+    SQLGetDiagRecW, SQLGetEnvAttr, SQLSetEnvAttr,
 };
 use odbc_sys::{HEnv, HandleType, Integer, Pointer, SqlReturn};
 use std::{collections::BTreeMap, ffi::c_void, mem::size_of};
@@ -23,7 +23,7 @@ fn get_set_env_attr(
         // Test the environment attribute's default value
         assert_eq!(
             SqlReturn::SUCCESS,
-            SQLGetEnvAttrW(
+            SQLGetEnvAttr(
                 handle as *mut _,
                 attr,
                 attr_buffer as Pointer,
@@ -42,11 +42,11 @@ fn get_set_env_attr(
                 let value = discriminant as Pointer;
                 assert_eq!(
                     expected_return,
-                    SQLSetEnvAttrW(handle as HEnv, attr, value, 0)
+                    SQLGetEnvAttr(handle as HEnv, attr, value, 0, string_length_ptr)
                 );
                 assert_eq!(
                     SqlReturn::SUCCESS,
-                    SQLGetEnvAttrW(
+                    SQLGetEnvAttr(
                         handle as *mut _,
                         attr,
                         attr_buffer as Pointer,
@@ -129,11 +129,11 @@ mod unit {
                 CpMatch::Strict as i32,
             );
 
-            // SQLGetEnvAttrW where value_ptr is null
+            // SQLGetEnvAttr where value_ptr is null
             let string_length_ptr = &mut 0;
             assert_eq!(
                 SqlReturn::SUCCESS,
-                SQLGetEnvAttrW(
+                SQLGetEnvAttr(
                     env_handle as *mut _,
                     EnvironmentAttribute::SQL_ATTR_OUTPUT_NTS as i32,
                     std::ptr::null_mut() as *mut c_void,
@@ -143,10 +143,10 @@ mod unit {
             );
             assert_eq!(0, *string_length_ptr);
 
-            // SQLGetEnvAttrW where string_length_ptr is null
+            // SQLGetEnvAttr where string_length_ptr is null
             assert_eq!(
                 SqlReturn::SUCCESS,
-                SQLGetEnvAttrW(
+                SQLGetEnvAttr(
                     env_handle as *mut _,
                     EnvironmentAttribute::SQL_ATTR_OUTPUT_NTS as i32,
                     std::ptr::null_mut() as *mut c_void,
@@ -162,6 +162,7 @@ mod unit {
     #[test]
     fn test_optional_value_changed() {
         use cstr::WideChar;
+        let string_length_ptr = &mut 0;
         unsafe {
             let handle: *mut _ = &mut MongoHandle::Env(Env::with_state(
                 EnvState::Allocated,
@@ -169,11 +170,12 @@ mod unit {
             ));
             assert_eq!(
                 SqlReturn::SUCCESS_WITH_INFO,
-                SQLSetEnvAttrW(
+                SQLGetEnvAttr(
                     handle as HEnv,
                     EnvironmentAttribute::SQL_ATTR_CP_MATCH as i32,
                     CpMatch::Relaxed as i32 as Pointer,
-                    0
+                    0,
+                    string_length_ptr
                 )
             );
 
@@ -255,11 +257,11 @@ mod unit {
                 CpMatch::Strict as i32,
             );
 
-            // SQLGetEnvAttrW where value_ptr is null
+            // SQLGetEnvAttr where value_ptr is null
             let string_length_ptr = &mut 0;
             assert_eq!(
                 SqlReturn::SUCCESS,
-                SQLGetEnvAttrW(
+                SQLGetEnvAttr(
                     env_handle as *mut _,
                     EnvironmentAttribute::SQL_ATTR_OUTPUT_NTS as i32,
                     std::ptr::null_mut() as *mut c_void,
@@ -269,10 +271,10 @@ mod unit {
             );
             assert_eq!(0, *string_length_ptr);
 
-            // SQLGetEnvAttrW where string_length_ptr is null
+            // SQLGetEnvAttr where string_length_ptr is null
             assert_eq!(
                 SqlReturn::SUCCESS,
-                SQLGetEnvAttrW(
+                SQLGetEnvAttr(
                     env_handle as *mut _,
                     EnvironmentAttribute::SQL_ATTR_OUTPUT_NTS as i32,
                     std::ptr::null_mut() as *mut c_void,

--- a/odbc/src/api/env_attr_tests.rs
+++ b/odbc/src/api/env_attr_tests.rs
@@ -169,7 +169,7 @@ mod unit {
             ));
             assert_eq!(
                 SqlReturn::SUCCESS_WITH_INFO,
-                SQLSetEnvAttrW(
+                SQLSetEnvAttr(
                     handle as HEnv,
                     EnvironmentAttribute::SQL_ATTR_CP_MATCH as i32,
                     CpMatch::Relaxed as i32 as Pointer,

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1691,16 +1691,14 @@ pub unsafe extern "C" fn SQLGetDiagRecW(
 }
 
 ///
-/// [`SQLGetEnvAttrW`]: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/SQLGetEnvAttr-function
-///
-/// This is the WideChar version of the SQLGetEnvAttr function
+/// [`SQLGetEnvAttr`]: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/SQLGetEnvAttr-function
 ///
 /// # Safety
 /// Because this is a C-interface, this is necessarily unsafe
 ///
 #[named]
 #[no_mangle]
-pub unsafe extern "C" fn SQLGetEnvAttrW(
+pub unsafe extern "C" fn SQLGetEnvAttr(
     environment_handle: HEnv,
     attribute: Integer,
     value_ptr: Pointer,
@@ -2870,7 +2868,7 @@ pub unsafe extern "C" fn SQLSetPos(
 ///
 #[named]
 #[no_mangle]
-pub unsafe extern "C" fn SQLSetEnvAttrW(
+pub unsafe extern "C" fn SQLSetEnvAttr(
     environment_handle: HEnv,
     attribute: Integer,
     value: Pointer,


### PR DESCRIPTION
Working patch : https://spruce.mongodb.com/version/646241a33e8e8628c178bacb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC