### PR TITLE
update to use tags

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1485,13 +1485,13 @@ tasks:
       - name: rustfmt
         variant: "*"
       - name: unit-test
-        variants: [windows-64, ubuntu2204]
+        variant: ".release-variant"
       - name: integration-test
-        variants: [windows-64, ubuntu2204]
+        variant: ".release-variant"
       - name: result-set-test
-        variants: [windows-64, ubuntu2204]
+        variant: ".release-variant"
       - name: sign
-        variants: [windows-64, ubuntu2204]
+        variant: ".release-variant"
     commands:
       - func: "upload release"
       - func: "upload debug"
@@ -1511,7 +1511,7 @@ tasks:
       - name: compile-debug
         variant: "*"
       - name: sign
-        variants: [windows-64, ubuntu2204]
+        variant: ".release-variant"
     commands:
       - func: "upload release"
       - func: "upload debug"
@@ -1564,6 +1564,7 @@ buildvariants:
       - name: rustfmt
 
   - name: windows-64
+    tags: ["release-variant"]
     display_name: Windows (64-bit)
     run_on: [windows-64-vs2019-large]
     tasks:
@@ -1576,6 +1577,7 @@ buildvariants:
         run_on: linux-64-amzn-build
 
   - name: ubuntu2204
+    tags: ["release-variant"]
     display_name: Ubuntu 22.04
     run_on: [ubuntu2204-large]
     tasks:


### PR DESCRIPTION
dependencies correctly show up under snapshot, so should also show up for sign

https://spruce.mongodb.com/task/mongosql_odbc_driver_release_snapshot_patch_28437756461ac8bb86261d730efaf90ccfe4565d_648cba31c9ec444d557450c9_23_06_16_19_39_33/logs?execution=0