### PR TITLE
SQL-1464: Check pointers before use

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1045,9 +1045,7 @@ pub mod i16_len {
             buffer_len / size_of::<WideChar>(),
         );
         // Only copy the length if the pointer is not null
-        if !text_length_ptr.is_null() {
-            *text_length_ptr = (size_of::<WideChar>() * len) as SmallInt;
-        }
+        set_str_length(text_length_ptr, (size_of::<WideChar>() * len) as SmallInt);
         ret
     }
 
@@ -1069,9 +1067,7 @@ pub mod i16_len {
         let message = cstr::to_widechar_vec(message);
         let (len, ret) = set_output_wstring_helper(&message, output_ptr, buffer_len);
         // Only copy the length if the pointer is not null
-        if !text_length_ptr.is_null() {
-            *text_length_ptr = len as SmallInt;
-        }
+        set_str_length(text_length_ptr, len as SmallInt);
         ret
     }
 
@@ -1088,10 +1084,9 @@ pub mod i16_len {
         output_ptr: Pointer,
         data_len_ptr: *mut SmallInt,
     ) -> SqlReturn {
-        if !data_len_ptr.is_null() {
-            // If the output_ptr is NULL, we should still return the length of the message.
-            *data_len_ptr = size_of::<T>() as i16;
-        }
+        // If the output_ptr is NULL, we should still return the length of the message.
+        set_str_length(data_len_ptr, size_of::<T>() as i16);
+
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
         }
@@ -1122,9 +1117,8 @@ pub mod i32_len {
             output_ptr as *mut WideChar,
             buffer_len / size_of::<WideChar>(),
         );
-        if !text_length_ptr.is_null() {
-            *text_length_ptr = (size_of::<WideChar>() * len) as Integer;
-        }
+
+        set_str_length(text_length_ptr, (size_of::<WideChar>() * len) as Integer);
         ret
     }
 
@@ -1141,10 +1135,9 @@ pub mod i32_len {
         output_ptr: Pointer,
         data_len_ptr: *mut Integer,
     ) -> SqlReturn {
-        if !data_len_ptr.is_null() {
-            // If the output_ptr is NULL, we should still return the length of the message.
-            *data_len_ptr = size_of::<T>() as i32;
-        }
+        // If the output_ptr is NULL, we should still return the length of the message.
+        set_str_length(data_len_ptr, size_of::<T>() as i32);
+
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
         }
@@ -1180,7 +1173,7 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            *text_length_ptr = 0;
+            set_str_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) = set_output_wstring_helper(
@@ -1189,7 +1182,10 @@ pub mod isize_len {
             buffer_len / size_of::<WideChar>(),
         );
         // the returned length should always be the total length of the data.
-        *text_length_ptr = (size_of::<WideChar>() * (message.len() - index)) as Len;
+        set_str_length(
+            text_length_ptr,
+            (size_of::<WideChar>() * (message.len() - index)) as Len,
+        );
         stmt.insert_var_data_cache(col_num, CachedData::WChar(index + len, message));
         ret
     }
@@ -1219,14 +1215,14 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            *text_length_ptr = 0;
+            set_str_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_string_helper(message.get(index..).unwrap(), output_ptr, buffer_len);
         // the returned length should always be the total length of the data.
-        *text_length_ptr = (message.len() - index) as Len;
-        // The lenth parameter does not matter because character data uses 8bit words and
+        set_str_length(text_length_ptr, (message.len() - index) as Len);
+        // The length parameter does not matter because character data uses 8bit words and
         // we can obtain it from message.chars().count() above.
         stmt.insert_var_data_cache(col_num, CachedData::Char(len + index, message));
         ret
@@ -1257,12 +1253,12 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the data is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= data.len() {
-            *text_length_ptr = 0;
+            set_str_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_binary_helper(data.get(index..).unwrap(), output_ptr, buffer_len);
-        *text_length_ptr = (data.len() - index) as Len;
+        set_str_length(text_length_ptr, (data.len() - index) as Len);
         stmt.insert_var_data_cache(col_num, CachedData::Bin(len + index, data));
         ret
     }
@@ -1284,10 +1280,10 @@ pub mod isize_len {
         if output_ptr.is_null() {
             return SqlReturn::ERROR;
         }
-        if !data_len_ptr.is_null() {
-            // If the output_ptr is NULL, we should still return the length of the message.
-            *data_len_ptr = size_of::<T>() as isize;
-        }
+
+        // If the output_ptr is NULL, we should still return the length of the message.
+        set_str_length(data_len_ptr, size_of::<T>() as isize);
+
         write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
     }
