### PR TITLE
SQL-1975: Set working ADF version in run_adf to pass integration tests

### DIFF
--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -364,6 +364,11 @@ if [ $ARG = $START ]; then
         fi
         cd $MONGOHOUSE_DIR
 
+        # SQL-1976: Update ADF config to work with changes to remove defaults
+        ADF_Version=ad72851
+        echo "checking out mongohouse: $ADF_Version"
+        git checkout $ADF_Version
+
 
         export GOPRIVATE=github.com/10gen
         # make sure mod vendor is cleaned up


### PR DESCRIPTION
Sets to an ADF version prior to the changes to require configuration values. 
Passing tests:
https://evergreen.mongodb.com/version/65f0858c1e2d1742684714e4