### PR TITLE
SQL-1684: Add enums to support ODBC 2.x

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -25,7 +25,7 @@ lazy_static! {
 
 // SQL states, stored as [ODBC2 state, ODBC3 state]
 pub const NOT_IMPLEMENTED: [&str; 2] = ["S1C00", "HYC00"];
-pub const TIMEOUT_EXPIRED:[&str; 2] = ["S1T00", "HYT00"];
+pub const TIMEOUT_EXPIRED: [&str; 2] = ["S1T00", "HYT00"];
 pub const GENERAL_ERROR: [&str; 2] = ["S1000", "HY000"];
 pub const PROGRAM_TYPE_OUT_OF_RANGE: [&str; 2] = ["S1003", "HY003"];
 pub const INVALID_SQL_TYPE: [&str; 2] = ["S1004", "HY004"];

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -23,32 +23,112 @@ lazy_static! {
     pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
 }
 
-// SQL states, stored as [ODBC2 state, ODBC3 state]
-pub const NOT_IMPLEMENTED: [&str; 2] = ["S1C00", "HYC00"];
-pub const TIMEOUT_EXPIRED: [&str; 2] = ["S1T00", "HYT00"];
-pub const GENERAL_ERROR: [&str; 2] = ["S1000", "HY000"];
-pub const PROGRAM_TYPE_OUT_OF_RANGE: [&str; 2] = ["S1003", "HY003"];
-pub const INVALID_SQL_TYPE: [&str; 2] = ["S1004", "HY004"];
-pub const INVALID_ATTR_VALUE: [&str; 2] = ["S1009", "HY024"];
-pub const INVALID_INFO_TYPE_VALUE: [&str; 2] = ["S1096", "HY096"];
-pub const NO_DSN_OR_DRIVER: [&str; 2] = ["IM007", "IM007"];
-pub const GENERAL_WARNING: [&str; 2] = ["01000", "01000"];
-pub const RIGHT_TRUNCATED: [&str; 2] = ["01004", "01004"];
-pub const OPTION_CHANGED: [&str; 2] = ["01S02", "01S02"];
-pub const FRACTIONAL_TRUNCATION: [&str; 2] = ["01S07", "01S07"];
-pub const UNABLE_TO_CONNECT: [&str; 2] = ["08001", "08001"];
-pub const INVALID_DESCRIPTOR_INDEX: [&str; 2] = ["07009", "07009"];
-pub const NO_RESULTSET: [&str; 2] = ["24000", "07005"];
-pub const RESTRICTED_DATATYPE: [&str; 2] = ["07006", "07006"];
-pub const INVALID_CURSOR_STATE: [&str; 2] = ["24000", "24000"];
-pub const FUNCTION_SEQUENCE_ERROR: [&str; 2] = ["S1010", "HY010"];
-pub const UNSUPPORTED_FIELD_DESCRIPTOR: [&str; 2] = ["S1091", "HY091"];
-pub const INVALID_ATTRIBUTE_OR_OPTION_IDENTIFIER: [&str; 2] = ["S1092", "HY092"];
-pub const INDICATOR_VARIABLE_REQUIRED: [&str; 2] = ["22002", "22002"];
-pub const INTEGRAL_TRUNCATION: [&str; 2] = ["22003", "22003"];
-pub const INVALID_DATETIME_FORMAT: [&str; 2] = ["22008", "22007"];
-pub const INVALID_CHARACTER_VALUE: [&str; 2] = ["22005", "22018"];
-pub const CONNECTION_NOT_OPEN: [&str; 2] = ["08003", "08003"];
+pub struct OdbcState<'a> {
+    pub odbc_2_state: &'a str,
+    pub odbc_3_state: &'a str,
+}
+
+pub const NOT_IMPLEMENTED: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1C00",
+    odbc_3_state: "HYC00",
+};
+pub const TIMEOUT_EXPIRED: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1T00",
+    odbc_3_state: "HYT00",
+};
+pub const GENERAL_ERROR: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1000",
+    odbc_3_state: "HY000",
+};
+
+pub const PROGRAM_TYPE_OUT_OF_RANGE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1003",
+    odbc_3_state: "HY003",
+};
+pub const INVALID_SQL_TYPE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1004",
+    odbc_3_state: "HY004",
+};
+pub const INVALID_ATTR_VALUE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1009",
+    odbc_3_state: "HY024",
+};
+pub const INVALID_INFO_TYPE_VALUE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1096",
+    odbc_3_state: "HY096",
+};
+pub const NO_DSN_OR_DRIVER: OdbcState<'static> = OdbcState {
+    odbc_2_state: "IM007",
+    odbc_3_state: "IM007",
+};
+pub const GENERAL_WARNING: OdbcState<'static> = OdbcState {
+    odbc_2_state: "01000",
+    odbc_3_state: "01000",
+};
+pub const RIGHT_TRUNCATED: OdbcState<'static> = OdbcState {
+    odbc_2_state: "01004",
+    odbc_3_state: "01004",
+};
+pub const OPTION_CHANGED: OdbcState<'static> = OdbcState {
+    odbc_2_state: "01S02",
+    odbc_3_state: "01S02",
+};
+pub const FRACTIONAL_TRUNCATION: OdbcState<'static> = OdbcState {
+    odbc_2_state: "01S07",
+    odbc_3_state: "01S07",
+};
+pub const UNABLE_TO_CONNECT: OdbcState<'static> = OdbcState {
+    odbc_2_state: "08001",
+    odbc_3_state: "08001",
+};
+pub const INVALID_DESCRIPTOR_INDEX: OdbcState<'static> = OdbcState {
+    odbc_2_state: "07009",
+    odbc_3_state: "07009",
+};
+pub const NO_RESULTSET: OdbcState<'static> = OdbcState {
+    odbc_2_state: "24000",
+    odbc_3_state: "07005",
+};
+pub const RESTRICTED_DATATYPE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "07006",
+    odbc_3_state: "07006",
+};
+pub const INVALID_CURSOR_STATE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "24000",
+    odbc_3_state: "24000",
+};
+pub const FUNCTION_SEQUENCE_ERROR: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1010",
+    odbc_3_state: "HY010",
+};
+pub const UNSUPPORTED_FIELD_DESCRIPTOR: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1091",
+    odbc_3_state: "HY091",
+};
+pub const INVALID_ATTRIBUTE_OR_OPTION_IDENTIFIER: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1092",
+    odbc_3_state: "HY092",
+};
+pub const INDICATOR_VARIABLE_REQUIRED: OdbcState<'static> = OdbcState {
+    odbc_2_state: "22002",
+    odbc_3_state: "22002",
+};
+pub const INTEGRAL_TRUNCATION: OdbcState<'static> = OdbcState {
+    odbc_2_state: "22003",
+    odbc_3_state: "22003",
+};
+pub const INVALID_DATETIME_FORMAT: OdbcState<'static> = OdbcState {
+    odbc_2_state: "22008",
+    odbc_3_state: "22007",
+};
+pub const INVALID_CHARACTER_VALUE: OdbcState<'static> = OdbcState {
+    odbc_2_state: "22005",
+    odbc_3_state: "22018",
+};
+pub const CONNECTION_NOT_OPEN: OdbcState<'static> = OdbcState {
+    odbc_2_state: "08003",
+    odbc_3_state: "08003",
+};
 
 pub const SQL_ALL_TABLE_TYPES: &str = "%";
 pub const SQL_ALL_CATALOGS: &str = "%";

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -85,6 +85,11 @@ pub const INVALID_DESCRIPTOR_INDEX: OdbcState<'static> = OdbcState {
     odbc_2_state: "S1002",
     odbc_3_state: "07009",
 };
