### PR TITLE
SQL-1265: Remove workaround for driver cleanup

### DIFF
--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -852,6 +852,14 @@ pub unsafe extern "C" fn SQLDisconnect(connection_handle: HDbc) -> SqlReturn {
             let conn = must_be_valid!((*conn_handle).as_connection());
             // set the mongo_connection to None. This will cause the previous mongo_connection
             // to drop and disconnect.
+            conn.mongo_connection
+                .write()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .client
+                .clone()
+                .shutdown();
             *conn.mongo_connection.write().unwrap() = None;
             SqlReturn::SUCCESS
         },

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -853,11 +853,6 @@ pub unsafe extern "C" fn SQLDisconnect(connection_handle: HDbc) -> SqlReturn {
             // set the mongo_connection to None. This will cause the previous mongo_connection
             // to drop and disconnect.
             *conn.mongo_connection.write().unwrap() = None;
-            // Temporary workaround for https://jira.mongodb.org/browse/RUST-1099
-            // This allows time for the underlying async runtime to clean up all of its
-            // resources before we report back success and subsequently drop the connection
-            // handle entirely
-            std::thread::sleep(std::time::Duration::from_millis(200));
             SqlReturn::SUCCESS
         },
         connection_handle


### PR DESCRIPTION
This PR removes the 200ms sleep after dropping the client. The ticket suggests this should be safe now that we've upgraded to rust driver 2.7.