### PR TITLE
SQL-1850: add LogLevel to dsn iterator

### DIFF
--- a/setup/setupDSN.reg
+++ b/setup/setupDSN.reg
@@ -12,6 +12,7 @@ Windows Registry Editor Version 5.00
 "uri"="%ADF_TEST_URI%"
 "user"="%ADF_TEST_USER%"
 "database"="%ADF_TEST_DB%"
+"loglevel"="info"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources]
 "ADF_Test"="MongoDB Atlas SQL ODBC Driver"

--- a/setup/setupDSN.reg
+++ b/setup/setupDSN.reg
@@ -12,7 +12,6 @@ Windows Registry Editor Version 5.00
 "uri"="%ADF_TEST_URI%"
 "user"="%ADF_TEST_USER%"
 "database"="%ADF_TEST_DB%"
-"loglevel"="info"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources]
 "ADF_Test"="MongoDB Atlas SQL ODBC Driver"

--- a/shared_sql_utils/src/dsn.rs
+++ b/shared_sql_utils/src/dsn.rs
@@ -13,7 +13,6 @@ const SERVER: &str = "server";
 const UID: &str = "uid";
 const URI: &str = "uri";
 const USER: &str = "user";
-const LOGLEVEL: &str = "loglevel";
 // SQL-1281
 // const LOGPATH: &str = "LOGPATH";
 
@@ -54,7 +53,6 @@ pub struct Dsn {
     pub user: String,
     pub server: String,
     pub driver_name: String,
-    pub log_level: Option<String>,
 }
 
 impl Dsn {
@@ -78,7 +76,6 @@ impl Dsn {
                 user: args.user.into(),
                 server: args.server.into(),
                 driver_name: args.driver_name.into(),
-                log_level: None,
             })
         } else if !validation[1] {
             Err(DsnError::Dsn(args.dsn.into()))
@@ -207,7 +204,6 @@ impl Dsn {
             URI => self.uri = value.to_string(),
             USER => self.user = value.to_string(),
             UID => self.user = value.to_string(),
-            LOGLEVEL => self.log_level = Some(value.to_string()),
             // SQL-1281
             // LOGPATH => self.logpath = value.to_string(),
             _ => {}

--- a/shared_sql_utils/src/dsn.rs
+++ b/shared_sql_utils/src/dsn.rs
@@ -249,6 +249,7 @@ impl<'a> DSNIterator<'a> {
                 ("Password", &dsn_opts.password),
                 ("Uri", &dsn_opts.uri),
                 ("User", &dsn_opts.user),
+                ("LogLevel", &dsn_opts.log_level),
                 // SQL-1281
                 // ("Logpath", &dsn_opts.logpath),
             ],

--- a/shared_sql_utils/src/dsn.rs
+++ b/shared_sql_utils/src/dsn.rs
@@ -43,7 +43,6 @@ pub struct DsnArgs<S: Into<String> + Copy> {
     pub user: S,
     pub server: S,
     pub driver_name: S,
-    pub log_level: S,
 }
 
 #[derive(Debug, Default)]
@@ -55,7 +54,7 @@ pub struct Dsn {
     pub user: String,
     pub server: String,
     pub driver_name: String,
-    pub log_level: String,
+    pub log_level: Option<String>,
 }
 
 impl Dsn {
@@ -79,7 +78,7 @@ impl Dsn {
                 user: args.user.into(),
                 server: args.server.into(),
                 driver_name: args.driver_name.into(),
-                log_level: args.log_level.into(),
+                log_level: None,
             })
         } else if !validation[1] {
             Err(DsnError::Dsn(args.dsn.into()))
@@ -208,7 +207,7 @@ impl Dsn {
             URI => self.uri = value.to_string(),
             USER => self.user = value.to_string(),
             UID => self.user = value.to_string(),
-            LOGLEVEL => self.log_level = value.to_string(),
+            LOGLEVEL => self.log_level = Some(value.to_string()),
             // SQL-1281
             // LOGPATH => self.logpath = value.to_string(),
             _ => {}
@@ -249,7 +248,6 @@ impl<'a> DSNIterator<'a> {
                 ("Password", &dsn_opts.password),
                 ("Uri", &dsn_opts.uri),
                 ("User", &dsn_opts.user),
-                ("LogLevel", &dsn_opts.log_level),
                 // SQL-1281
                 // ("Logpath", &dsn_opts.logpath),
             ],
@@ -279,7 +277,6 @@ mod test {
             user: "test",
             server: "test",
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_err());
     }
@@ -294,7 +291,6 @@ mod test {
             user: "test",
             server: "test",
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_err());
     }
@@ -309,7 +305,6 @@ mod test {
             user: "test",
             server: "test",
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_err());
     }