+
+// ODBC 3.x SQLSTATE 07009 is mapped to ODBC 2.x SQLSTATE S1093 if the underlying function is SQLBindParameter or SQLDescribeParam.
+// S1093 is a DM error for SQLBindParameter, but not always for SQLDescribeParam.
+// If we implement the latter, we will need to add that error here.
+
 pub const INVALID_COLUMN_NUMBER: OdbcState<'static> = OdbcState {
     odbc_2_state: "07009",
     odbc_3_state: "07009",

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -82,6 +82,10 @@ pub const UNABLE_TO_CONNECT: OdbcState<'static> = OdbcState {
     odbc_3_state: "08001",
 };
 pub const INVALID_DESCRIPTOR_INDEX: OdbcState<'static> = OdbcState {
+    odbc_2_state: "S1002",
+    odbc_3_state: "07009",
+};
+pub const INVALID_COLUMN_NUMBER: OdbcState<'static> = OdbcState {
     odbc_2_state: "07009",
     odbc_3_state: "07009",
 };

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -23,32 +23,32 @@ lazy_static! {
     pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
 }
 
-// SQL states
-pub const NOT_IMPLEMENTED: &str = "HYC00";
-pub const TIMEOUT_EXPIRED: &str = "HYT00";
-pub const GENERAL_ERROR: &str = "HY000";
-pub const PROGRAM_TYPE_OUT_OF_RANGE: &str = "HY003";
-pub const INVALID_SQL_TYPE: &str = "HY004";
-pub const INVALID_ATTR_VALUE: &str = "HY024";
-pub const INVALID_INFO_TYPE_VALUE: &str = "HY096";
-pub const NO_DSN_OR_DRIVER: &str = "IM007";
-pub const GENERAL_WARNING: &str = "01000";
-pub const RIGHT_TRUNCATED: &str = "01004";
-pub const OPTION_CHANGED: &str = "01S02";
-pub const FRACTIONAL_TRUNCATION: &str = "01S07";
-pub const UNABLE_TO_CONNECT: &str = "08001";
-pub const INVALID_DESCRIPTOR_INDEX: &str = "07009";
-pub const NO_RESULTSET: &str = "07005";
-pub const RESTRICTED_DATATYPE: &str = "07006";
-pub const INVALID_CURSOR_STATE: &str = "24000";
-pub const FUNCTION_SEQUENCE_ERROR: &str = "HY010";
-pub const UNSUPPORTED_FIELD_DESCRIPTOR: &str = "HY091";
-pub const INVALID_ATTRIBUTE_OR_OPTION_IDENTIFIER: &str = "HY092";
-pub const INDICATOR_VARIABLE_REQUIRED: &str = "22002";
-pub const INTEGRAL_TRUNCATION: &str = "22003";
-pub const INVALID_DATETIME_FORMAT: &str = "22007";
-pub const INVALID_CHARACTER_VALUE: &str = "22018";
-pub const CONNECTION_NOT_OPEN: &str = "08003";
+// SQL states, stored as [ODBC2 state, ODBC3 state]
+pub const NOT_IMPLEMENTED: [&str; 2] = ["S1C00", "HYC00"];
+pub const TIMEOUT_EXPIRED:[&str; 2] = ["S1T00", "HYT00"];
+pub const GENERAL_ERROR: [&str; 2] = ["S1000", "HY000"];
+pub const PROGRAM_TYPE_OUT_OF_RANGE: [&str; 2] = ["S1003", "HY003"];
+pub const INVALID_SQL_TYPE: [&str; 2] = ["S1004", "HY004"];
+pub const INVALID_ATTR_VALUE: [&str; 2] = ["S1009", "HY024"];
+pub const INVALID_INFO_TYPE_VALUE: [&str; 2] = ["S1096", "HY096"];
+pub const NO_DSN_OR_DRIVER: [&str; 2] = ["IM007", "IM007"];
+pub const GENERAL_WARNING: [&str; 2] = ["01000", "01000"];
+pub const RIGHT_TRUNCATED: [&str; 2] = ["01004", "01004"];
+pub const OPTION_CHANGED: [&str; 2] = ["01S02", "01S02"];
+pub const FRACTIONAL_TRUNCATION: [&str; 2] = ["01S07", "01S07"];
+pub const UNABLE_TO_CONNECT: [&str; 2] = ["08001", "08001"];
+pub const INVALID_DESCRIPTOR_INDEX: [&str; 2] = ["07009", "07009"];
+pub const NO_RESULTSET: [&str; 2] = ["24000", "07005"];
+pub const RESTRICTED_DATATYPE: [&str; 2] = ["07006", "07006"];
+pub const INVALID_CURSOR_STATE: [&str; 2] = ["24000", "24000"];
+pub const FUNCTION_SEQUENCE_ERROR: [&str; 2] = ["S1010", "HY010"];
+pub const UNSUPPORTED_FIELD_DESCRIPTOR: [&str; 2] = ["S1091", "HY091"];
+pub const INVALID_ATTRIBUTE_OR_OPTION_IDENTIFIER: [&str; 2] = ["S1092", "HY092"];
+pub const INDICATOR_VARIABLE_REQUIRED: [&str; 2] = ["22002", "22002"];
+pub const INTEGRAL_TRUNCATION: [&str; 2] = ["22003", "22003"];
+pub const INVALID_DATETIME_FORMAT: [&str; 2] = ["22008", "22007"];
+pub const INVALID_CHARACTER_VALUE: [&str; 2] = ["22005", "22018"];
+pub const CONNECTION_NOT_OPEN: [&str; 2] = ["08003", "08003"];
 
 pub const SQL_ALL_TABLE_TYPES: &str = "%";
 pub const SQL_ALL_CATALOGS: &str = "%";

