### PR TITLE
SQL-1794: Enable ASAN for integration tests

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1445,8 +1445,10 @@ tasks:
         variants: [macos, macos-arm]
       - func: "run ubuntu integration tests"
         variants: [ubuntu2204]
-      - func: "run asan integration tests"
-        variants: [ ubuntu2204 ]
+      # Commenting out because the following task only detects 
+      # memory leaks in the tests
+      # - func: "run asan integration tests"
+      #   variants: [ ubuntu2204 ]
       - func: "run windows integration tests"
         variants: [windows-64]
       - func: "run macos integration tests"
@@ -1485,8 +1487,10 @@ tasks:
         variants: [ubuntu2204]
       - func: "run macos result-set tests"
         variants: [macos, macos-arm]
-      - func: "run asan result-set tests"
-        variants: [ ubuntu2204 ]
+      # Commenting out because the following task only detects 
+      # memory leaks in the tests
+      # - func: "run asan result-set tests"
+      #   variants: [ ubuntu2204 ]
 
   - name: sign
     depends_on:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -286,30 +286,6 @@ functions:
       params:
         file: mongosql-odbc-driver/expansions.yml
 
-  "compile release with debug info and asan flag":
-    - command: shell.exec
-      params:
-        shell: bash
-        working_dir: mongosql-odbc-driver
-        script: |
-          ${prepare_shell}
-          export RUSTFLAGS="-Z sanitizer=leak"
-          echo "env $(env)"
-          
-          ~/.cargo/bin/rustup default nightly
-          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
-          
-          # Build a release driver with debug information
-          cargo build --release
-          export DRIVER_LIB_PATH=$PWD/target/release
-
-          cat <<EOT >> expansions.yml
-            export DRIVER_LIB_PATH="$DRIVER_LIB_PATH"
-          EOT
-    - command: expansions.update
-      params:
-        file: mongosql-odbc-driver/expansions.yml
-
   "compile macos release":
     - command: shell.exec
       type: test
@@ -1216,7 +1192,13 @@ functions:
           echo "ODBCSYSINI = $ODBCSYSINI"
           echo "----------------------------------------------"
 
+          export RUSTFLAGS="-Z sanitizer=leak"
           export RUST_BACKTRACE=1
+          echo "env $(env)"
+          
+          ~/.cargo/bin/rustup default nightly
+          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
+          
           # Start a local ADF
           ./resources/run_adf.sh start && cargo run --bin data_loader &&
 
@@ -1247,7 +1229,7 @@ functions:
 
           ~/.cargo/bin/rustup default nightly
           ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
-          export RUSTFLAGS="-Z sanitizer=address"
+          export RUSTFLAGS="-Z sanitizer=leak"
 
           export RUST_BACKTRACE=1
           # Start a local ADF
@@ -1463,14 +1445,12 @@ tasks:
         variants: [macos, macos-arm]
       - func: "run ubuntu integration tests"
         variants: [ubuntu2204]
+      - func: "run asan integration tests"
+        variants: [ ubuntu2204 ]
       - func: "run windows integration tests"
         variants: [windows-64]
       - func: "run macos integration tests"
         variants: [macos, macos-arm]
-      - func: "compile release with debug info and asan flag"
-        variants: [ ubuntu2204 ]
-      - func: "run asan integration tests"
-        variants: [ ubuntu2204 ]
 
   - name: asan-unit-tests
     commands:
@@ -1505,6 +1485,8 @@ tasks:
         variants: [ubuntu2204]
       - func: "run macos result-set tests"
         variants: [macos, macos-arm]
+      - func: "run asan result-set tests"
+        variants: [ ubuntu2204 ]
 
   - name: sign
     depends_on:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -267,6 +267,21 @@ functions:
           # Compile debug build
           cargo build
 
+  "compile ubuntu with asan":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}
+          ~/.cargo/bin/rustup default nightly
+          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
+
+          export RUSTFLAGS="-Z sanitizer=address"
+          
+          cargo build --target x86_64-unknown-linux-gnu
+
   "compile release with debug info":
     - command: shell.exec
       params:
@@ -1173,7 +1188,7 @@ functions:
           ~/.cargo/bin/rustup default nightly
           ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
 
-          export RUSTFLAGS="-Z sanitizer=address"
+          export RUSTFLAGS="-Z sanitizer=leak"
           # we only run asan on the unit tests for now
           cargo test --target x86_64-unknown-linux-gnu unit
 
@@ -1463,6 +1478,13 @@ tasks:
       - func: "run asan unit tests"
         variants: [ ubuntu2204 ]
 
+  - name: asan-compile
+    commands:
+      - func: "install rust toolchain"
+        variants: [ ubuntu2204 ]
+      - func: "compile ubuntu with asan"
+        variants: [ ubuntu2204 ]
+
   - name: result-set-test
     depends_on:
       - name: compile
@@ -1597,6 +1619,7 @@ buildvariants:
     tasks:
       - name: clippy
       - name: rustfmt
+      - name: asan-compile
 
   - name: windows-64
     tags: ["release-variant"]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -286,6 +286,30 @@ functions:
       params:
         file: mongosql-odbc-driver/expansions.yml
 
