### PR TITLE
SQL-1962: Add integration tests for SSIS preview data flow

### DIFF
--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -177,7 +177,7 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
 /// the test results should be written to a file for baseline test file
 /// generation, or be asserted for correctness.
 pub fn run_resultset_tests_odbc_2(generate: bool) -> Result<()> {
-    let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
+    let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC2);
     unsafe {
         assert_eq!(
             SqlReturn::SUCCESS,

--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -2,8 +2,8 @@ mod test_generator_util;
 
 use cstr::WideChar;
 use definitions::{
-    CDataType, Desc, EnvironmentAttribute, HDbc, HStmt, Handle, HandleType, SmallInt, SqlReturn,
-    USmallInt,
+    AttrOdbcVersion, CDataType, Desc, EnvironmentAttribute, HDbc, HStmt, Handle, HandleType,
+    SmallInt, SqlReturn, USmallInt,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -141,10 +141,10 @@ pub fn odbc2_resultset_tests() -> Result<()> {
 }
 
 /// Run an integration test. The generate argument indicates whether
-/// the test results should written to a file for baseline test file
+/// the test results should be written to a file for baseline test file
 /// generation, or be asserted for correctness.
 pub fn run_resultset_tests(generate: bool) -> Result<()> {
-    let env = allocate_env().unwrap();
+    let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
     let paths = load_file_paths(PathBuf::from(TEST_FILE_DIR)).unwrap();
     for path in paths {
         let yaml = parse_test_file_yaml(&path).unwrap();
@@ -174,10 +174,10 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
 }
 
 /// Runs odbc 2 compatibility integration test. The generate argument indicates whether
-/// the test results should written to a file for baseline test file
+/// the test results should be written to a file for baseline test file
 /// generation, or be asserted for correctness.
 pub fn run_resultset_tests_odbc_2(generate: bool) -> Result<()> {
-    let env = allocate_env().unwrap();
+    let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
     unsafe {
         assert_eq!(
             SqlReturn::SUCCESS,

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -152,7 +152,9 @@ pub fn allocate_env(odbc_version: AttrOdbcVersion) -> HEnv {
                 HandleType::SQL_HANDLE_ENV,
                 null_mut(),
                 &mut env as *mut Handle,
-            )
+            ),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_ENV, env as Handle)
         );
         assert_eq!(
             SqlReturn::SUCCESS,
@@ -161,7 +163,9 @@ pub fn allocate_env(odbc_version: AttrOdbcVersion) -> HEnv {
                 EnvironmentAttribute::SQL_ATTR_ODBC_VERSION,
                 odbc_version.into(),
                 0
-            )
+            ),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_ENV, env as Handle)
         );
     }
     env as HEnv

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -265,6 +265,7 @@ pub fn disconnect_and_close_handles(dbc: HDbc, stmt: HStmt) {
     }
 }
 
+#[allow(dead_code)]
 /// Helper function for disconnecting and freeing HDbc and HEnv handles.
 /// Note that this function explicitly does NOT free the statement handle
 /// since it is intended for use with tests that invoke SQLFreeStmt.
@@ -355,6 +356,7 @@ pub fn fetch_and_get_data(
     }
 }
 
+#[allow(dead_code)]
 /// Helper function for checking result set metadata. It optionally takes a list
 /// of attributes to get. If none is provided, the following defaults will be
 /// checked. It also optionally invokes SQLDescribeColW.
@@ -425,6 +427,7 @@ pub fn get_column_attributes(
     }
 }
 
+#[allow(dead_code)]
 /// Helper function for invoking SQLDescribeColW. None of the outputs are tested.
 /// This helper just assures SqlReturn::SUCCESS is returned.
 unsafe fn assert_sql_describe_col(stmt: HStmt, col_num: u16) {

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -265,6 +265,37 @@ pub fn disconnect_and_close_handles(dbc: HDbc, stmt: HStmt) {
     }
 }
 