--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -52,7 +52,7 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn get_sql_state(&self) -> &'static str {
+    pub fn get_sql_state(&self) -> [&'static str; 2] {
         match self {
             Error::CollectionCursorUpdate(err)
             | Error::DatabaseVersionRetreival(err)

--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -1,6 +1,6 @@
 use constants::{
-    FUNCTION_SEQUENCE_ERROR, GENERAL_ERROR, INVALID_CURSOR_STATE, INVALID_DESCRIPTOR_INDEX,
-    NO_DSN_OR_DRIVER, TIMEOUT_EXPIRED, UNABLE_TO_CONNECT,
+    OdbcState, FUNCTION_SEQUENCE_ERROR, GENERAL_ERROR, INVALID_CURSOR_STATE,
+    INVALID_DESCRIPTOR_INDEX, NO_DSN_OR_DRIVER, TIMEOUT_EXPIRED, UNABLE_TO_CONNECT,
 };
 use mongodb::error::{BulkWriteFailure, ErrorKind, WriteFailure};
 use thiserror::Error;
@@ -52,7 +52,7 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn get_sql_state(&self) -> [&'static str; 2] {
+    pub fn get_sql_state(&self) -> OdbcState {
         match self {
             Error::CollectionCursorUpdate(err)
             | Error::DatabaseVersionRetreival(err)

--- a/core/src/mock_query.rs
+++ b/core/src/mock_query.rs
@@ -42,7 +42,9 @@ impl MongoStatement for MongoQuery {
     // Get the BSON value for the cell at the given colIndex on the current row.
     // Fails if the first row has not been retrieved (next must be called at least once before get_value).
     fn get_value(&self, col_index: u16) -> Result<Option<Bson>> {
-        let md = self.get_col_metadata(col_index)?;
+        let md = self
+            .get_col_metadata(col_index)
+            .map_err(|_| Error::ColIndexOutOfBounds(col_index))?;
         let datasource = self.resultset[self.current.ok_or(Error::InvalidCursorState)?]
             .get_document(&md.table_name)
             .map_err(|e: ValueAccessError| Error::ValueAccess(col_index.to_string(), e))?;

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -97,7 +97,9 @@ impl MongoStatement for MongoQuery {
     // Fails if the first row as not been retrieved (next must be called at least once before getValue).
     fn get_value(&self, col_index: u16) -> Result<Option<Bson>> {
         let current = self.current.as_ref().ok_or(Error::InvalidCursorState)?;
-        let md = self.get_col_metadata(col_index)?;
+        let md = self
+            .get_col_metadata(col_index)
+            .map_err(|_| Error::ColIndexOutOfBounds(col_index))?;
         let datasource = current
             .get_document(&md.table_name)
             .map_err(|e: ValueAccessError| Error::ValueAccess(col_index.to_string(), e))?;

--- a/odbc/src/api/col_attr_describe_tests.rs
+++ b/odbc/src/api/col_attr_describe_tests.rs
@@ -265,7 +265,7 @@ mod unit {
                     )
                 );
                 assert_eq!(
-                    format!("[MongoDB][API] The field index {col_index} is out of bounds",),
+                    format!("[MongoDB][API] The column index {col_index} is out of bounds",),
                     format!(
                         "{}",
                         (*stmt_handle)

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1494,28 +1494,28 @@ mod unit {
             type V = Vec<(&'static str, i32, Result<(), ()>, Option<&'static str>)>;
             let strings: HashMap<String, V> = map! {
                 (-PI).to_string() => vec![
-                    ("i64", -3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
-                    ("i32", -3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i64", -3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
+                    ("i32", -3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
                 ],
                 PI.to_string() => vec![
-                    ("i64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
-                    ("i32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
-                    ("u64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
-                    ("u32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("i64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
+                    ("i32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
+                    ("u64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION.odbc_3_state)),
                 ],
                 i128::MIN.to_string() => vec![
-                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
                 ],
                 i128::MAX.to_string() => vec![
-                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
                 ],
                 i32::MAX.to_string() => vec![
                     ("i64", i32::MAX, Ok(()), None),
@@ -1524,10 +1524,10 @@ mod unit {
                     ("u32", i32::MAX, Ok(()), None),
                 ],
                 "foo".to_string() => vec![
-                    ("i64", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
-                    ("i32", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
-                    ("u64", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
-                    ("u32", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("i64", 0, Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
+                    ("i32", 0, Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
+                    ("u64", 0, Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
                 ],
             };
             strings.iter().for_each(|(k, v)| {
@@ -1549,11 +1549,11 @@ mod unit {
                 ],
                 f64::MAX.to_string() => vec![
                     ("f64", f64::MAX, Ok(()), None),
-                    ("f32", 0., Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("f32", 0., Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
                 ],
                 "foo".to_string() => vec![
-                    ("f64", 0., Err(()), Some(INVALID_CHARACTER_VALUE[1])),
-                    ("f32", 0., Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("f64", 0., Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
+                    ("f32", 0., Err(()), Some(INVALID_CHARACTER_VALUE.odbc_3_state)),
                 ],
             };
             strings.iter().for_each(|(k, v)| {
@@ -1568,9 +1568,9 @@ mod unit {
             let int_64s: HashMap<i64, V> = map! {
                 i64::MAX => vec![
                     ("i64", i64::MAX, Ok(()), None),
-                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
                     ("u64", i64::MAX, Ok(()), None),
-                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1]))
+                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state))
                 ],
                 i32::MAX as i64 => vec![
                     ("i64", i32::MAX as i64, Ok(()), None),
@@ -1580,15 +1580,15 @@ mod unit {
                 ],
                 i64::MIN => vec![
                     ("i64", i64::MIN, Ok(()), None),
-                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u64", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1]))
+                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u64", 0i64, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state))
                 ],
                 i32::MIN as i64 => vec![
                     ("i64", i32::MIN as i64, Ok(()), None),
                     ("i32", i32::MIN as i64, Ok(()), None),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1]))
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state))
                 ],
             };
 
@@ -1611,8 +1611,8 @@ mod unit {
                 i32::MIN => vec![
                     ("i64", i32::MIN, Ok(()), None),
                     ("i32", i32::MIN, Ok(()), None),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1]))
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state)),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION.odbc_3_state))
                 ]
             };
 
@@ -1663,7 +1663,7 @@ mod unit {
                     "2014-11-28 09:23:24.1234567890",
                     datetime_expectation_millis,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
                 (
                     "2014-11-28T09:23:24.123456789Z",
@@ -1675,32 +1675,32 @@ mod unit {
                     "2014-11-28T09:23:24.1234567890Z",
                     datetime_expectation_millis,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
                 ("2014-11-28", date_expectation, Ok(()), None),
                 (
                     "11/28/2014",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT[1]),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
                 ),
                 (
                     "2014-35-80",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT[1]),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
                 ),
                 (
                     "2014-30-90 09:23:24.1234567890",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT[1]),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
                 ),
                 (
                     "30:23:24",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT[1]),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
                 ),
                 (
                     "09:23:24",
@@ -1718,7 +1718,7 @@ mod unit {
                     "09:23:24.1234567898",
                     today_plus_time_millis_expectation,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
             ];
             test_cases
@@ -1750,16 +1750,28 @@ mod unit {
             let date_expectation = NaiveDate::from_ymd_opt(2014, 11, 28).unwrap();
             let test_cases: Vec<(&str, Result<(), ()>, Option<&'static str>)> = vec![
                 ("2014-11-28", Ok(()), None),
-                ("11/28/2014", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
-                ("2014-22-22", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
-                ("10:15:30", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                (
+                    "11/28/2014",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
+                (
+                    "2014-22-22",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
+                (
+                    "10:15:30",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
                 ("2014-11-28 00:00:00", Ok(()), None),
                 ("2014-11-28 00:00:00.000", Ok(()), None),
                 ("2014-11-28T00:00:00Z", Ok(()), None),
                 (
                     "2014-11-28 10:15:30",
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
             ];
             test_cases.iter().for_each(|(input, result, info)| {
@@ -1791,7 +1803,7 @@ mod unit {
                 ("2014-11-28T00:00:00Z".parse().unwrap(), None),
                 (
                     "2014-11-28T10:15:30.123Z".parse().unwrap(),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
             ];
             test_cases.iter().for_each(|(input, info)| {
@@ -1810,14 +1822,26 @@ mod unit {
             let test_cases: Vec<(&str, Result<(), ()>, Option<&'static str>)> = vec![
                 ("10:15:30", Ok(()), None),
                 ("10:15:30.00000", Ok(()), None),
-                ("10:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
-                ("25:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
-                ("2022-10-15", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                (
+                    "10:15:30.123",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
+                (
+                    "25:15:30.123",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
+                (
+                    "2022-10-15",
+                    Err(()),
+                    Some(INVALID_DATETIME_FORMAT.odbc_3_state),
+                ),
                 ("2014-11-28 10:15:30.000", Ok(()), None),
                 (
                     "2014-11-28 10:15:30.1243",
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
             ];
             test_cases.iter().for_each(|(input, result, info)| {
@@ -1849,7 +1873,7 @@ mod unit {
                 ("2014-11-28T10:15:30Z".parse().unwrap(), None),
                 (
                     "2014-11-28T10:15:30.123Z".parse().unwrap(),
-                    Some(FRACTIONAL_TRUNCATION[1]),
+                    Some(FRACTIONAL_TRUNCATION.odbc_3_state),
                 ),
             ];
             test_cases.iter().for_each(|(input, info)| {

--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -1494,28 +1494,28 @@ mod unit {
             type V = Vec<(&'static str, i32, Result<(), ()>, Option<&'static str>)>;
             let strings: HashMap<String, V> = map! {
                 (-PI).to_string() => vec![
-                    ("i64", -3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
-                    ("i32", -3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
+                    ("i64", -3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("i32", -3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
                 ],
                 PI.to_string() => vec![
-                    ("i64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
-                    ("i32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
-                    ("u64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
-                    ("u32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION)),
+                    ("i64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("i32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("u64", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
+                    ("u32", 3, Ok(()), Some(FRACTIONAL_TRUNCATION[1])),
                 ],
                 i128::MIN.to_string() => vec![
-                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
+                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
                 ],
                 i128::MAX.to_string() => vec![
-                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
+                    ("i64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("i32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
                 ],
                 i32::MAX.to_string() => vec![
                     ("i64", i32::MAX, Ok(()), None),
@@ -1524,10 +1524,10 @@ mod unit {
                     ("u32", i32::MAX, Ok(()), None),
                 ],
                 "foo".to_string() => vec![
-                    ("i64", 0, Err(()), Some(INVALID_CHARACTER_VALUE)),
-                    ("i32", 0, Err(()), Some(INVALID_CHARACTER_VALUE)),
-                    ("u64", 0, Err(()), Some(INVALID_CHARACTER_VALUE)),
-                    ("u32", 0, Err(()), Some(INVALID_CHARACTER_VALUE)),
+                    ("i64", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("i32", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("u64", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("u32", 0, Err(()), Some(INVALID_CHARACTER_VALUE[1])),
                 ],
             };
             strings.iter().for_each(|(k, v)| {
@@ -1549,11 +1549,11 @@ mod unit {
                 ],
                 f64::MAX.to_string() => vec![
                     ("f64", f64::MAX, Ok(()), None),
-                    ("f32", 0., Err(()), Some(INTEGRAL_TRUNCATION)),
+                    ("f32", 0., Err(()), Some(INTEGRAL_TRUNCATION[1])),
                 ],
                 "foo".to_string() => vec![
-                    ("f64", 0., Err(()), Some(INVALID_CHARACTER_VALUE)),
-                    ("f32", 0., Err(()), Some(INVALID_CHARACTER_VALUE)),
+                    ("f64", 0., Err(()), Some(INVALID_CHARACTER_VALUE[1])),
+                    ("f32", 0., Err(()), Some(INVALID_CHARACTER_VALUE[1])),
                 ],
             };
             strings.iter().for_each(|(k, v)| {
@@ -1568,9 +1568,9 @@ mod unit {
             let int_64s: HashMap<i64, V> = map! {
                 i64::MAX => vec![
                     ("i64", i64::MAX, Ok(()), None),
-                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION)),
+                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
                     ("u64", i64::MAX, Ok(()), None),
-                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION))
+                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1]))
                 ],
                 i32::MAX as i64 => vec![
                     ("i64", i32::MAX as i64, Ok(()), None),
@@ -1580,15 +1580,15 @@ mod unit {
                 ],
                 i64::MIN => vec![
                     ("i64", i64::MIN, Ok(()), None),
-                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u64", 0i64, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION))
+                    ("i32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u64", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0i64, Err(()), Some(INTEGRAL_TRUNCATION[1]))
                 ],
                 i32::MIN as i64 => vec![
                     ("i64", i32::MIN as i64, Ok(()), None),
                     ("i32", i32::MIN as i64, Ok(()), None),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION))
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1]))
                 ],
             };
 
@@ -1611,8 +1611,8 @@ mod unit {
                 i32::MIN => vec![
                     ("i64", i32::MIN, Ok(()), None),
                     ("i32", i32::MIN, Ok(()), None),
-                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION)),
-                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION))
+                    ("u64", 0, Err(()), Some(INTEGRAL_TRUNCATION[1])),
+                    ("u32", 0, Err(()), Some(INTEGRAL_TRUNCATION[1]))
                 ]
             };
 
@@ -1663,7 +1663,7 @@ mod unit {
                     "2014-11-28 09:23:24.1234567890",
                     datetime_expectation_millis,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
                 (
                     "2014-11-28T09:23:24.123456789Z",
@@ -1675,32 +1675,32 @@ mod unit {
                     "2014-11-28T09:23:24.1234567890Z",
                     datetime_expectation_millis,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
                 ("2014-11-28", date_expectation, Ok(()), None),
                 (
                     "11/28/2014",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT),
+                    Some(INVALID_DATETIME_FORMAT[1]),
                 ),
                 (
                     "2014-35-80",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT),
+                    Some(INVALID_DATETIME_FORMAT[1]),
                 ),
                 (
                     "2014-30-90 09:23:24.1234567890",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT),
+                    Some(INVALID_DATETIME_FORMAT[1]),
                 ),
                 (
                     "30:23:24",
                     datetime_expectation_no_millis,
                     Err(()),
-                    Some(INVALID_DATETIME_FORMAT),
+                    Some(INVALID_DATETIME_FORMAT[1]),
                 ),
                 (
                     "09:23:24",
@@ -1718,7 +1718,7 @@ mod unit {
                     "09:23:24.1234567898",
                     today_plus_time_millis_expectation,
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
             ];
             test_cases
@@ -1750,13 +1750,17 @@ mod unit {
             let date_expectation = NaiveDate::from_ymd_opt(2014, 11, 28).unwrap();
             let test_cases: Vec<(&str, Result<(), ()>, Option<&'static str>)> = vec![
                 ("2014-11-28", Ok(()), None),
-                ("11/28/2014", Err(()), Some(INVALID_DATETIME_FORMAT)),
-                ("2014-22-22", Err(()), Some(INVALID_DATETIME_FORMAT)),
-                ("10:15:30", Err(()), Some(INVALID_DATETIME_FORMAT)),
+                ("11/28/2014", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                ("2014-22-22", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                ("10:15:30", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
                 ("2014-11-28 00:00:00", Ok(()), None),
                 ("2014-11-28 00:00:00.000", Ok(()), None),
                 ("2014-11-28T00:00:00Z", Ok(()), None),
-                ("2014-11-28 10:15:30", Ok(()), Some(FRACTIONAL_TRUNCATION)),
+                (
+                    "2014-11-28 10:15:30",
+                    Ok(()),
+                    Some(FRACTIONAL_TRUNCATION[1]),
+                ),
             ];
             test_cases.iter().for_each(|(input, result, info)| {
                 match result {
@@ -1787,7 +1791,7 @@ mod unit {
                 ("2014-11-28T00:00:00Z".parse().unwrap(), None),
                 (
                     "2014-11-28T10:15:30.123Z".parse().unwrap(),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
             ];
             test_cases.iter().for_each(|(input, info)| {
@@ -1806,14 +1810,14 @@ mod unit {
             let test_cases: Vec<(&str, Result<(), ()>, Option<&'static str>)> = vec![
                 ("10:15:30", Ok(()), None),
                 ("10:15:30.00000", Ok(()), None),
-                ("10:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT)),
-                ("25:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT)),
-                ("2022-10-15", Err(()), Some(INVALID_DATETIME_FORMAT)),
+                ("10:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                ("25:15:30.123", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
+                ("2022-10-15", Err(()), Some(INVALID_DATETIME_FORMAT[1])),
                 ("2014-11-28 10:15:30.000", Ok(()), None),
                 (
                     "2014-11-28 10:15:30.1243",
                     Ok(()),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
             ];
             test_cases.iter().for_each(|(input, result, info)| {
@@ -1845,7 +1849,7 @@ mod unit {
                 ("2014-11-28T10:15:30Z".parse().unwrap(), None),
                 (
                     "2014-11-28T10:15:30.123Z".parse().unwrap(),
-                    Some(FRACTIONAL_TRUNCATION),
+                    Some(FRACTIONAL_TRUNCATION[1]),
                 ),
             ];
             test_cases.iter().for_each(|(input, info)| {

--- a/odbc/src/api/definitions.rs
+++ b/odbc/src/api/definitions.rs
@@ -9,6 +9,7 @@ pub enum SqlBool {
 // Environment attributes
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum OdbcVersion {
+    Odbc2 = 2,
     Odbc3 = 3,
     Odbc3_80 = 380,
 }

--- a/odbc/src/api/errors.rs
+++ b/odbc/src/api/errors.rs
@@ -171,7 +171,7 @@ impl ODBCError {
             ODBCError::ConnectionNotOpen => CONNECTION_NOT_OPEN,
         };
         // SQL-1687: use odbc version parameter to map sql state rather than hard coding ODBC 3.x sql states
-        state[1]
+        state.odbc_3_state
     }
 
     pub fn get_native_err_code(&self) -> i32 {

--- a/odbc/src/api/errors.rs
+++ b/odbc/src/api/errors.rs
@@ -59,7 +59,7 @@ pub enum ODBCError {
     IndicatorVariableRequiredButNotSupplied,
     #[error("[{}][API] The field index {0} is out of bounds", VENDOR_IDENTIFIER)]
     InvalidDescriptorIndex(u16),
-    #[error("[{}][API] The field index {0} is out of bounds", VENDOR_IDENTIFIER)]
+    #[error("[{}][API] The column index {0} is out of bounds", VENDOR_IDENTIFIER)]
     InvalidColumnNumber(u16),
     #[error("[{}][API] No ResultSet", VENDOR_IDENTIFIER)]
     InvalidCursorState,

--- a/odbc/src/api/errors.rs
+++ b/odbc/src/api/errors.rs
@@ -135,7 +135,7 @@ pub type Result<T> = std::result::Result<T, ODBCError>;
 
 impl ODBCError {
     pub fn get_sql_state(&self) -> &str {
-        match self {
+        let state = match self {
             ODBCError::Unimplemented(_)
             | ODBCError::UnimplementedDataType(_)
             | ODBCError::UnsupportedDriverConnectOption(_)
@@ -169,7 +169,9 @@ impl ODBCError {
             ODBCError::NoResultSet => NO_RESULTSET,
             ODBCError::UnknownInfoType(_) => INVALID_INFO_TYPE_VALUE,
             ODBCError::ConnectionNotOpen => CONNECTION_NOT_OPEN,
-        }
+        };
+        // SQL-1687: use odbc version parameter to map sql state rather than hard coding ODBC 3.x sql states
+        state[1]
     }
 
     pub fn get_native_err_code(&self) -> i32 {

--- a/odbc/src/api/errors.rs
+++ b/odbc/src/api/errors.rs
@@ -1,10 +1,10 @@
 use constants::{
     CONNECTION_NOT_OPEN, FRACTIONAL_TRUNCATION, GENERAL_ERROR, GENERAL_WARNING,
     INDICATOR_VARIABLE_REQUIRED, INTEGRAL_TRUNCATION, INVALID_ATTRIBUTE_OR_OPTION_IDENTIFIER,
-    INVALID_ATTR_VALUE, INVALID_CHARACTER_VALUE, INVALID_CURSOR_STATE, INVALID_DATETIME_FORMAT,
-    INVALID_DESCRIPTOR_INDEX, INVALID_INFO_TYPE_VALUE, INVALID_SQL_TYPE, NOT_IMPLEMENTED,
-    NO_DSN_OR_DRIVER, NO_RESULTSET, OPTION_CHANGED, PROGRAM_TYPE_OUT_OF_RANGE, RESTRICTED_DATATYPE,
-    RIGHT_TRUNCATED, UNSUPPORTED_FIELD_DESCRIPTOR, VENDOR_IDENTIFIER,
+    INVALID_ATTR_VALUE, INVALID_CHARACTER_VALUE, INVALID_COLUMN_NUMBER, INVALID_CURSOR_STATE,
+    INVALID_DATETIME_FORMAT, INVALID_DESCRIPTOR_INDEX, INVALID_INFO_TYPE_VALUE, INVALID_SQL_TYPE,
+    NOT_IMPLEMENTED, NO_DSN_OR_DRIVER, NO_RESULTSET, OPTION_CHANGED, PROGRAM_TYPE_OUT_OF_RANGE,
+    RESTRICTED_DATATYPE, RIGHT_TRUNCATED, UNSUPPORTED_FIELD_DESCRIPTOR, VENDOR_IDENTIFIER,
 };
 use thiserror::Error;
 
@@ -59,6 +59,8 @@ pub enum ODBCError {
     IndicatorVariableRequiredButNotSupplied,
     #[error("[{}][API] The field index {0} is out of bounds", VENDOR_IDENTIFIER)]
     InvalidDescriptorIndex(u16),
+    #[error("[{}][API] The field index {0} is out of bounds", VENDOR_IDENTIFIER)]
+    InvalidColumnNumber(u16),
     #[error("[{}][API] No ResultSet", VENDOR_IDENTIFIER)]
     InvalidCursorState,
     #[error("[{}][API] Invalid SQL Type: {0}", VENDOR_IDENTIFIER)]
@@ -156,6 +158,7 @@ impl ODBCError {
             ODBCError::MissingDriverOrDSNProperty => NO_DSN_OR_DRIVER,
             ODBCError::UnsupportedFieldDescriptor(_) => UNSUPPORTED_FIELD_DESCRIPTOR,
             ODBCError::InvalidDescriptorIndex(_) => INVALID_DESCRIPTOR_INDEX,
+            ODBCError::InvalidColumnNumber(_) => INVALID_COLUMN_NUMBER,
             ODBCError::InvalidSqlType(_) => INVALID_SQL_TYPE,
             ODBCError::RestrictedDataType(_, _) => RESTRICTED_DATATYPE,
             ODBCError::FractionalTruncation(_) => FRACTIONAL_TRUNCATION,
@@ -197,6 +200,7 @@ impl ODBCError {
             | ODBCError::UnsupportedFieldSchema()
             | ODBCError::OptionValueChanged(_, _)
             | ODBCError::InvalidDescriptorIndex(_)
+            | ODBCError::InvalidColumnNumber(_)
             | ODBCError::RestrictedDataType(_, _)
             | ODBCError::IndicatorVariableRequiredButNotSupplied
             | ODBCError::FractionalTruncation(_)

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -813,7 +813,7 @@ pub unsafe extern "C" fn SQLDescribeColW(
                     );
                 }
             }
-            add_diag_info!(stmt_handle, ODBCError::InvalidDescriptorIndex(col_number));
+            add_diag_info!(stmt_handle, ODBCError::InvalidColumnNumber(col_number));
 
             SqlReturn::ERROR
         },

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3096,17 +3096,18 @@ unsafe fn sql_set_env_attrw_helper(
     match attribute {
         EnvironmentAttribute::SQL_ATTR_ODBC_VERSION => {
             match FromPrimitive::from_i32(value_ptr as i32) {
-                Some(version) => {
-                    env.attributes.write().unwrap().odbc_ver = version;
-                    SqlReturn::SUCCESS
-                }
-                None => {
+                // SQL-1690: add support for ODBC2 in SQLSetEnvAttr
+                Some(OdbcVersion::Odbc2) | None => {
                     add_diag_with_function!(
                         env_handle,
                         ODBCError::InvalidAttrValue("SQL_ATTR_ODBC_VERSION"),
                         "SQLSetEnvAttrW"
                     );
                     SqlReturn::ERROR
+                }
+                Some(version) => {
+                    env.attributes.write().unwrap().odbc_ver = version;
+                    SqlReturn::SUCCESS
                 }
             }
         }

--- a/odbc/tests/connection_tests.rs
+++ b/odbc/tests/connection_tests.rs
@@ -24,7 +24,8 @@ macro_rules! test_connection_diagnostics {
             let mut env_handl: Handle = null_mut();
             let mut conn_handl: Handle = null_mut();
 
-            let mut expected_sql_state_encoded = cstr::to_widechar_vec(expected_sql_state[1]);
+            let mut expected_sql_state_encoded =
+                cstr::to_widechar_vec(expected_sql_state.odbc_3_state);
             expected_sql_state_encoded.push(0);
             let mut in_connection_string_encoded = cstr::to_widechar_vec(in_connection_string);
             in_connection_string_encoded.push(0);
@@ -53,7 +54,7 @@ macro_rules! test_connection_diagnostics {
                 HandleType::Dbc,
                 conn_handl as *mut _,
                 1,
-                expected_sql_state[1],
+                expected_sql_state.odbc_3_state,
                 expected_error_message,
                 0,
             );

--- a/odbc/tests/connection_tests.rs
+++ b/odbc/tests/connection_tests.rs
@@ -24,7 +24,7 @@ macro_rules! test_connection_diagnostics {
             let mut env_handl: Handle = null_mut();
             let mut conn_handl: Handle = null_mut();
 
-            let mut expected_sql_state_encoded = cstr::to_widechar_vec(expected_sql_state);
+            let mut expected_sql_state_encoded = cstr::to_widechar_vec(expected_sql_state[1]);
             expected_sql_state_encoded.push(0);
             let mut in_connection_string_encoded = cstr::to_widechar_vec(in_connection_string);
             in_connection_string_encoded.push(0);
@@ -53,7 +53,7 @@ macro_rules! test_connection_diagnostics {
                 HandleType::Dbc,
                 conn_handl as *mut _,
                 1,
-                expected_sql_state,
+                expected_sql_state[1],
                 expected_error_message,
                 0,
             );


### PR DESCRIPTION
- Turns sql states into a list of length 2 to store both odbc 2 and odbc 3 sql states
- add odbc 2 to odbc version enum
- error if odbc 2 is set in SQLSetEnvAttr