### PR TITLE
SQL-1448: Update signing tasks to use the new Garasign platform - ODBC driver

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -201,12 +201,12 @@ functions:
         working_dir: mongosql-odbc-driver/installer/msi
         script: |
           podman run \
-          -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
-          -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
-          --rm \
-          -v $(pwd):$(pwd) -w $(pwd) \
-          ${garasign_jsign_image} \
-          /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 mongoodbc.msi"
+            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_jsign_image} \
+            /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 mongoodbc.msi"
 
   "sign ubuntu":
     - command: shell.exec

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -193,40 +193,42 @@ functions:
       type: system
       params:
         silent: true
-        working_dir: mongosql-odbc-driver/installer/msi
         script: |
-          echo "${signing_token_odbc_driver}" > ./signing_auth_token
+          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
     - command: shell.exec
       type: system
       params:
         working_dir: mongosql-odbc-driver/installer/msi
         script: |
-          /usr/local/bin/notary-client.py \
-              --key-name "bi-connector" \
-              --auth-token-file ./signing_auth_token \
-              --comment "Evergreen Automatic Signing (Atlas SQL ODBC) - ${version_id} - ${build_variant}" \
-              --notary-url "${notary_client_url}" \
-              mongoodbc.msi
+          podman run \
+          -e GRS_CONFIG_USER1_USERNAME=${garasign_jsign_username} \
+          -e GRS_CONFIG_USER1_PASSWORD=${garasign_jsign_password} \
+          --rm \
+          -v $(pwd):$(pwd) -w $(pwd) \
+          ${garasign_jsign_image} \
+          /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 mongoodbc.msi"
 
+
+# FIGURE OUT THE USERNAME AND PASSWORD FOR GARASIGN. ALSO, CAN THEY BE THE SAME VARIABLE?
   "sign ubuntu":
     - command: shell.exec
       type: system
       params:
         silent: true
-        working_dir: mongosql-odbc-driver/installer/tgz
         script: |
-          echo "${signing_token_odbc_driver}" > ./signing_auth_token
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
     - command: shell.exec
       type: system
       params:
         working_dir: mongosql-odbc-driver/installer/tgz
         script: |
-          /usr/local/bin/notary-client.py \
-              --key-name "bi-connector" \
-              --auth-token-file ./signing_auth_token \
-              --comment "Evergreen Automatic Signing (Atlas SQL ODBC) - ${version_id} - ${build_variant}" \
-              --notary-url "${notary_client_url}" \
-              mongoodbc.tar.gz
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME=${garasign_gpg_username_70} \
+            -e GRS_CONFIG_USER1_PASSWORD=${garasign_gpg_password_70} \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongoodbc.tar.gz.sig --detach-sign mongoodbc.tar.gz"
 
   "compile ubuntu and win release":
     - command: shell.exec

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -208,7 +208,7 @@ functions:
             ${garasign_jsign_image} \
             /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 mongoodbc.msi"
 
-  "sign ubuntu":
+  "sign ubuntu and verify signature":
     - command: shell.exec
       type: system
       params:
