### PR TITLE
SQL-1416: remove release-with-debug profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ members = [
   "macos_postinstall",
 ]
 
-[profile.release-with-debug]
-inherits = "release"
+[profile.release]
 debug = true

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -44,7 +44,7 @@ export DYLD_LIBRARY_PATH="$INSTALLED_ODBC_PATH/lib"
 ```
 Finally, return to the root folder, and update the ini files to set the relevant values and export additional environment variables:
 ```
-export DRIVER_LIB_PATH=$PWD/target/release-with-debug
+export DRIVER_LIB_PATH=$PWD/target/release
 sed -i.bu "s,%DRIVER_LIB_PATH%,$DRIVER_LIB_PATH,g" setup/iodbcinst.ini
 sed -i.bu "s,%DRIVER_LIB_PATH%,$DRIVER_LIB_PATH,g" setup/iodbc.ini
 sed -i.bu "s,%ADF_TEST_DB%,${ADF_TEST_LOCAL_DB},g" setup/iodbc.ini

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -272,8 +272,8 @@ functions:
           ${prepare_shell}
           echo "env $(env)"
           # Build a release driver with debug information
-          cargo build --profile=release-with-debug
-          export DRIVER_LIB_PATH=$PWD/target/release-with-debug
+          cargo build --release
+          export DRIVER_LIB_PATH=$PWD/target/release
 
           cat <<EOT >> expansions.yml
             export DRIVER_LIB_PATH="$DRIVER_LIB_PATH"
@@ -316,8 +316,8 @@ functions:
           ${prepare_shell}
           echo "env $(env)"
           # Build a release driver with debug information
-          cargo build --features odbc-sys/iodbc,cstr/utf32 --profile=release-with-debug
-          export DRIVER_LIB_PATH=$PWD/target/release-with-debug
+          cargo build --features odbc-sys/iodbc,cstr/utf32 --release
+          export DRIVER_LIB_PATH=$PWD/target/release
           cat <<EOT >> expansions.yml
             export DRIVER_LIB_PATH="$DRIVER_LIB_PATH"
           EOT


### PR DESCRIPTION
The custom "release-with-debug" profile is removed, and the "release" profile is now configured to include debug symbols