### PR TITLE
SQL-1867: implement additional connection attributes

### DIFF
--- a/definitions/src/desc.rs
+++ b/definitions/src/desc.rs
@@ -189,3 +189,12 @@ pub enum Desc {
     #[cfg(feature = "odbc_version_4")]
     SQL_DESC_MIME_TYPE = 36,
 }
+
+/// Used in `SQLColAttributeW`.
+#[allow(non_camel_case_types)]
+#[repr(u16)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AllocType {
+    SQL_DESC_ALLOC_AUTO = 1,
+    SQL_DESC_ALLOC_USER = 2,
+}

--- a/odbc/src/api/connect_attr_tests.rs
+++ b/odbc/src/api/connect_attr_tests.rs
@@ -247,12 +247,7 @@ mod unit {
     #[test]
     fn set_invalid_attr() {
         unsafe {
-            for attr in [
-                &UNSUPPORTED_ATTRS[..],
-                &[ConnectionAttribute::SQL_ATTR_CONNECTION_TIMEOUT][..],
-            ]
-            .concat()
-            {
+            for attr in UNSUPPORTED_ATTRS {
                 let conn = Connection::with_state(std::ptr::null_mut(), ConnectionState::Connected);
                 let mongo_handle: *mut _ = &mut MongoHandle::Connection(conn);
 

--- a/odbc/src/api/connect_attr_tests.rs
+++ b/odbc/src/api/connect_attr_tests.rs
@@ -139,6 +139,15 @@ mod unit {
             expected_value = 42u32,
             actual_value_modifier = modify_numeric_attr,
         );
+
+        test_get_attr!(
+            connection_dead,
+            attribute = ConnectionAttribute::SQL_ATTR_CONNECTION_DEAD as i32,
+            expected_sql_return = SqlReturn::SUCCESS,
+            expected_length = std::mem::size_of::<u32>() as i32,
+            expected_value = 1u32,
+            actual_value_modifier = modify_numeric_attr,
+        );
     }
 
     // Test setting LoginTimeout attribute.
@@ -190,7 +199,7 @@ mod unit {
         }
     }
 
-    const UNSUPPORTED_ATTRS: [ConnectionAttribute; 19] = [
+    const UNSUPPORTED_ATTRS: [ConnectionAttribute; 18] = [
         ConnectionAttribute::SQL_ATTR_ASYNC_ENABLE,
         ConnectionAttribute::SQL_ATTR_ACCESS_MODE,
         ConnectionAttribute::SQL_ATTR_AUTOCOMMIT,
@@ -207,7 +216,6 @@ mod unit {
         ConnectionAttribute::SQL_ATTR_ASYNC_DBC_EVENT,
         ConnectionAttribute::SQL_ATTR_ENLIST_IN_DTC,
         ConnectionAttribute::SQL_ATTR_ENLIST_IN_XA,
-        ConnectionAttribute::SQL_ATTR_CONNECTION_DEAD,
         ConnectionAttribute::SQL_ATTR_AUTO_IPD,
         ConnectionAttribute::SQL_ATTR_METADATA_ID,
     ];

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1458,7 +1458,7 @@ unsafe fn sql_get_connect_attrw_helper(
             }
             // according to the spec, SQL_ATTR_CONNECTION_DEAD just returns the latest status of the connection, not the current status
             ConnectionAttribute::SQL_ATTR_CONNECTION_DEAD => {
-                let connection_dead = match *conn.mongo_connection.write().unwrap() {
+                let connection_dead = match *conn.mongo_connection.read().unwrap() {
                     Some(_) => SqlBool::SQL_FALSE,
                     None => SqlBool::SQL_TRUE,
                 };

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -15,12 +15,12 @@ use constants::*;
 use cstr::{input_text_to_string_w, Charset, WideChar};
 
 use definitions::{
-    AsyncEnable, AttrConnectionPooling, AttrCpMatch, AttrOdbcVersion, CDataType, Concurrency,
-    ConnectionAttribute, CursorScrollable, CursorSensitivity, CursorType, Desc, DiagType,
-    DriverConnectOption, EnvironmentAttribute, FetchOrientation, FreeStmtOption, HDbc, HDesc, HEnv,
-    HStmt, HWnd, Handle, HandleType, Integer, Len, NoScan, Nullability, Pointer, RetCode,
-    RetrieveData, SmallInt, SqlBool, SqlDataType, SqlReturn, StatementAttribute, ULen, USmallInt,
-    UseBookmarks,
+    AllocType, AsyncEnable, AttrConnectionPooling, AttrCpMatch, AttrOdbcVersion, CDataType,
+    Concurrency, ConnectionAttribute, CursorScrollable, CursorSensitivity, CursorType, Desc,
+    DiagType, DriverConnectOption, EnvironmentAttribute, FetchOrientation, FreeStmtOption, HDbc,
+    HDesc, HEnv, HStmt, HWnd, Handle, HandleType, Integer, Len, NoScan, Nullability, Pointer,
+    RetCode, RetrieveData, SmallInt, SqlBool, SqlDataType, SqlReturn, StatementAttribute, ULen,
+    USmallInt, UseBookmarks,
 };
 use function_name::named;
 use log::{debug, error, info};
@@ -583,11 +583,13 @@ pub unsafe extern "C" fn SQLColAttributeW(
                 Desc::SQL_DESC_UNSIGNED => {
                     numeric_col_attr(&|x: &MongoColMetadata| x.is_unsigned as Len)
                 }
+                Desc::SQL_DESC_ALLOC_TYPE => {
+                    numeric_col_attr(&|_| AllocType::SQL_DESC_ALLOC_AUTO as Len)
+                }
                 desc @ (Desc::SQL_DESC_OCTET_LENGTH_PTR
                 | Desc::SQL_DESC_DATETIME_INTERVAL_CODE
                 | Desc::SQL_DESC_INDICATOR_PTR
                 | Desc::SQL_DESC_DATA_PTR
-                | Desc::SQL_DESC_ALLOC_TYPE
                 | Desc::SQL_DESC_ARRAY_SIZE
                 | Desc::SQL_DESC_ARRAY_STATUS_PTR
                 | Desc::SQL_DESC_BIND_OFFSET_PTR

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1454,6 +1454,14 @@ unsafe fn sql_get_connect_attrw_helper(
                 let login_timeout = attributes.login_timeout.unwrap_or(0);
                 i32_len::set_output_fixed_data(&login_timeout, value_ptr, string_length_ptr)
             }
+            // according to the spec, SQL_ATTR_CONNECTION_DEAD just returns the latest status of the connection, not the current status
+            ConnectionAttribute::SQL_ATTR_CONNECTION_DEAD => {
+                let connection_dead = match *conn.mongo_connection.write().unwrap() {
+                    Some(_) => SqlBool::SQL_FALSE,
+                    None => SqlBool::SQL_TRUE,
+                };
+                i32_len::set_output_fixed_data(&connection_dead, value_ptr, string_length_ptr)
+            }
             ConnectionAttribute::SQL_ATTR_CONNECTION_TIMEOUT => {
                 let connection_timeout = attributes.connection_timeout.unwrap_or(0);
                 i32_len::set_output_fixed_data(&connection_timeout, value_ptr, string_length_ptr)


### PR DESCRIPTION
These connection and column attributes allow for SSMS to relay correct errors with a query (both from the application and driver side). Previously, it would output cached errors caused by these.