@@ -324,7 +319,6 @@ mod test {
             user: "test",
             server: "t".repeat(MAX_VALUE_LENGTH + 1).as_str(),
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_err());
     }
@@ -339,7 +333,6 @@ mod test {
             server: "test",
             user: "t".repeat(MAX_VALUE_LENGTH + 1).as_str(),
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_err());
     }
@@ -354,7 +347,6 @@ mod test {
             server: "test",
             user: "test",
             driver_name: "test",
-            log_level: "info",
         });
         assert!(dsn_opts.is_ok());
     }

--- a/win_setupgui/src/gui.rs
+++ b/win_setupgui/src/gui.rs
@@ -82,14 +82,6 @@ pub struct ConfigGui {
     #[nwg_layout_item(layout: grid,  row: 5, col: 2, col_span: 7)]
     database_input: nwg::TextInput,
 
-    #[nwg_control(flags: "VISIBLE", text: "Log Level")]
-    #[nwg_layout_item(layout: grid,  row: 6, col: 0, col_span: 2)]
-    log_level_field: nwg::Label,
-
-    #[nwg_control(flags: "VISIBLE", text: "Info")]
-    #[nwg_layout_item(layout: grid,  row: 6, col: 3, col_span: 6)]
-    log_level_input: nwg::TextInput,
-
     #[nwg_control(flags: "VISIBLE", text: "Test")]
     #[nwg_events( OnButtonClick: [ConfigGui::test_connection] )]
     #[nwg_layout_item(layout: grid,  row: 10, col: 0, col_span: 1)]
@@ -134,25 +126,13 @@ impl ConfigGui {
             self.password_input.text().is_empty(),
             self.mongodb_uri_input.text().is_empty(),
             self.user_input.text().is_empty(),
-            self.log_level_input.text().is_empty(),
         ) {
-            (false, false, false, false, false, false) => {}
+            (false, false, false, false, false) => {}
             _ => {
                 nwg::modal_error_message(
                     &self.window,
                     "Error",
                     "All fields are required and cannot be empty.",
-                );
-                return None;
-            }
-        }
-        match self.log_level_input.text().to_lowercase().as_str() {
-            "info" | "debug" | "error" => {}
-            _ => {
-                nwg::modal_error_message(
-                    &self.window,
-                    "Error",
-                    "Log level must be one of: Info, Debug, Error.",
                 );
                 return None;
             }
@@ -165,7 +145,6 @@ impl ConfigGui {
             user: self.user_input.text().as_str(),
             server: "",
             driver_name: self.driver_name.text().as_str(),
-            log_level: self.log_level_input.text().as_str(),
         }) {
             Err(e) => {
                 nwg::modal_error_message(&self.window, "Error", &e.to_string());


### PR DESCRIPTION
This allows the log level to be written / read properly, so that the odbc configuration (set via dsn, or registry file) will be used by the driver.

Ubuntu tests are failing, but appears to not be related -- periodic build started failing 12/29: https://spruce.mongodb.com/variant-history/mongosql-odbc-driver/ubuntu2204?selectedCommit=521