### PR TITLE
SQL-1915: Switch to feature flags instead of ignore for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.2.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-executor",
+ "async-io 2.3.1",
+ "async-lock 3.3.0",
+ "blocking",
+ "futures-lite 2.2.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "parking",
+ "polling 3.5.0",
+ "rustix 0.38.31",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +231,12 @@ dependencies = [
  "quote",
  "syn 2.0.49",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -159,6 +320,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "piper",
+ "tracing",
+]
+
+[[package]]
 name = "bson"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +473,12 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -431,7 +623,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -468,6 +660,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +726,21 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "finl_unicode"
@@ -552,6 +817,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +909,18 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "hashbrown"
@@ -744,6 +1049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "integration_test"
 version = "0.0.0"
 dependencies = [
@@ -765,6 +1079,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,7 +1097,7 @@ checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
  "socket2 0.5.5",
  "widestring",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
@@ -804,6 +1129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -852,6 +1186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "serde",
+ "value-bag",
 ]
 
 [[package]]
@@ -980,7 +1327,7 @@ checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1011,6 +1358,7 @@ dependencies = [
 name = "mongo-odbc-driver"
 version = "0.0.0"
 dependencies = [
+ "async-std",
  "bson",
  "chrono",
  "constants",
@@ -1194,6 +1542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1609,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1636,36 @@ name = "plotters-backend"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.31",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1423,7 +1818,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1477,6 +1872,33 @@ checksum = "d31b7153270ebf48bf91c65ae5b0c00e749c4cfad505f66530ac74950249582f"
 dependencies = [
  "rustc_version 0.2.3",
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1750,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1926,7 +2348,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2006,6 +2428,22 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "trust-dns-proto"
@@ -2154,10 +2592,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "wasi"
@@ -2188,6 +2638,18 @@ dependencies = [
  "quote",
  "syn 2.0.49",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2309,6 +2771,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2498,7 +2969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -106,7 +106,7 @@ cargo run --bin data_loader
 #### macos
 To run result set sets:
 ```
-cargo test  --features definitions/iodbc,cstr/utf32 -- --ignored
+cargo test --package integration_test --lib test_runner --features definitions/iodbc,cstr/utf32,integration_test/result_set
 ```
 To run integration tests (note: at present, there is still work to be done to ensure these run properly. Some failures are expected):
 ```
@@ -116,7 +116,7 @@ cargo test  --features definitions/iodbc,cstr/utf32 integration
 #### windows
 To run result set sets:
 ```
-cargo test -- --ignored
+cargo test --package integration_test --lib test_runner --features integration_test/result_set
 ```
 To run integration tests (note: at present, there is still work to be done to ensure these run properly. Some failures are expected):
 ```

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,3 +37,6 @@ windows = { version = "0.44.0", features = [
     "Win32_Foundation",
     "Win32_System_Search",
 ] }
+
+[features]
+bad_host = []

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -108,7 +108,7 @@ mod test {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "bad_host")]
     // this test is ignored due to the 30 second connection timeout
     fn bad_host() {
         let mut buffer = [0; 1024];

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -109,7 +109,6 @@ mod test {
 
     #[test]
     #[cfg(feature = "bad_host")]
-    // this test is ignored due to the 30 second connection timeout
     fn bad_host() {
         let mut buffer = [0; 1024];
         let mut buffer_len = 0;

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -977,7 +977,7 @@ functions:
           cargo run --bin data_loader &&
           cargo test integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
           EXITCODE=$?
           echo "****** ls -l ./target/debug/deps *******"
           ls -l ./target/debug/deps
@@ -1081,7 +1081,7 @@ functions:
           # Run integration tests with ubuntu
           cargo test integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
 
           EXITCODE=$?
 
@@ -1154,7 +1154,7 @@ functions:
           # Run integration tests with macos
           cargo test --features definitions/iodbc,cstr/utf32 integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level --features definitions/iodbc,cstr/utf32 -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features definitions/iodbc,cstr/utf32 -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features definitions/iodbc,cstr/utf32,core/bad_host -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1233,7 +1233,7 @@ functions:
           # Run integration tests with asan
           cargo test --target x86_64-unknown-linux-gnu integration -- --skip test_driver_log_level --nocapture &&
           cargo test --target x86_64-unknown-linux-gnu --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --target x86_64-unknown-linux-gnu --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
+          cargo test --target x86_64-unknown-linux-gnu --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -976,7 +976,7 @@ functions:
           ./resources/run_adf.sh start &&
           cargo run --bin data_loader &&
           cargo test integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --test connection_tests integration::test_driver_log_level -- --ignored --nocapture
+          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture
           EXITCODE=$?
           echo "****** ls -l ./target/debug/deps *******"
           ls -l ./target/debug/deps
@@ -1079,7 +1079,7 @@ functions:
 
           # Run integration tests with ubuntu
           cargo test integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --test connection_tests integration::test_driver_log_level -- --ignored --nocapture
+          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture
 
           EXITCODE=$?
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -977,7 +977,7 @@ functions:
           cargo run --bin data_loader &&
           cargo test integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features bad_host -- --exact --nocapture
           EXITCODE=$?
           echo "****** ls -l ./target/debug/deps *******"
           ls -l ./target/debug/deps
@@ -1081,7 +1081,7 @@ functions:
           # Run integration tests with ubuntu
           cargo test integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features bad_host -- --exact --nocapture
 
           EXITCODE=$?
 
@@ -1154,7 +1154,7 @@ functions:
           # Run integration tests with macos
           cargo test --features definitions/iodbc,cstr/utf32 integration -- --skip test_driver_log_level --nocapture &&
           cargo test --test connection_tests integration::test_driver_log_level --features definitions/iodbc,cstr/utf32 -- --nocapture &&
-          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features definitions/iodbc,cstr/utf32,core/bad_host -- --exact --nocapture
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features definitions/iodbc,cstr/utf32,bad_host -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1233,7 +1233,7 @@ functions:
           # Run integration tests with asan
           cargo test --target x86_64-unknown-linux-gnu integration -- --skip test_driver_log_level --nocapture &&
           cargo test --target x86_64-unknown-linux-gnu --test connection_tests integration::test_driver_log_level -- --nocapture &&
-          cargo test --target x86_64-unknown-linux-gnu --package mongo-odbc-core --lib util::test_connection::test::bad_host --features core/bad_host -- --exact --nocapture
+          cargo test --target x86_64-unknown-linux-gnu --package mongo-odbc-core --lib util::test_connection::test::bad_host --features bad_host -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1109,7 +1109,7 @@ functions:
           ./resources/run_adf.sh start && cargo run --bin data_loader &&
 
           # Run integration tests with macos
-          cargo test --features definitions/iodbc,cstr/utf32 -- --ignored
+          cargo test --package integration_test --lib test_runner --features definitions/iodbc,cstr/utf32,integration_test/result_set
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1180,7 +1180,7 @@ functions:
           ./resources/run_adf.sh start && cargo run --bin data_loader &&
 
           # Run integration tests with ubuntu
-          cargo test -- --ignored
+          cargo test --package integration_test --lib test_runner --features integration_test/result_set
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1260,7 +1260,7 @@ functions:
           ./resources/run_adf.sh start && cargo run --bin data_loader &&
 
           # Run integration tests with asan
-          cargo test --target x86_64-unknown-linux-gnu -- --ignored
+          cargo test --target x86_64-unknown-linux-gnu --package integration_test --lib test_runner --features integration_test/result_set
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1279,7 +1279,7 @@ functions:
         export RUST_BACKTRACE=1
         ./resources/run_adf.sh start &&
         cargo run --bin data_loader &&
-        cargo test -- --ignored
+        cargo test --package integration_test --lib test_runner --features integration_test/result_set
         EXITCODE=$?
         # The execution termimated with a segfault
         if [ $EXITCODE -eq 139 ]; then

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -976,7 +976,8 @@ functions:
           ./resources/run_adf.sh start &&
           cargo run --bin data_loader &&
           cargo test integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture
+          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
           EXITCODE=$?
           echo "****** ls -l ./target/debug/deps *******"
           ls -l ./target/debug/deps
@@ -1079,7 +1080,8 @@ functions:
 
           # Run integration tests with ubuntu
           cargo test integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture
+          cargo test --test connection_tests integration::test_driver_log_level -- --nocapture &&
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
 
           EXITCODE=$?
 
@@ -1151,7 +1153,8 @@ functions:
 
           # Run integration tests with macos
           cargo test --features definitions/iodbc,cstr/utf32 integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --test connection_tests integration::test_driver_log_level --features definitions/iodbc,cstr/utf32 -- --nocapture
+          cargo test --test connection_tests integration::test_driver_log_level --features definitions/iodbc,cstr/utf32 -- --nocapture &&
+          cargo test --package mongo-odbc-core --lib util::test_connection::test::bad_host --features definitions/iodbc,cstr/utf32 -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF
@@ -1229,7 +1232,8 @@ functions:
 
           # Run integration tests with asan
           cargo test --target x86_64-unknown-linux-gnu integration -- --skip test_driver_log_level --nocapture &&
-          cargo test --target x86_64-unknown-linux-gnu --test connection_tests integration::test_driver_log_level -- --nocapture
+          cargo test --target x86_64-unknown-linux-gnu --test connection_tests integration::test_driver_log_level -- --nocapture &&
+          cargo test --target x86_64-unknown-linux-gnu --package mongo-odbc-core --lib util::test_connection::test::bad_host -- --exact --nocapture
           EXITCODE=$?
 
           # Stop the local ADF

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -26,4 +26,3 @@ features = ["tokio-sync"]
 
 [features]
 result_set = []
-temp = []

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -23,3 +23,7 @@ num-derive = "0.3.3"
 version = "2"
 default-features = false
 features = ["tokio-sync"]
+
+[features]
+result_set = []
+temp = []

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -126,13 +126,6 @@ impl fmt::Display for TestDef {
     }
 }
 
-#[test]
-#[cfg(feature = "temp")]
-fn t() {
-    println!("yes");
-    assert!(false)
-}
-
 /// resultset_tests runs the query and function tests contained in the TEST_FILE_DIR directory
 #[test]
 #[cfg(feature = "result_set")]

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -126,16 +126,23 @@ impl fmt::Display for TestDef {
     }
 }
 
+#[test]
+#[cfg(feature = "temp")]
+fn t() {
+    println!("yes");
+    assert!(false)
+}
+
 /// resultset_tests runs the query and function tests contained in the TEST_FILE_DIR directory
 #[test]
-#[ignore]
+#[cfg(feature = "result_set")]
 pub fn resultset_tests() -> Result<()> {
     run_resultset_tests(false)
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 #[test]
-#[ignore]
+#[cfg(feature = "result_set")]
 pub fn odbc2_resultset_tests() -> Result<()> {
     run_resultset_tests_odbc_2(false)
 }


### PR DESCRIPTION
This PR updates the result set tests to use feature flags instead of the `#[ignore]` attribute. Before this PR, only 3 test functions used the `#[ignore]` attribute -- two of them are `resultset_tests` and `odbc2_resultset_tests`. Those two tests have been updated to use the `#[cfg(features = "result_set")]` attribute. There is also the the `bad_host` test [here](https://github.com/mongodb/mongo-odbc-driver/blob/78610f8d3b4112cef27566d44442e19374ee69cf/core/src/util/test_connection.rs#L113) that was seemingly run _unintentionally_ as part of the result set test tasks. I have not updated that one since it looks like we actually do mean to ignore it. Let me know if that is not the case.