@@ -227,6 +227,19 @@ functions:
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
             /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongoodbc.tar.gz.sig --detach-sign mongoodbc.tar.gz"
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: mongosql-odbc-driver/installer/tgz
+        silent: false
+        script: |
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME=${odbc_garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${odbc_garasign_password} \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --verify mongoodbc.tar.gz.sig mongoodbc.tar.gz"
 
   "compile ubuntu and win release":
     - command: shell.exec
@@ -509,6 +522,7 @@ functions:
         local_file: mongosql-odbc-driver/installer/msi/mongoodbc.msi
         bucket: mciuploads
         permissions: public-read
+        display_name: mongoodbc-signed.msi
         content_type: application/octet-stream
 
   "upload ubuntu sig file":
@@ -1467,7 +1481,7 @@ tasks:
         variants: [ubuntu2204]
       - func: "sign windows"
         variants: [windows-64]
-      - func: "sign ubuntu"
+      - func: "sign ubuntu and verify signature"
         variants: [ubuntu2204]
       - func: "upload signed windows artifacts"
         variants: [windows-64]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1573,7 +1573,6 @@ buildvariants:
       - name: windows-test-integration-group
       - name: windows-test-result-set-group
       - name: sign
-        run_on: linux-64-amzn-build
 
   - name: ubuntu2204
     display_name: Ubuntu 22.04
@@ -1585,7 +1584,6 @@ buildvariants:
       - name: integration-test
       - name: result-set-test
       - name: sign
-        run_on: linux-64-amzn-build
 
   - name: macos
     display_name: "macOS 11.0"

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -194,15 +194,15 @@ functions:
       params:
         silent: true
         script: |
-          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
+          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
     - command: shell.exec
       type: system
       params:
         working_dir: mongosql-odbc-driver/installer/msi
         script: |
           podman run \
-            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
-            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
+            -e GRS_CONFIG_USER1_USERNAME=${odbc_garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${odbc_garasign_password} \
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jsign_image} \
@@ -214,15 +214,15 @@ functions:
       params:
         silent: true
         script: |
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
     - command: shell.exec
       type: system
       params:
         working_dir: mongosql-odbc-driver/installer/tgz
         script: |
           docker run \
-            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
-            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
+            -e GRS_CONFIG_USER1_USERNAME=${odbc_garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${odbc_garasign_password} \
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -194,13 +194,13 @@ functions:
       params:
         silent: true
         script: |
-          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
     - command: shell.exec
       type: system
       params:
         working_dir: mongosql-odbc-driver/installer/msi
         script: |
-          podman run \
+          docker run \
             -e GRS_CONFIG_USER1_USERNAME=${odbc_garasign_username} \
             -e GRS_CONFIG_USER1_PASSWORD=${odbc_garasign_password} \
             --rm \
@@ -506,7 +506,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         remote_file: mongosql-odbc-driver/artifacts/${version_id}/windows-64/release/mongoodbc-signed.msi
-        local_file: mongosql-odbc-driver/installer/msi/mongoodbc-signed.msi
+        local_file: mongosql-odbc-driver/installer/msi/mongoodbc.msi
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
@@ -1574,6 +1574,7 @@ buildvariants:
       - name: windows-test-integration-group
       - name: windows-test-result-set-group
       - name: sign
+        run_on: ubuntu2204-large
 
   - name: ubuntu2204
     tags: ["release-variant"]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -201,15 +201,13 @@ functions:
         working_dir: mongosql-odbc-driver/installer/msi
         script: |
           podman run \
-          -e GRS_CONFIG_USER1_USERNAME=${garasign_jsign_username} \
-          -e GRS_CONFIG_USER1_PASSWORD=${garasign_jsign_password} \
+          -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
+          -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
           --rm \
           -v $(pwd):$(pwd) -w $(pwd) \
           ${garasign_jsign_image} \
           /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 mongoodbc.msi"
 
-
-# FIGURE OUT THE USERNAME AND PASSWORD FOR GARASIGN. ALSO, CAN THEY BE THE SAME VARIABLE?
   "sign ubuntu":
     - command: shell.exec
       type: system
@@ -223,8 +221,8 @@ functions:
         working_dir: mongosql-odbc-driver/installer/tgz
         script: |
           docker run \
-            -e GRS_CONFIG_USER1_USERNAME=${garasign_gpg_username_70} \
-            -e GRS_CONFIG_USER1_PASSWORD=${garasign_gpg_password_70} \
+            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \


### PR DESCRIPTION
This ticket covers replacing uses of Notary Service with Garasign. In this ticket, I created a few new evergreen variables: `sql_engines_artifactory_username`, `sql_engines_artifactory_auth_token`, `release_tools_container_registry`, `odbc_garasign_username`, `odbc_garasign_password`, `garasign_jsign_image`, `garasign_gpg_image`. 

Two things I'm wondering about:
1. Despite the sign task for Windows running successfully, I see this error in the logs: `ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...`. I'm not sure if this matters.
2. Should I create a signing verification step like in the tableau driver? There's nothing like this already in the `evergreen.yml`, so I'm not sure how necessary it is to do.