### PR TITLE
SQL-1439: clear diagnostics between odbc function calls

### DIFF
--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -655,7 +655,7 @@ mod unit {
                             .unwrap()
                             .errors
                             .read()
-                            .unwrap()[1]
+                            .unwrap()[0]
                     ),
                 );
                 guid_val_test(

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -111,7 +111,8 @@ macro_rules! odbc_unwrap {
     }};
 }
 
-// panic_safe_exec executes `function` such that any panics do not crash the runtime.
+// panic_safe_exec_clear_diagnostics executes `function` such that any panics do not crash the runtime,
+// while clearing any diagnostics in the $handle's error vec.
 // If a panic occurs during execution, the panic is caught and turned into a String.
 // The panic message is added to the diagnostics of `handle` and SqlReturn::ERROR returned.
 macro_rules! panic_safe_exec_clear_diagnostics {
@@ -174,7 +175,8 @@ macro_rules! panic_safe_exec_clear_diagnostics {
 }
 pub(crate) use panic_safe_exec_clear_diagnostics;
 
-// panic_safe_exec_keep_diagnostics executes `function` such that any panics do not crash the runtime.
+// panic_safe_exec_keep_diagnostics executes `function` such that any panics do not crash the runtime,
+// while retaining any diagnostics in the provided $handle's errors vec.
 // If a panic occurs during execution, the panic is caught and turned into a String.
 // The panic message is added to the diagnostics of `handle` and SqlReturn::ERROR returned.
 macro_rules! panic_safe_exec_keep_diagnostics {

--- a/odbc/src/api/panic_safe_exec_tests.rs
+++ b/odbc/src/api/panic_safe_exec_tests.rs
@@ -3,7 +3,7 @@ use crate::{
     add_diag_with_function,
     errors::ODBCError,
     handles::definitions::{MongoHandle, MongoHandleRef, Statement, StatementState},
-    panic_safe_exec,
+    panic_safe_exec_clear_diagnostics,
 };
 use function_name::named;
 use odbc_sys::{HStmt, SqlReturn};
@@ -24,12 +24,12 @@ mod unit {
 
     #[named]
     unsafe fn non_panic_fn(stmt_handle: HStmt) -> SqlReturn {
-        panic_safe_exec!(debug, || { SqlReturn::SUCCESS }, stmt_handle);
+        panic_safe_exec_clear_diagnostics!(debug, || { SqlReturn::SUCCESS }, stmt_handle);
     }
 
     #[named]
     unsafe fn panic_fn(stmt_handle: HStmt) -> SqlReturn {
-        panic_safe_exec!(error, || { panic!("panic test") }, stmt_handle);
+        panic_safe_exec_clear_diagnostics!(error, || { panic!("panic test") }, stmt_handle);
     }
 
     #[test]


### PR DESCRIPTION
The only functions that we implement that should not clear diagnostics are SQLGetDiagRec and SQLGetField (we don't implement SQLError).

I also set SQLAllocHandle and SQLFreeHandle to keep diagnostics to avoid any potential for calling unallocated memory, and freeing the handle is probably the ultimate way to clear diagnostics anyway.

Most of the changes are pretty mundane as I renamed the `panic_safe_exec` and that propagated everywhere.