+/// Helper function for disconnecting and freeing HDbc and HEnv handles.
+/// Note that this function explicitly does NOT free the statement handle
+/// since it is intended for use with tests that invoke SQLFreeStmt.
+///  - SQLDisconnect(dbc)
+///  - SQLFreeHandle(dbc)
+///  - SQLFreeHandle(env)
+pub fn disconnect_and_free_dbc_and_env_handles(env_handle: HEnv, conn_handle: HDbc) {
+    unsafe {
+        assert_eq!(
+            SqlReturn::SUCCESS,
+            SQLDisconnect(conn_handle),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_DBC, conn_handle as Handle)
+        );
+
+        assert_eq!(
+            SqlReturn::SUCCESS,
+            SQLFreeHandle(HandleType::SQL_HANDLE_DBC, conn_handle as Handle),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_DBC, conn_handle as Handle)
+        );
+
+        assert_eq!(
+            SqlReturn::SUCCESS,
+            SQLFreeHandle(HandleType::SQL_HANDLE_ENV, env_handle as Handle),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_ENV, env_handle as Handle)
+        );
+    }
+}
+
 #[allow(dead_code)]
 ///  Helper function for fetching and getting data
 ///  - Until SQLFetch returns SQL_NO_DATA

--- a/integration_test/tests/connection_tests.rs
+++ b/integration_test/tests/connection_tests.rs
@@ -7,7 +7,7 @@ mod integration {
     };
     use constants::DRIVER_NAME;
     use cstr::{to_char_ptr, to_widechar_ptr, WideChar};
-    use definitions::{SQLExecDirectW, SqlReturn};
+    use definitions::{AttrOdbcVersion, SQLExecDirectW, SqlReturn};
     use lazy_static::lazy_static;
     use logger::Logger;
     use regex::Regex;
