### PR TITLE
SQL-1976: Update ADF config to add new required values

### DIFF
--- a/resources/integration_test/config/adf_config.yaml
+++ b/resources/integration_test/config/adf_config.yaml
@@ -1,34 +1,33 @@
 hostProvider: local
 hostRegion: local
 environment: local
-
-showInternalErrors: false
-
-diagnostics:
-  bindAddr: ":8080"
-  metrics:
-    enabled: true
-    endpoint: /metrics
-  pprof:
-    enabled: true
-    endpoint: /debug/pprof
-
 agent:
-  bindAddr: "localhost:8027"
-
+  bindAddr: localhost:8027
+  batchFlushPeriod: 1s
 backend:
-  bindAddr: "localhost:8029"
-
-frontend:
-  bindAddr: ":27017"
-  cursor:
-    metadata:
-      memory: true
-  resultCache:
-    metadata:
-      memory: true
-
+  authTokens: {}
+  bindAddr: localhost:8029
 execution:
+  agentOnly: true
+  maxDocumentSize: 16MiB
+  outToSchemaMemoryLimit: 5MiB
+  computeModeMongod:
+    port: ${COMPUTE_MODE_MONGOD_PORT:=47017}
+    exponentialRetry:
+      maxAttempts: 1
+  remote:
+    branchingDepth: 2
+    branchingFactor: 2
+    maxRequestPendingDuration: 15m
+    maxSerialNum: 1
+    maxSerialSize: 500MiB
+    rpcChunkSize: 10B
+    uris:
+      local: localhost:8027
+      aws:
+        us-east-1: localhost:8027
+        us-west-1: localhost:8027
+        eu-west-1: localhost:8027
   currentOp:
     mongodb:
       uri: mongodb://localhost:28017
@@ -36,26 +35,20 @@ execution:
       collection: queries
   queryHistory:
     memory: true
-  computeModeMongod:
-    port: ${COMPUTE_MODE_MONGOD_PORT:=47017}
-    exponentialRetry:
-      maxAttempts: 1
   mongoClient:
     cache:
       enabled: true
-  remote:
-    uris:
-      local: "localhost:8027"
-    branchingFactor: 2
-    maxSerialNum: 1
-    rpcChunkSize: 10B
-
+diagnostics:
+  bindAddr: :8080
+  logging:
+    level: debug
+  metrics:
+    enabled: true
+    endpoint: /metrics
+  pprof:
+    enabled: true
+    endpoint: /debug/pprof
 dls:
-  frontend:
-    catalog:
-      disabled: true
-    expirationRules:
-      disabled: true
   agent:
     catalog:
       disabled: true
@@ -71,7 +64,39 @@ dls:
         disabled: true
     expirationRules:
       disabled: true
-
+  frontend:
+    catalog:
+      disabled: true
+    expirationRules:
+      disabled: true
+events:
+  memQueueSize: 10000
+  shutdownTimeout: 10m
+frontend:
+  bindAddr: localhost:27017
+  cursor:
+    prunePeriod: 1h
+    heartbeatInterval: 10s
+    maxCursorFileSize: 100MiB
+    maxCursorFiles: 100
+    maxWaitTimeForAvailableSpace: 15s
+    metadata:
+      memory: true
+  defaultHostname: localhost
+  proxyProtocolTimeout: 5s
+  resultCache:
+    metadata:
+      memory: true
+    expireAfter: 720h
+    heartbeatPeriod: 10s
+    heartbeatTimeout: 1m
+    pollPeriod: 1s
+    pruneDelay: 1m
+    prunePeriod: 1h
+  tenants:
+    refreshInterval: 5m
+    updateThreshold: 30s
+  tcpKeepAlivePeriod: 30s
 query:
   killOp:
     server:
@@ -79,28 +104,29 @@ query:
         uri: "mongodb://localhost:28017"
         database: adf
         collection: killop
-
+      refreshInterval: 10s
 tenant:
-  config:
-    server:
-      inline:
-        file: "./testdata/config/inline_local/tenant-config.json"
-  storageconfig:
-    server:
-      inline:
-        file: "./testdata/config/inline_local/tenant-config.json"
   schema:
     server:
       memory:
-        - database: "test"
-          collection: "quux"
-          schemaFile: "./testdata/tenantschema/quux.json"
-        - database: "test"
-          collection: "bar"
-          schemaFile: "./testdata/tenantschema/bar.json"
-        - database: "test2"
-          collection: "cities"
-          schemaFile: "./testdata/tenantschema/cities.json"
+        - database: test
+          collection: quux
+          schemaFile: ./testdata/tenantschema/quux.json
+        - database: test
+          collection: bar
+          schemaFile: ./testdata/tenantschema/bar.json
+        - database: test2
+          collection: cities
+          schemaFile: ./testdata/tenantschema/cities.json
     client:
-      uri: "localhost:8029"
-      token: "frontend-auth-token"
+      uri: localhost:8029
+      token: frontend-auth-token
+  config:
+    server:
+      inline:
+        file: ./testdata/config/inline_local/tenant-config.json
+  storageconfig:
+    server:
+      inline:
+        file: ./testdata/config/inline_local/tenant-config.json
+

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -364,12 +364,6 @@ if [ $ARG = $START ]; then
         fi
         cd $MONGOHOUSE_DIR
 
-        # SQL-1976: Update ADF config to work with changes to remove defaults
-        ADF_Version=ad72851
-        echo "checking out mongohouse: $ADF_Version"
-        git checkout $ADF_Version
-
-
         export GOPRIVATE=github.com/10gen
         # make sure mod vendor is cleaned up
         $GO mod vendor


### PR DESCRIPTION
Added  `currentOp:` and `query: killOp:` configuration  to the latest [ADF config](https://github.com/10gen/mongohouse/blob/master/testdata/config/inline_local/frontend-agent-backend.yaml) for inline_local. 

@pmeredit the ADF config for the ODBC repo has changes to enable match filters after currentOp that Jonathan added.  This config is different from the JDBC/Power BI repos so that could be one reason to keep the run_adf scripts separate. 