@@ -1299,7 +1295,7 @@ pub mod isize_len {
 /// # Safety
 /// This writes to a raw C-pointers
 ///
-pub unsafe fn set_str_length(string_length_ptr: *mut Integer, length: Integer) {
+pub unsafe fn set_str_length<T>(string_length_ptr: *mut T, length: T) {
     if !string_length_ptr.is_null() {
         *string_length_ptr = length
     }

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1045,7 +1045,7 @@ pub mod i16_len {
             buffer_len / size_of::<WideChar>(),
         );
         // Only copy the length if the pointer is not null
-        set_str_length(text_length_ptr, (size_of::<WideChar>() * len) as SmallInt);
+        set_data_length(text_length_ptr, (size_of::<WideChar>() * len) as SmallInt);
         ret
     }
 
@@ -1067,7 +1067,7 @@ pub mod i16_len {
         let message = cstr::to_widechar_vec(message);
         let (len, ret) = set_output_wstring_helper(&message, output_ptr, buffer_len);
         // Only copy the length if the pointer is not null
-        set_str_length(text_length_ptr, len as SmallInt);
+        set_data_length(text_length_ptr, len as SmallInt);
         ret
     }
 
@@ -1085,7 +1085,7 @@ pub mod i16_len {
         data_len_ptr: *mut SmallInt,
     ) -> SqlReturn {
         // If the output_ptr is NULL, we should still return the length of the message.
-        set_str_length(data_len_ptr, size_of::<T>() as i16);
+        set_data_length(data_len_ptr, size_of::<T>() as i16);
 
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
@@ -1118,7 +1118,7 @@ pub mod i32_len {
             buffer_len / size_of::<WideChar>(),
         );
 
-        set_str_length(text_length_ptr, (size_of::<WideChar>() * len) as Integer);
+        set_data_length(text_length_ptr, (size_of::<WideChar>() * len) as Integer);
         ret
     }
 
@@ -1136,7 +1136,7 @@ pub mod i32_len {
         data_len_ptr: *mut Integer,
     ) -> SqlReturn {
         // If the output_ptr is NULL, we should still return the length of the message.
-        set_str_length(data_len_ptr, size_of::<T>() as i32);
+        set_data_length(data_len_ptr, size_of::<T>() as i32);
 
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
@@ -1173,7 +1173,7 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            set_str_length(text_length_ptr, 0);
+            set_data_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) = set_output_wstring_helper(
@@ -1182,7 +1182,7 @@ pub mod isize_len {
             buffer_len / size_of::<WideChar>(),
         );
         // the returned length should always be the total length of the data.
-        set_str_length(
+        set_data_length(
             text_length_ptr,
             (size_of::<WideChar>() * (message.len() - index)) as Len,
         );
@@ -1215,13 +1215,13 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            set_str_length(text_length_ptr, 0);
+            set_data_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_string_helper(message.get(index..).unwrap(), output_ptr, buffer_len);
         // the returned length should always be the total length of the data.
-        set_str_length(text_length_ptr, (message.len() - index) as Len);
+        set_data_length(text_length_ptr, (message.len() - index) as Len);
         // The length parameter does not matter because character data uses 8bit words and
         // we can obtain it from message.chars().count() above.
         stmt.insert_var_data_cache(col_num, CachedData::Char(len + index, message));
@@ -1253,12 +1253,12 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the data is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= data.len() {
-            set_str_length(text_length_ptr, 0);
+            set_data_length(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_binary_helper(data.get(index..).unwrap(), output_ptr, buffer_len);
-        set_str_length(text_length_ptr, (data.len() - index) as Len);
+        set_data_length(text_length_ptr, (data.len() - index) as Len);
         stmt.insert_var_data_cache(col_num, CachedData::Bin(len + index, data));
         ret
     }
@@ -1282,7 +1282,7 @@ pub mod isize_len {
         }
 
         // If the output_ptr is NULL, we should still return the length of the message.
-        set_str_length(data_len_ptr, size_of::<T>() as isize);
+        set_data_length(data_len_ptr, size_of::<T>() as isize);
 
         write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
@@ -1295,9 +1295,9 @@ pub mod isize_len {
 /// # Safety
 /// This writes to a raw C-pointers
 ///
-pub unsafe fn set_str_length<T>(string_length_ptr: *mut T, length: T) {
-    if !string_length_ptr.is_null() {
-        *string_length_ptr = length
+pub unsafe fn set_data_length<T>(data_length_ptr: *mut T, length: T) {
+    if !data_length_ptr.is_null() {
+        *data_length_ptr = length
     }
 }
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1295,9 +1295,9 @@ pub mod isize_len {
 /// # Safety
 /// This writes to a raw C-pointers
 ///
-pub unsafe fn len_ptr_safe_write<T>(data_length_ptr: *mut T, length: T) {
-    if !data_length_ptr.is_null() {
-        *data_length_ptr = length
+pub unsafe fn len_ptr_safe_write<T>(length_ptr: *mut T, length: T) {
+    if !length_ptr.is_null() {
+        *length_ptr = length
     }
 }
 

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1045,7 +1045,7 @@ pub mod i16_len {
             buffer_len / size_of::<WideChar>(),
         );
         // Only copy the length if the pointer is not null
-        len_ptr_safe_write(text_length_ptr, (size_of::<WideChar>() * len) as SmallInt);
+        ptr_safe_write(text_length_ptr, (size_of::<WideChar>() * len) as SmallInt);
         ret
     }
 
@@ -1067,7 +1067,7 @@ pub mod i16_len {
         let message = cstr::to_widechar_vec(message);
         let (len, ret) = set_output_wstring_helper(&message, output_ptr, buffer_len);
         // Only copy the length if the pointer is not null
-        len_ptr_safe_write(text_length_ptr, len as SmallInt);
+        ptr_safe_write(text_length_ptr, len as SmallInt);
         ret
     }
 
@@ -1085,7 +1085,7 @@ pub mod i16_len {
         data_len_ptr: *mut SmallInt,
     ) -> SqlReturn {
         // If the output_ptr is NULL, we should still return the length of the message.
-        len_ptr_safe_write(data_len_ptr, size_of::<T>() as i16);
+        ptr_safe_write(data_len_ptr, size_of::<T>() as i16);
 
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
@@ -1118,7 +1118,7 @@ pub mod i32_len {
             buffer_len / size_of::<WideChar>(),
         );
 
-        len_ptr_safe_write(text_length_ptr, (size_of::<WideChar>() * len) as Integer);
+        ptr_safe_write(text_length_ptr, (size_of::<WideChar>() * len) as Integer);
         ret
     }
 
@@ -1136,7 +1136,7 @@ pub mod i32_len {
         data_len_ptr: *mut Integer,
     ) -> SqlReturn {
         // If the output_ptr is NULL, we should still return the length of the message.
-        len_ptr_safe_write(data_len_ptr, size_of::<T>() as i32);
+        ptr_safe_write(data_len_ptr, size_of::<T>() as i32);
 
         if output_ptr.is_null() {
             return SqlReturn::SUCCESS_WITH_INFO;
@@ -1173,7 +1173,7 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            len_ptr_safe_write(text_length_ptr, 0);
+            ptr_safe_write(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) = set_output_wstring_helper(
@@ -1182,7 +1182,7 @@ pub mod isize_len {
             buffer_len / size_of::<WideChar>(),
         );
         // the returned length should always be the total length of the data.
-        len_ptr_safe_write(
+        ptr_safe_write(
             text_length_ptr,
             (size_of::<WideChar>() * (message.len() - index)) as Len,
         );
@@ -1215,13 +1215,13 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the string is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= message.len() {
-            len_ptr_safe_write(text_length_ptr, 0);
+            ptr_safe_write(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_string_helper(message.get(index..).unwrap(), output_ptr, buffer_len);
         // the returned length should always be the total length of the data.
-        len_ptr_safe_write(text_length_ptr, (message.len() - index) as Len);
+        ptr_safe_write(text_length_ptr, (message.len() - index) as Len);
         // The length parameter does not matter because character data uses 8bit words and
         // we can obtain it from message.chars().count() above.
         stmt.insert_var_data_cache(col_num, CachedData::Char(len + index, message));
@@ -1253,12 +1253,12 @@ pub mod isize_len {
         // TODO Power BI: This will return NO_DATA if the data is size 0 to begin with, not just
         // when the data runs out. Check to see if this is correct behavior.
         if index >= data.len() {
-            len_ptr_safe_write(text_length_ptr, 0);
+            ptr_safe_write(text_length_ptr, 0);
             return SqlReturn::NO_DATA;
         }
         let (len, ret) =
             set_output_binary_helper(data.get(index..).unwrap(), output_ptr, buffer_len);
-        len_ptr_safe_write(text_length_ptr, (data.len() - index) as Len);
+        ptr_safe_write(text_length_ptr, (data.len() - index) as Len);
         stmt.insert_var_data_cache(col_num, CachedData::Bin(len + index, data));
         ret
     }
@@ -1282,7 +1282,7 @@ pub mod isize_len {
         }
 
         // If the output_ptr is NULL, we should still return the length of the message.
-        len_ptr_safe_write(data_len_ptr, size_of::<T>() as isize);
+        ptr_safe_write(data_len_ptr, size_of::<T>() as isize);
 
         write_fixed_data(data, output_ptr);
         SqlReturn::SUCCESS
@@ -1290,14 +1290,14 @@ pub mod isize_len {
 }
 
 ///
-/// set_str_length writes the given length to [`string_length_ptr`].
+/// ptr_safe_write writes the given data to [`ptr`].
 ///
 /// # Safety
 /// This writes to a raw C-pointers
 ///
-pub unsafe fn len_ptr_safe_write<T>(length_ptr: *mut T, length: T) {
-    if !length_ptr.is_null() {
-        *length_ptr = length
+pub unsafe fn ptr_safe_write<T>(ptr: *mut T, data: T) {
+    if !ptr.is_null() {
+        *ptr = data;
     }
 }
 

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1,7 +1,7 @@
 use crate::{
     add_diag_with_function,
     api::{
-        data::{i16_len, i32_len, set_data_length},
+        data::{i16_len, i32_len, len_ptr_safe_write},
         definitions::*,
         diag::{get_diag_field, get_diag_recw, get_stmt_diag_field},
         errors::{ODBCError, Result},
@@ -1751,9 +1751,9 @@ unsafe fn sql_get_env_attrw_helper(
 ) -> SqlReturn {
     let env = must_be_valid!(env_handle.as_env());
     if value_ptr.is_null() {
-        set_data_length(string_length, 0);
+        len_ptr_safe_write(string_length, 0);
     } else {
-        set_data_length(string_length, size_of::<Integer>() as Integer);
+        len_ptr_safe_write(string_length, size_of::<Integer>() as Integer);
         match attribute {
             EnvironmentAttribute::SQL_ATTR_ODBC_VERSION => {
                 *(value_ptr as *mut OdbcVersion) = env.attributes.read().unwrap().odbc_ver;
@@ -2287,7 +2287,7 @@ unsafe fn sql_get_stmt_attrw_helper(
 ) -> SqlReturn {
     // Most attributes have type SQLULEN, so default to the size of that
     // type.
-    set_data_length(string_length_ptr, size_of::<ULen>() as Integer);
+    len_ptr_safe_write(string_length_ptr, size_of::<ULen>() as Integer);
 
     let mut err = None;
 
@@ -2297,30 +2297,30 @@ unsafe fn sql_get_stmt_attrw_helper(
             StatementAttribute::SQL_ATTR_APP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_row_desc as Pointer;
-                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_APP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_param_desc as Pointer;
-                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_row_desc as Pointer;
-                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_param_desc as Pointer;
-                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_FETCH_BOOKMARK_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().fetch_bookmark_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut Len>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut Len>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_CURSOR_SCROLLABLE => {
@@ -2367,7 +2367,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_bind_offset_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_TYPE => {
@@ -2376,17 +2376,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_operation_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_status_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMS_PROCESSED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_processed_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMSET_SIZE => {
@@ -2403,7 +2403,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_bind_offset_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_TYPE => {
@@ -2416,17 +2416,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_operation_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_status_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROWS_FETCHED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().rows_fetched_ptr;
-                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE | StatementAttribute::SQL_ROWSET_SIZE => {

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1,7 +1,7 @@
 use crate::{
     add_diag_with_function,
     api::{
-        data::{i16_len, i32_len, set_str_length},
+        data::{i16_len, i32_len, set_data_length},
         definitions::*,
         diag::{get_diag_field, get_diag_recw, get_stmt_diag_field},
         errors::{ODBCError, Result},
@@ -1751,9 +1751,9 @@ unsafe fn sql_get_env_attrw_helper(
 ) -> SqlReturn {
     let env = must_be_valid!(env_handle.as_env());
     if value_ptr.is_null() {
-        set_str_length(string_length, 0);
+        set_data_length(string_length, 0);
     } else {
-        set_str_length(string_length, size_of::<Integer>() as Integer);
+        set_data_length(string_length, size_of::<Integer>() as Integer);
         match attribute {
             EnvironmentAttribute::SQL_ATTR_ODBC_VERSION => {
                 *(value_ptr as *mut OdbcVersion) = env.attributes.read().unwrap().odbc_ver;
@@ -2287,7 +2287,7 @@ unsafe fn sql_get_stmt_attrw_helper(
 ) -> SqlReturn {
     // Most attributes have type SQLULEN, so default to the size of that
     // type.
-    set_str_length(string_length_ptr, size_of::<ULen>() as Integer);
+    set_data_length(string_length_ptr, size_of::<ULen>() as Integer);
 
     let mut err = None;
 
@@ -2297,30 +2297,30 @@ unsafe fn sql_get_stmt_attrw_helper(
             StatementAttribute::SQL_ATTR_APP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_row_desc as Pointer;
-                set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_APP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_param_desc as Pointer;
-                set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_row_desc as Pointer;
-                set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_param_desc as Pointer;
-                set_str_length(string_length_ptr, size_of::<Pointer>() as Integer);
+                set_data_length(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_FETCH_BOOKMARK_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().fetch_bookmark_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut Len>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut Len>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_CURSOR_SCROLLABLE => {
@@ -2367,7 +2367,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_bind_offset_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_TYPE => {
@@ -2376,17 +2376,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_operation_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_status_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMS_PROCESSED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_processed_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMSET_SIZE => {
@@ -2403,7 +2403,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_bind_offset_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_TYPE => {
@@ -2416,17 +2416,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_operation_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_status_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROWS_FETCHED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().rows_fetched_ptr;
-                set_str_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                set_data_length(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE | StatementAttribute::SQL_ROWSET_SIZE => {

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1,7 +1,7 @@
 use crate::{
     add_diag_with_function,
     api::{
-        data::{i16_len, i32_len, len_ptr_safe_write},
+        data::{i16_len, i32_len, ptr_safe_write},
         definitions::*,
         diag::{get_diag_field, get_diag_recw, get_stmt_diag_field},
         errors::{ODBCError, Result},
@@ -1751,9 +1751,9 @@ unsafe fn sql_get_env_attrw_helper(
 ) -> SqlReturn {
     let env = must_be_valid!(env_handle.as_env());
     if value_ptr.is_null() {
-        len_ptr_safe_write(string_length, 0);
+        ptr_safe_write(string_length, 0);
     } else {
-        len_ptr_safe_write(string_length, size_of::<Integer>() as Integer);
+        ptr_safe_write(string_length, size_of::<Integer>() as Integer);
         match attribute {
             EnvironmentAttribute::SQL_ATTR_ODBC_VERSION => {
                 *(value_ptr as *mut OdbcVersion) = env.attributes.read().unwrap().odbc_ver;
@@ -2287,7 +2287,7 @@ unsafe fn sql_get_stmt_attrw_helper(
 ) -> SqlReturn {
     // Most attributes have type SQLULEN, so default to the size of that
     // type.
-    len_ptr_safe_write(string_length_ptr, size_of::<ULen>() as Integer);
+    ptr_safe_write(string_length_ptr, size_of::<ULen>() as Integer);
 
     let mut err = None;
 
@@ -2297,30 +2297,30 @@ unsafe fn sql_get_stmt_attrw_helper(
             StatementAttribute::SQL_ATTR_APP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_row_desc as Pointer;
-                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_APP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().app_param_desc as Pointer;
-                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_ROW_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_row_desc as Pointer;
-                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_IMP_PARAM_DESC => {
                 *(value_ptr as *mut Pointer) =
                     stmt.attributes.read().unwrap().imp_param_desc as Pointer;
-                len_ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<Pointer>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_FETCH_BOOKMARK_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().fetch_bookmark_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut Len>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut Len>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_CURSOR_SCROLLABLE => {
@@ -2367,7 +2367,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_bind_offset_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_BIND_TYPE => {
@@ -2376,17 +2376,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_PARAM_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_operation_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAM_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_status_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMS_PROCESSED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().param_processed_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_PARAMSET_SIZE => {
@@ -2403,7 +2403,7 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_OFFSET_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_bind_offset_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_BIND_TYPE => {
@@ -2416,17 +2416,17 @@ unsafe fn sql_get_stmt_attrw_helper(
             }
             StatementAttribute::SQL_ATTR_ROW_OPERATION_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_operation_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_STATUS_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().row_status_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut USmallInt>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROWS_FETCHED_PTR => {
                 *(value_ptr as *mut _) = stmt.attributes.read().unwrap().rows_fetched_ptr;
-                len_ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
+                ptr_safe_write(string_length_ptr, size_of::<*mut ULen>() as Integer);
                 SqlReturn::SUCCESS
             }
             StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE | StatementAttribute::SQL_ROWSET_SIZE => {


### PR DESCRIPTION
Essentially, I renamed `set_str_length` to `set_data_length` and changed it to use generics. Then I called it in the places where `data_len_ptr` and `text_length_ptr` are set. 