### PR TITLE
SQL-1828: Directly compare OdbcStates in data.rs unit tests

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -23,7 +23,7 @@ lazy_static! {
     pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub struct OdbcState<'a> {
     pub odbc_2_state: &'a str,
     pub odbc_3_state: &'a str,

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -23,6 +23,7 @@ lazy_static! {
     pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
 }
 
+#[derive(PartialEq, Debug)]
 pub struct OdbcState<'a> {
     pub odbc_2_state: &'a str,
     pub odbc_3_state: &'a str,


### PR DESCRIPTION
This PR updates the `data.rs` unit tests to directly compare `OdbcState`s. To achieve this, we derive `PartialEq, Debug, Copy, Clone` on the `OdbcState` type.