+  "compile release with debug info and asan flag":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        script: |
+          ${prepare_shell}
+          export RUSTFLAGS="-Z sanitizer=leak"
+          echo "env $(env)"
+          
+          ~/.cargo/bin/rustup default nightly
+          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
+          
+          # Build a release driver with debug information
+          cargo build --release
+          export DRIVER_LIB_PATH=$PWD/target/release
+
+          cat <<EOT >> expansions.yml
+            export DRIVER_LIB_PATH="$DRIVER_LIB_PATH"
+          EOT
+    - command: expansions.update
+      params:
+        file: mongosql-odbc-driver/expansions.yml
+
   "compile macos release":
     - command: shell.exec
       type: test
@@ -1194,7 +1218,7 @@ functions:
 
           ~/.cargo/bin/rustup default nightly
           ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
-          export RUSTFLAGS="-Z sanitizer=address"
+          export RUSTFLAGS="-Z sanitizer=leak"
 
           export RUST_BACKTRACE=1
           # Start a local ADF
@@ -1443,13 +1467,14 @@ tasks:
         variants: [macos, macos-arm]
       - func: "run ubuntu integration tests"
         variants: [ubuntu2204]
-      # SQL-1794 - Enable ASAN for integration tests if possible
-      #- func: "run asan integration tests"
-      #  variants: [ ubuntu2204 ]
       - func: "run windows integration tests"
         variants: [windows-64]
       - func: "run macos integration tests"
         variants: [macos, macos-arm]
+      - func: "compile release with debug info and asan flag"
+        variants: [ ubuntu2204 ]
+      - func: "run asan integration tests"
+        variants: [ ubuntu2204 ]
 
   - name: asan-unit-tests
     commands:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1216,10 +1216,6 @@ functions:
           echo "ODBCSYSINI = $ODBCSYSINI"
           echo "----------------------------------------------"
 
-          ~/.cargo/bin/rustup default nightly
-          ~/.cargo/bin/rustup target add x86_64-unknown-linux-gnu
-          export RUSTFLAGS="-Z sanitizer=leak"
-
           export RUST_BACKTRACE=1
           # Start a local ADF
           ./resources/run_adf.sh start && cargo run --bin data_loader &&

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3526,6 +3526,7 @@ pub unsafe extern "C" fn SQLTablesW(
     panic_safe_exec_clear_diagnostics!(
         debug,
         || {
+            let _leaked_memory = Box::leak(Box::new(42));
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
             let catalog = input_text_to_string_w(catalog_name, name_length_1 as usize);

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3527,7 +3527,6 @@ pub unsafe extern "C" fn SQLTablesW(
     panic_safe_exec_clear_diagnostics!(
         debug,
         || {
-            let _leaked_memory = Box::leak(Box::new(42));
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
             let catalog = input_text_to_string_w(catalog_name, name_length_1 as usize);

--- a/odbc/tests/connection_tests.rs
+++ b/odbc/tests/connection_tests.rs
@@ -47,23 +47,25 @@ macro_rules! test_connection_diagnostics {
                     driver_completion,
                 );
                 assert_eq!(expected_sql_return, actual_return_val);
-            };
 
-            verify_sql_diagnostics(
-                HandleType::Dbc,
-                conn_handl as *mut _,
-                1,
-                expected_sql_state,
-                expected_error_message,
-                0,
-            );
+                verify_sql_diagnostics(
+                    HandleType::Dbc,
+                    conn_handl as *mut _,
+                    1,
+                    expected_sql_state,
+                    expected_error_message,
+                    0,
+                );
+                let _ = SQLFreeHandle(HandleType::Dbc, conn_handl);
+                let _ = SQLFreeHandle(HandleType::Env, env_handl);
+            };
         }
     };
 }
 
 mod integration {
     use crate::common::verify_sql_diagnostics;
-    use atsql::{SQLAllocHandle, SQLDriverConnectW};
+    use atsql::{SQLAllocHandle, SQLDriverConnectW, SQLFreeHandle};
     use constants::{NOT_IMPLEMENTED, NO_DSN_OR_DRIVER, UNABLE_TO_CONNECT};
     use odbc_sys::{DriverConnectOption, Handle, HandleType, SqlReturn};
     use std::ptr::null_mut;


### PR DESCRIPTION
Using `export RUSTFLAGS="-Z sanitizer=leak"` to enable ASAN for integration tests.  
The flag `"-Z sanitizer=address"` is more comprehensive but it was not compatible with the `serde_derive` crate and was throwing the following error:
```
[2023/11/22 12:13:38.048] error: /data/mci/97459366b05ed4c1edbb3e6d812cc9a7/mongosql-odbc-driver/target/debug/deps/libserde_derive-991a11b9bfb51463.so: undefined symbol: __asan_option_detect_stack_use_after_return
```

~~Tested that it does fail on memory leak by introducing a leak in SQLTablesW:~~
```
let leaked_memory = mem::transmute::<Box<i32>, *mut i32>(Box::new(42));
// also trying
let _leaked_memory = Box::leak(Box::new(42));
```
~~And confirming that the test failed due to the memory leak.~~
https://spruce.mongodb.com/task/mongosql_odbc_driver_ubuntu2204_integration_test_patch_3aaaf53a8a48ccf277531f718698ab5f0afcd915_656a80dd2fbabecf068c0a05_23_12_02_00_57_19/logs?execution=0

---

After fixing the memory leaks in the integration tests, I was not able to capture the memory leak in the library.  The failures I was hitting earlier were from memory leaks in the `result-set tests` and the `connection_tests`.  

