### PR TITLE
SQL-1421: Refactor all ODBC string writing/reading to cstr

### DIFF
--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -1,5 +1,5 @@
 use crate::{odbc_uri::ODBCUri, ConnectionAttributes, MongoConnection};
-use cstr::{input_text_to_string_w, write_to_buffer, WideChar};
+use cstr::{input_text_to_string_w, write_widechar_to_buffer, WideChar};
 
 /// atlas_sql_test_connection returns true if a connection can be established
 /// with the provided connection string.
@@ -35,21 +35,28 @@ pub unsafe extern "C" fn atlas_sql_test_connection(
                 match MongoConnection::connect(client_options, connection_attributes.into()) {
                     Ok(_) => true,
                     Err(e) => {
-                        let len =
-                            write_to_buffer(&e.to_string(), buffer_in_len, buffer as *mut WideChar);
+                        let len = write_widechar_to_buffer(
+                            &e.to_string(),
+                            buffer_in_len,
+                            buffer as *mut WideChar,
+                        );
                         *buffer_out_len = len;
                         false
                     }
                 }
             }
             Err(e) => {
-                let len = write_to_buffer(&e.to_string(), buffer_in_len, buffer as *mut WideChar);
+                let len = write_widechar_to_buffer(
+                    &e.to_string(),
+                    buffer_in_len,
+                    buffer as *mut WideChar,
+                );
                 *buffer_out_len = len;
                 false
             }
         }
     } else {
-        let len = write_to_buffer(
+        let len = write_widechar_to_buffer(
             "Invalid connection string.",
             buffer_in_len,
             buffer as *mut WideChar,

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -1,5 +1,5 @@
 use crate::{odbc_uri::ODBCUri, ConnectionAttributes, MongoConnection};
-use cstr::{input_text_to_string_w, write_widechar_to_buffer, WideChar};
+use cstr::{input_text_to_string_w, write_string_to_buffer, WideChar};
 
 /// atlas_sql_test_connection returns true if a connection can be established
 /// with the provided connection string.
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn atlas_sql_test_connection(
                 match MongoConnection::connect(client_options, connection_attributes.into()) {
                     Ok(_) => true,
                     Err(e) => {
-                        let len = write_widechar_to_buffer(
+                        let len = write_string_to_buffer(
                             &e.to_string(),
                             buffer_in_len,
                             buffer as *mut WideChar,
@@ -46,17 +46,14 @@ pub unsafe extern "C" fn atlas_sql_test_connection(
                 }
             }
             Err(e) => {
-                let len = write_widechar_to_buffer(
-                    &e.to_string(),
-                    buffer_in_len,
-                    buffer as *mut WideChar,
-                );
+                let len =
+                    write_string_to_buffer(&e.to_string(), buffer_in_len, buffer as *mut WideChar);
                 *buffer_out_len = len;
                 false
             }
         }
     } else {
-        let len = write_widechar_to_buffer(
+        let len = write_string_to_buffer(
             "Invalid connection string.",
             buffer_in_len,
             buffer as *mut WideChar,

--- a/cstr/src/lib.rs
+++ b/cstr/src/lib.rs
@@ -195,7 +195,7 @@ pub unsafe fn write_wstring_slice_to_buffer(
 
     unsafe {
         copy_nonoverlapping(message[..len].as_ptr(), output_ptr, len);
-        *output_ptr.offset(len as isize) = 0;
+        *output_ptr.add(len) = 0;
     }
 
     (len + 1) as u16
@@ -215,7 +215,7 @@ pub unsafe fn write_string_slice_to_buffer(
 
     unsafe {
         copy_nonoverlapping(message[..len].as_ptr(), output_ptr, len);
-        *output_ptr.offset(len as isize) = 0;
+        *output_ptr.add(len) = 0;
     }
 
     (len + 1) as u16

--- a/cstr/src/lib.rs
+++ b/cstr/src/lib.rs
@@ -244,7 +244,7 @@ pub unsafe fn write_binary_slice_to_buffer(
 }
 
 ///
-/// write_fixed_data_to_buffer writes the input data to the output buffer with a length of 1.
+/// write_fixed_data_to_buffer writes the input data (a single value) to the output buffer.
 ///
 /// # Safety
 /// This writes to a raw c-pointer, which requires unsafe operations
@@ -309,7 +309,8 @@ mod test {
         let expected = "test\0";
         let input = &to_widechar_vec("test")[..];
         let mut buffer = [0; 5];
-        let len = unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
+        let len =
+            unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
         assert_eq!(expected, from_widechar_ref_lossy(&buffer));
         assert_eq!(len, std::cmp::min(input.len() + 1, buffer.len()) as u16);
     }
@@ -319,7 +320,8 @@ mod test {
         let expected = "te\0";
         let input = &to_widechar_vec("test")[..];
         let mut buffer = [0; 3];
-        let len = unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
+        let len =
+            unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
         assert_eq!(expected, from_widechar_ref_lossy(&buffer));
         assert_eq!(len, std::cmp::min(input.len() + 1, buffer.len()) as u16);
     }
@@ -329,7 +331,8 @@ mod test {
         let expected = "tes\0";
         let input = &to_widechar_vec("test")[..];
         let mut buffer = [0; 4];
-        let len = unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
+        let len =
+            unsafe { write_wstring_slice_to_buffer(input, buffer.len(), buffer.as_mut_ptr()) };
         assert_eq!(expected, from_widechar_ref_lossy(&buffer));
         assert_eq!(len, std::cmp::min(input.len() + 1, buffer.len()) as u16);
     }
@@ -398,9 +401,10 @@ mod test {
     fn test_write_fixed_data() {
         let expected = 42i32;
         let input = &42i32;
-        let output_ptr: *mut c_void =
-            Box::into_raw(Box::new([0i32; 1])) as *mut _;
+        let output_ptr: *mut c_void = Box::into_raw(Box::new([0i32; 1])) as *mut _;
         unsafe { write_fixed_data(input, output_ptr) };
-        unsafe { assert_eq!(expected, *(output_ptr as *mut i32)); }
+        unsafe {
+            assert_eq!(expected, *(output_ptr as *mut i32));
+        }
     }
 }

--- a/cstr/src/lib.rs
+++ b/cstr/src/lib.rs
@@ -176,7 +176,7 @@ pub unsafe fn write_string_to_buffer(message: &str, len: usize, output_ptr: *mut
     let mut v = to_widechar_vec(&message[..len]);
     v.push(0);
     unsafe {
-        copy_nonoverlapping(v.as_mut_ptr(), output_ptr, len);
+        copy_nonoverlapping(v.as_ptr(), output_ptr, len);
     }
     v.len() as u16
 }
@@ -192,14 +192,13 @@ pub unsafe fn write_wstring_slice_to_buffer(
     output_ptr: *mut WideChar,
 ) -> u16 {
     let len = std::cmp::min(message.len(), len - 1);
-    let mut v = message[..len].to_vec();
-    v.push(0);
 
     unsafe {
-        copy_nonoverlapping(v.as_mut_ptr(), output_ptr, len);
+        copy_nonoverlapping(message[..len].as_ptr(), output_ptr, len);
+        *output_ptr.offset(len as isize) = 0;
     }
 
-    v.len() as u16
+    (len + 1) as u16
 }
 
 ///
@@ -213,14 +212,13 @@ pub unsafe fn write_string_slice_to_buffer(
     output_ptr: *mut Char,
 ) -> u16 {
     let len = std::cmp::min(message.len(), len - 1);
-    let mut v = message[..len].to_vec();
-    v.push(0);
 
     unsafe {
-        copy_nonoverlapping(v.as_mut_ptr(), output_ptr, len);
+        copy_nonoverlapping(message[..len].as_ptr(), output_ptr, len);
+        *output_ptr.offset(len as isize) = 0;
     }
 
-    v.len() as u16
+    (len + 1) as u16
 }
 
 ///
@@ -234,13 +232,12 @@ pub unsafe fn write_binary_slice_to_buffer(
     output_ptr: *mut Char,
 ) -> u16 {
     let len = std::cmp::min(message.len(), len);
-    let mut v = message[..len].to_vec();
 
     unsafe {
-        copy_nonoverlapping(v.as_mut_ptr(), output_ptr, len);
+        copy_nonoverlapping(message[..len].as_ptr(), output_ptr, len);
     }
 
-    v.len() as u16
+    len as u16
 }
 
 ///

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -7,7 +7,7 @@ use crate::{
 use bson::{spec::BinarySubtype, Bson, UuidRepresentation};
 use chrono::{offset::Utc, DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use cstr::{
-    write_binary_slice_to_buffer, write_fixed_data_to_buffer, write_string_slice_to_buffer,
+    write_binary_slice_to_buffer, write_fixed_data, write_string_slice_to_buffer,
     write_wstring_slice_to_buffer, WideChar,
 };
 use odbc_sys::{
@@ -1095,7 +1095,7 @@ pub mod i16_len {
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
         }
-        write_fixed_data_to_buffer(data, output_ptr);
+        write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
     }
 }
@@ -1146,7 +1146,7 @@ pub mod i32_len {
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
         }
-        write_fixed_data_to_buffer(data, output_ptr);
+        write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
     }
 }
@@ -1286,7 +1286,7 @@ pub mod isize_len {
             // If the output_ptr is NULL, we should still return the length of the message.
             *data_len_ptr = size_of::<T>() as isize;
         }
-        write_fixed_data_to_buffer(data, output_ptr);
+        write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
     }
 }


### PR DESCRIPTION
I refactored `odbc/api/data.rs` so that all instances of `copy_nonoverlapping` have been replaced with a helper function in `cstr`. 