@@ -17,7 +17,7 @@ mod integration {
 
     #[test]
     fn test_invalid_connection() {
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         // Missing PWD
         let conn_str = "Driver=MongoDB Atlas SQL ODBC Driver;USER=N_A;SERVER=N_A";
         let result = connect_with_conn_string(env_handle, conn_str.to_string());
@@ -31,7 +31,7 @@ mod integration {
 
     #[test]
     fn test_default_connection() {
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_default_connection_str();
         let _ = connect_with_conn_string(env_handle, conn_str).unwrap();
         let _ = unsafe { Box::from_raw(env_handle) };
@@ -39,7 +39,7 @@ mod integration {
 
     #[test]
     fn uuid_csharp_legacy() {
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=csharpLegacy",
         );
@@ -49,7 +49,7 @@ mod integration {
 
     #[test]
     fn uuid_java_legacy() {
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=javaLegacy",
         );
@@ -59,7 +59,7 @@ mod integration {
 
     #[test]
     fn uuid_python_legacy() {
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=pythonLegacy",
         );
@@ -72,10 +72,11 @@ mod integration {
      */
     mod test_dsn {
         use crate::common::{allocate_env, connect_with_conn_string};
+        use definitions::AttrOdbcVersion;
 
         #[test]
         fn test_valid_dsn_connection() {
-            let env_handle = allocate_env().unwrap();
+            let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
             let conn_str = "DSN=ADF_Test";
             connect_with_conn_string(env_handle, conn_str.to_string()).unwrap();
             let _ = unsafe { Box::from_raw(env_handle) };
@@ -83,7 +84,7 @@ mod integration {
 
         #[test]
         fn test_uri_opts_override_dsn() {
-            let env_handle = allocate_env().unwrap();
+            let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
             let conn_str = "PWD=wrong;DSN=ADF_Test";
             let result = connect_with_conn_string(env_handle, conn_str.to_string());
             assert!(
@@ -121,7 +122,7 @@ mod integration {
 
         let log_file = log_file_path.as_os_str().to_str().unwrap().to_string();
 
-        let env_handle = allocate_env().unwrap();
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
 
         let mut conn_str = crate::common::generate_default_connection_str();
         let (dbc1, stmt1) = connect_and_allocate_statement(env_handle, Some(conn_str));

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -133,7 +133,7 @@ mod integration {
                 stmt_handle as Handle,
                 Some(3),
                 vec![SqlReturn::SUCCESS; 2],
-                vec![CDataType::SQL_C_SSHORT, CDataType::SQL_C_SLONG],
+                vec![CDataType::SQL_C_SLONG, CDataType::SQL_C_SBIGINT],
             );
 
             assert_eq!(SqlReturn::SUCCESS, SQLCancel(stmt_handle))

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -101,7 +101,7 @@ mod integration {
     ///     - SQLCancel
     #[test]
     fn test_cancel() {
-        let (env_handle, conn_handle, stmt_handle) = setup_connect_and_alloc_stmt();
+        let (_, _, stmt_handle) = setup_connect_and_alloc_stmt();
 
         unsafe {
             let timeout: i32 = 15;

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -1,0 +1,133 @@
+mod common;
+
+/// The tests in this module are based on the Preview Data workflow using SSIS.
+/// Although that tool is the inspiration for these tests, they more generally
+/// test what happens when
+///   1. a user allocates and uses a statement, and then calls SQLFreeStmt
+///   2. a user allocates and uses a statement to execute a query, and then
+///      calls SQLCancel
+/// These are workflows that could appear in any ODBC use-case, not just SSIS.
+mod integration {
+    use crate::common::{
+        allocate_env, connect_and_allocate_statement, disconnect_and_free_dbc_and_env_handles,
+        get_column_attributes,
+    };
+    use cstr::WideChar;
+    use definitions::{
+        Desc, FreeStmtOption, HDbc, HEnv, HStmt, Handle, SQLFreeStmt, SQLPrepareW, SqlReturn,
+        SQL_NTS,
+    };
+
+    /// Setup flow that connects and allocates a statement. This allocates a
+    /// new environment handle, sets the ODBC_VERSION environment attribute,
+    /// connects using the default URI, and allocates a statement. The flow
+    /// is:
+    ///     - SQLAllocHandle(SQL_HANDLE_ENV)
+    ///     - SQLSetEnvAttr(SQL_ATTR_ODBC_VERSION, SQL_OV_ODBC3)
+    ///     - SQLAllocHandle(SQL_HANDLE_DBC)
+    ///     - SQLDriverConnectW
+    ///     - SQLAllocHandle(SQL_HANDLE_STMT)
+    fn setup_connect_and_alloc_stmt() -> (HEnv, HDbc, HStmt) {
+        let env_handle = allocate_env().unwrap();
+        let (conn_handle, stmt_handle) = connect_and_allocate_statement(env_handle, None);
+
+        (env_handle, conn_handle, stmt_handle)
+    }
+
+    /// This test is inspired by the SSIS Preview Data result set metadata flow.
+    /// It is altered to be more general than that specific flow, with a focus
+    /// on freeing the statement handle after gathering some metadata. This flow
+    /// depends on setup_connect_and_alloc_stmt.
+    /// After allocating a statement handle, the flow is:
+    ///     - SQLPrepareW(<query>)
+    ///     - SQLNumResultCols
+    ///     - <loop: for each column>
+    ///         - SQLDescribeColW
+    ///         - SQLColAttributeW(SQL_DESC_UNSIGNED)
+    ///         - SQLColAttributeW(SQL_DESC_UPDATABLE)
+    ///     - SQLFreeStmt(SQL_CLOSE)
+    ///     - SQLDisconnect
+    ///     - SQLFreeHandle(SQL_HANDLE_DBC)
+    ///     - SQLFreeHandle(SQL_HANDLE_ENV)
+    #[test]
+    fn test_free_stmt() {
+        let (env_handle, conn_handle, stmt_handle) = setup_connect_and_alloc_stmt();
+
+        unsafe {
+            let mut query: Vec<WideChar> =
+                cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
+            query.push(0);
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLPrepareW(stmt_handle, query.as_ptr(), SQL_NTS as i32),
+            );
+
+            get_column_attributes(
+                stmt_handle as Handle,
+                2,
+                Some(vec![Desc::SQL_DESC_UNSIGNED, Desc::SQL_DESC_UPDATABLE]),
+                true,
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_CLOSE)
+            );
+
+            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
+        }
+    }
+
+    #[test]
+    fn test_cancel() {
+        todo!()
+        // todo:
+        //  - implement/test "Preview Data data flow"
+        //  - use setup_and_connect() as the foundation
+        //  - investigate if you need to do the second set of allocations...
+        //  - consider skipping some of the attr setting/getting
+        //  - Preview Data data flow (with slightly alternate Connect flow)
+        //      (start alt connect flow)
+        //      SQLAllocHandle(SQL_HANDLE_ENV)
+        //      SQLSetEnvAttr(SQL_ATTR_ODBC_VERSION = SQL_OV_ODBC3)
+        //      (next 2 aren't used later)
+        //        SQLAllocHandle(SQL_HANDLE_DBC)
+        //        SQLDriverConnectW
+        //      (end)
+        //      SQLAllocHandle(SQL_HANDLE_DBC)
+        //      SQLSetConnectAttrW(SQL_ATTR_LOGIN_TIMEOUT)
+        //      SQLDriverConnectW
+        //      (end alt connect flow)
+        //      (start Preview data data flow)
+        //      SQLAllocHandle(SQL_HANDLE_STMT)
+        //      SQLSetStmtAttrW(SQL_ATTR_QUERY_TIMEOUT)
+        //      SQLGetInfo(SQL_DRIVER_ODBC_VER)
+        //      SQLSetStmtAttrW(1228 <unknown>)
+        //      SQLGetDiagFieldW
+        //      SQLSetStmtAttrW(1227 <unknown>)
+        //      SQLGetDiagFieldW
+        //      SQLExecDirectW(<query>)
+        //      SQLRowCount
+        //      SQLNumResultCols
+        //      <loop: for each col>
+        //         SQLColAttributeW(SQL_DESC_CONCISE_TYPE)
+        //         SQLColAttributeW(SQL_DESC_UNSIGNED)
+        //         SQLColAttributeW(SQL_DESC_OCTET_LENGTH)
+        //         SQLColAttributeW(4 <unknown>)
+        //         SQLColAttributeW(5 <unknown>)
+        //         SQLColAttributeW(SQL_DESC_AUTO_UNIQUE_VALUE)
+        //         SQLColAttributeW(SQL_DESC_AUTO_UPDATABLE)
+        //         SQLColAttributeW(SQL_DESC_AUTO_NULLABLE)
+        //     SQLColAttributeW(SQL_DESC_NAME) <col 1>
+        //     SQLColAttributeW(SQL_DESC_NAME) <col 2>
+        //     <loop: for each row (or perhaps for first 3 rows) (or perhaps until SQLFetch returns SQL_NO_DATA_FOUND***)>
+        //        SQLFetch
+        //        <loop: for each col>
+        //           <if row 1>
+        //              SQLColAttributeW(SQL_DESC_CONCISE_TYPE)
+        //              SQLColAttributeW(SQL_DESC_UNSIGNED)
+        //           SQLGetData
+        //     SQLCancel
+    }
+}

--- a/integration_test/tests/odbc_2_tests.rs
+++ b/integration_test/tests/odbc_2_tests.rs
@@ -2,57 +2,28 @@ mod common;
 
 mod integration {
     use crate::common::{
-        connect_and_allocate_statement, disconnect_and_close_handles, get_sql_diagnostics,
-        BUFFER_LENGTH,
+        allocate_env, default_setup_connect_and_alloc_stmt, disconnect_and_close_handles,
+        get_sql_diagnostics, BUFFER_LENGTH,
     };
     use definitions::{
-        CDataType, EnvironmentAttribute, HEnv, HStmt, Handle, HandleType, Len, Pointer,
-        SQLAllocHandle, SQLFetch, SQLGetData, SQLGetTypeInfo, SQLSetEnvAttr, SQLTablesW, SmallInt,
-        SqlDataType, SqlReturn,
+        AttrOdbcVersion, CDataType, HStmt, Handle, HandleType, Len, Pointer, SQLFetch, SQLGetData,
+        SQLGetTypeInfo, SQLTablesW, SmallInt, SqlDataType, SqlReturn,
     };
 
     use cstr::WideChar;
     use std::ptr::null_mut;
 
-    // set up env handle and set odbc version to 2
-    fn setup() -> definitions::HEnv {
-        let mut env: Handle = null_mut();
-
-        unsafe {
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLAllocHandle(
-                    HandleType::SQL_HANDLE_ENV,
-                    null_mut(),
-                    &mut env as *mut Handle
-                )
-            );
-
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLSetEnvAttr(
-                    env as HEnv,
-                    EnvironmentAttribute::SQL_ATTR_ODBC_VERSION,
-                    2 as *mut _,
-                    0,
-                )
-            );
-        }
-
-        env as HEnv
-    }
-
     /// Test Setup flow
     #[test]
     fn test_setup() {
-        setup();
+        allocate_env(AttrOdbcVersion::SQL_OV_ODBC2);
     }
 
     /// Test list_tables, which should yield all tables
     #[test]
     fn test_list_tables() {
-        let env_handle = setup();
-        let (conn_handle, stmt_handle) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, conn_handle, stmt_handle) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC2);
 
         unsafe {
             let mut table_view: Vec<WideChar> = cstr::to_widechar_vec("TABLE");
@@ -118,8 +89,8 @@ mod integration {
     /// we expect back.
     #[test]
     fn test_type_listing() {
-        let env_handle = setup();
-        let (conn_handle, stmt_handle) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, conn_handle, stmt_handle) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC2);
 
         let output_buffer = &mut [0u16; (BUFFER_LENGTH as usize - 1)] as *mut _;
 

--- a/integration_test/tests/power_bi_tests.rs
+++ b/integration_test/tests/power_bi_tests.rs
@@ -461,7 +461,7 @@ mod integration {
             //      - SQLColAttributeW(SQL_DESC_TYPE_NAME)
             //      - SQLColAttributeW(SQL_COLUMN_LENGTH)
             //      - SQLColAttributeW(SQL_COLUMN_SCALE)
-            get_column_attributes(stmt, 2, None, false);
+            get_column_attributes(stmt, 2);
 
             //  - Until SQLFetch returns SQL_NO_DATA
             //      - SQLFetch()
@@ -540,7 +540,7 @@ mod integration {
             //      - SQLColAttributeW(SQL_DESC_TYPE_NAME)
             //      - SQLColAttributeW(SQL_COLUMN_LENGTH)
             //      - SQLColAttributeW(SQL_COLUMN_SCALE)
-            get_column_attributes(stmt, 5, None, false);
+            get_column_attributes(stmt, 5);
 
             //  - Until SQLFetch returns SQL_NO_DATA
             //      - SQLFetch()

--- a/integration_test/tests/power_bi_tests.rs
+++ b/integration_test/tests/power_bi_tests.rs
@@ -461,7 +461,7 @@ mod integration {
             //      - SQLColAttributeW(SQL_DESC_TYPE_NAME)
             //      - SQLColAttributeW(SQL_COLUMN_LENGTH)
             //      - SQLColAttributeW(SQL_COLUMN_SCALE)
-            get_column_attributes(stmt, 2);
+            get_column_attributes(stmt, 2, None, false);
 
             //  - Until SQLFetch returns SQL_NO_DATA
             //      - SQLFetch()
@@ -540,7 +540,7 @@ mod integration {
             //      - SQLColAttributeW(SQL_DESC_TYPE_NAME)
             //      - SQLColAttributeW(SQL_COLUMN_LENGTH)
             //      - SQLColAttributeW(SQL_COLUMN_SCALE)
-            get_column_attributes(stmt, 5);
+            get_column_attributes(stmt, 5, None, false);
 
             //  - Until SQLFetch returns SQL_NO_DATA
             //      - SQLFetch()

--- a/integration_test/tests/prepared_statement_tests.rs
+++ b/integration_test/tests/prepared_statement_tests.rs
@@ -2,20 +2,21 @@ mod common;
 
 mod integration {
     use crate::common::{
-        allocate_env, connect_and_allocate_statement, disconnect_and_close_handles,
-        fetch_and_get_data, get_column_attributes, get_sql_diagnostics,
+        allocate_env, connect_and_allocate_statement, default_setup_connect_and_alloc_stmt,
+        disconnect_and_close_handles, fetch_and_get_data, get_column_attributes,
+        get_sql_diagnostics,
     };
     use definitions::{
-        CDataType, HStmt, Handle, HandleType, SQLExecute, SQLFetch, SQLPrepareW, SmallInt,
-        SqlReturn, SQL_NTS,
+        AttrOdbcVersion, CDataType, HStmt, Handle, HandleType, SQLExecute, SQLFetch, SQLPrepareW,
+        SmallInt, SqlReturn, SQL_NTS,
     };
 
     use cstr::WideChar;
 
     #[test]
     fn test_error_execute_before_prepare() {
-        let env_handle = allocate_env().unwrap();
-        let (dbc, stmt) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, dbc, stmt) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
 
         let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
         query.push(0);
@@ -34,8 +35,8 @@ mod integration {
 
     #[test]
     fn test_prepare_get_resultset_metadata() {
-        let env_handle = allocate_env().unwrap();
-        let (dbc, stmt) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, dbc, stmt) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -59,8 +60,8 @@ mod integration {
 
     #[test]
     fn test_error_fetch_before_execute() {
-        let env_handle = allocate_env().unwrap();
-        let (dbc, stmt) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, dbc, stmt) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -87,8 +88,8 @@ mod integration {
 
     #[test]
     fn test_prepare_execute_retrieve_data() {
-        let env_handle = allocate_env().unwrap();
-        let (dbc, stmt) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, dbc, stmt) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -133,8 +134,8 @@ mod integration {
 
     #[test]
     fn test_prepare_execute_multiple_times() {
-        let env_handle = allocate_env().unwrap();
-        let (dbc, stmt) = connect_and_allocate_statement(env_handle, None);
+        let (env_handle, dbc, stmt) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");

--- a/integration_test/tests/prepared_statement_tests.rs
+++ b/integration_test/tests/prepared_statement_tests.rs
@@ -50,7 +50,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2);
+            get_column_attributes(stmt as Handle, 2, None, false);
 
             disconnect_and_close_handles(dbc, stmt);
         }
@@ -73,7 +73,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2);
+            get_column_attributes(stmt as Handle, 2, None, false);
 
             assert_eq!(SqlReturn::ERROR, SQLFetch(stmt as HStmt),);
 
@@ -101,7 +101,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2);
+            get_column_attributes(stmt as Handle, 2, None, false);
 
             // Executing the prepared statement.
             // The $sql pipeline is now executed and the result set cursor.

--- a/integration_test/tests/prepared_statement_tests.rs
+++ b/integration_test/tests/prepared_statement_tests.rs
@@ -51,7 +51,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2, None, false);
+            get_column_attributes(stmt as Handle, 2);
 
             disconnect_and_close_handles(dbc, stmt);
         }
@@ -74,7 +74,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2, None, false);
+            get_column_attributes(stmt as Handle, 2);
 
             assert_eq!(SqlReturn::ERROR, SQLFetch(stmt as HStmt),);
 
@@ -102,7 +102,7 @@ mod integration {
             );
 
             // Retrieve result set metadata
-            get_column_attributes(stmt as Handle, 2, None, false);
+            get_column_attributes(stmt as Handle, 2);
 
             // Executing the prepared statement.
             // The $sql pipeline is now executed and the result set cursor.

--- a/integration_test/tests/prepared_statement_tests.rs
+++ b/integration_test/tests/prepared_statement_tests.rs
@@ -2,9 +2,8 @@ mod common;
 
 mod integration {
     use crate::common::{
-        allocate_env, connect_and_allocate_statement, default_setup_connect_and_alloc_stmt,
-        disconnect_and_close_handles, fetch_and_get_data, get_column_attributes,
-        get_sql_diagnostics,
+        default_setup_connect_and_alloc_stmt, disconnect_and_close_handles, fetch_and_get_data,
+        get_column_attributes, get_sql_diagnostics,
     };
     use definitions::{
         AttrOdbcVersion, CDataType, HStmt, Handle, HandleType, SQLExecute, SQLFetch, SQLPrepareW,
@@ -16,7 +15,7 @@ mod integration {
     #[test]
     fn test_error_execute_before_prepare() {
         let (env_handle, dbc, stmt) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
         query.push(0);
@@ -36,7 +35,7 @@ mod integration {
     #[test]
     fn test_prepare_get_resultset_metadata() {
         let (env_handle, dbc, stmt) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -61,7 +60,7 @@ mod integration {
     #[test]
     fn test_error_fetch_before_execute() {
         let (env_handle, dbc, stmt) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -89,7 +88,7 @@ mod integration {
     #[test]
     fn test_prepare_execute_retrieve_data() {
         let (env_handle, dbc, stmt) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");
@@ -135,7 +134,7 @@ mod integration {
     #[test]
     fn test_prepare_execute_multiple_times() {
         let (env_handle, dbc, stmt) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3.into());
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
             let mut query: Vec<WideChar> = cstr::to_widechar_vec("select * from example");


### PR DESCRIPTION
This PR adds integration tests for the SSIS preview data flow. I broke it down into two tests since SSIS has a tendency to free all handles between discrete units of work. As discussed individually, I attempted to make these tests _slightly_ more general than the exact SSIS workflow. Instead of naming them "ssis_tests" I called the file "free_and_cancel_tests.rs" since this is the first set of integration tests that focus on the newly implemented `SQLFreeStmt` and `SQLCancel` functions. I am open to modifying the names/coverage as requested.