### PR TITLE
SQL-1554: handle telemetry data correctly

### DIFF
--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -352,7 +352,11 @@ impl ODBCUri {
     }
 
     fn handle_app_name(&mut self, app_name: Option<String>) -> Option<String> {
-        // log::info!("Connecting with PowerBI Connector version: {s}");
+        if let Some(ref app_name) = app_name {
+            if app_name.contains(POWERBI_CONNECTOR) {
+                log::info!("Connecting with PowerBI Connector version: {}", app_name);
+            }
+        }
         Some(
             vec![
                 Some(DEFAULT_APP_NAME.to_string()),
@@ -370,18 +374,6 @@ impl ODBCUri {
             }),
         )
     }
-
-    // fn handle_app_name(&mut self) -> Option<String> {
-    //     self.remove(&[APPNAME])
-    //         .map(|s| {
-    //             if s.contains(POWERBI_CONNECTOR) {
-    //                 format!("{}+{}", s, DRIVER_METRICS_VERSION.as_str())
-    //             } else {
-    //                 s
-    //             }
-    //         })
-    //         .or(Some(DEFAULT_APP_NAME.to_string()))
-    // }
 }
 
 mod unit {

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -912,6 +912,34 @@ mod unit {
         }
 
         #[test]
+        fn app_name_in_odbc_uri_and_no_mongodb_uri() {
+            use crate::odbc_uri::ODBCUri;
+            use constants::DEFAULT_APP_NAME;
+            let uri_opts = ODBCUri::new(
+                "USER=foo;PWD=bar;SERVER=localhost:27017;APPNAME=powerbi-connector+1.0.0"
+                    .to_string(),
+            )
+            .unwrap()
+            .try_into_client_options()
+            .unwrap();
+            assert_eq!(
+                format!("{}|powerbi-connector+1.0.0", *DEFAULT_APP_NAME),
+                uri_opts.client_options.app_name.unwrap()
+            );
+        }
+
+        #[test]
+        fn no_app_name_in_odbc_uri_and_no_mongodb_uri() {
+            use crate::odbc_uri::ODBCUri;
+            use constants::DEFAULT_APP_NAME;
+            let uri_opts = ODBCUri::new("USER=foo;PWD=bar;SERVER=localhost:27017;".to_string())
+                .unwrap()
+                .try_into_client_options()
+                .unwrap();
+            assert_eq!(*DEFAULT_APP_NAME, uri_opts.client_options.app_name.unwrap());
+        }
+
+        #[test]
         fn app_name_in_odbc_uri_shows_with_odbc_driver_version_added() {
             use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
@@ -974,6 +1002,21 @@ mod unit {
             .unwrap()
             .try_into_client_options()
             .unwrap();
+
+            assert_eq!(
+                DRIVER_SHORT_NAME,
+                uri_opts.client_options.driver_info.unwrap().name
+            );
+        }
+
+        #[test]
+        fn driver_info_with_no_mongodb_uri_and_no_odbc_uri_appname() {
+            use crate::odbc_uri::ODBCUri;
+            use constants::DRIVER_SHORT_NAME;
+            let uri_opts = ODBCUri::new("USER=foo;PWD=bar;SERVER=localhost:27017".to_string())
+                .unwrap()
+                .try_into_client_options()
+                .unwrap();
 
             assert_eq!(
                 format!("{DRIVER_SHORT_NAME}",),

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -353,9 +353,7 @@ impl ODBCUri {
 
     fn handle_app_name(&mut self, app_name: Option<String>) -> Option<String> {
         if let Some(ref app_name) = app_name {
-            if app_name.contains(POWERBI_CONNECTOR) {
-                log::info!("Connecting with PowerBI Connector version: {}", app_name);
-            }
+            log::info!("Connecting with : {app_name}");
         }
         Some(
             vec![


### PR DESCRIPTION
This change makes the odbc driver report telemetry the same as the jdbc driver. I deleted the old test and introduced new tests to isolate the behavior for each condition.