### PR TITLE
SQL-1685: add function to get odbc version from any mongo handle

### DIFF
--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -92,6 +92,31 @@ impl MongoHandle {
         }
     }
 
+    /// get the odbc_version from the underlying env handle, used to handle
+    /// behavior that is different between odbc versions properly
+    pub fn odbc_version(&mut self) -> OdbcVersion {
+        let env = match self {
+            MongoHandle::Env(_) => self,
+            MongoHandle::Connection(conn) => conn.env,
+            MongoHandle::Descriptor(Descriptor {
+                connection: conn, ..
+            })
+            | MongoHandle::Statement(Statement {
+                connection: conn, ..
+            }) => unsafe { conn.as_ref().unwrap().as_connection().unwrap().env },
+        };
+        unsafe {
+            env.as_ref()
+                .unwrap()
+                .as_env()
+                .unwrap()
+                .attributes
+                .read()
+                .unwrap()
+                .odbc_ver
+        }
+    }
+
     ///
     /// Generate a String containing the current handle and its parents address.
     ///

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -94,7 +94,7 @@ impl MongoHandle {
 
     /// get the odbc_version from the underlying env handle, used to handle
     /// behavior that is different between odbc versions properly
-    pub fn odbc_version(&mut self) -> OdbcVersion {
+    pub fn get_odbc_version(&mut self) -> OdbcVersion {
         let env = match self {
             MongoHandle::Env(_) => self,
             MongoHandle::Connection(conn) => conn.env,

--- a/odbc/src/handles/unit.rs
+++ b/odbc/src/handles/unit.rs
@@ -390,12 +390,12 @@ fn test_odbc_ver() {
     ));
 
     // assert correct types for all handles
-    assert_eq!(odbc_2_env_handle.odbc_version(), OdbcVersion::Odbc2);
-    assert_eq!(odbc_2_conn_handle.odbc_version(), OdbcVersion::Odbc2);
-    assert_eq!(odbc_2_desc_handle.odbc_version(), OdbcVersion::Odbc2);
-    assert_eq!(odbc_2_stmt_handle.odbc_version(), OdbcVersion::Odbc2);
-    assert_eq!(odbc_3_env_handle.odbc_version(), OdbcVersion::Odbc3_80);
-    assert_eq!(odbc_3_conn_handle.odbc_version(), OdbcVersion::Odbc3_80);
-    assert_eq!(odbc_3_desc_handle.odbc_version(), OdbcVersion::Odbc3_80);
-    assert_eq!(odbc_3_stmt_handle.odbc_version(), OdbcVersion::Odbc3_80);
+    assert_eq!(odbc_2_env_handle.get_odbc_version(), OdbcVersion::Odbc2);
+    assert_eq!(odbc_2_conn_handle.get_odbc_version(), OdbcVersion::Odbc2);
+    assert_eq!(odbc_2_desc_handle.get_odbc_version(), OdbcVersion::Odbc2);
+    assert_eq!(odbc_2_stmt_handle.get_odbc_version(), OdbcVersion::Odbc2);
+    assert_eq!(odbc_3_env_handle.get_odbc_version(), OdbcVersion::Odbc3_80);
+    assert_eq!(odbc_3_conn_handle.get_odbc_version(), OdbcVersion::Odbc3_80);
+    assert_eq!(odbc_3_desc_handle.get_odbc_version(), OdbcVersion::Odbc3_80);
+    assert_eq!(odbc_3_stmt_handle.get_odbc_version(), OdbcVersion::Odbc3_80);
 }


### PR DESCRIPTION
This will enable functions to get the odbc version from any arbitrary handle passed in, i.e.,
```
let mongo_handle = MongoHandleRef::from(statement_handle);
let odbc_ver = mongo_handle.odbc_ver();
```

This can then be used to fork behavior based on odbc version -- namely in `SQLTables` and the `SQLGetDiag*` funcs.