### PR TITLE
SQL-1964: Add integration tests for SSIS query flow

### DIFF
--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -29,9 +29,9 @@ mod integration {
             exec_direct_default_query(stmt_handle);
 
             let id_buffer = &mut [0u8; 4] as *mut _;
-            let id_indicator = &mut [0isize; 2] as *mut Len;
+            let id_indicator = &mut [0isize; 1] as *mut Len;
             let a_buffer = &mut [0u8; 8] as *mut _;
-            let a_indicator = &mut [0isize; 2] as *mut Len;
+            let a_indicator = &mut [0isize; 1] as *mut Len;
             bind_cols(
                 stmt_handle,
                 vec![

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -1,0 +1,77 @@
+mod common;
+
+mod integration {
+    use crate::common::{
+        default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
+        exec_direct_default_query, fetch_and_bind_cols, get_sql_diagnostics,
+    };
+    use definitions::{
+        AttrOdbcVersion, BindType, CDataType, FreeStmtOption, Handle, HandleType, Pointer,
+        SQLFreeStmt, SQLSetStmtAttrW, SqlReturn, StatementAttribute,
+    };
+
+    /// This test is inspired by the SSIS Query flow. It is altered to be
+    /// more general than that specific flow, with a focus on freeing the
+    /// statement handle after calling SQLBindCol. This flow depends on
+    /// default_setup_connect_and_alloc_stmt.
+    /// After allocating a statement handle, the flow is:
+    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN)
+    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_ARRAY_SIZE, 1000)
+    ///     - SQLExecDirectW(<query>)
+    ///     - <loop: until SQLFetchScroll returns SQL_NO_DATA>
+    ///         - SQLBindCol for each column
+    ///         - SQLFetchScroll
+    ///     - SQLFreeStmt(SQL_UNBIND)
+    ///     - SQLDisconnect
+    ///     - SQLFreeHandle(SQL_HANDLE_DBC)
+    ///     - SQLFreeHandle(SQL_HANDLE_ENV)
+    #[test]
+    fn test_free_stmt_after_bind_col() {
+        let (env_handle, conn_handle, stmt_handle) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+
+        unsafe {
+            let bind_type = BindType::SQL_BIND_BY_COLUMN as i32;
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLSetStmtAttrW(
+                    stmt_handle,
+                    StatementAttribute::SQL_ATTR_ROW_BIND_TYPE,
+                    bind_type as Pointer,
+                    0,
+                ),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            let row_array_size = 1000;
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLSetStmtAttrW(
+                    stmt_handle,
+                    StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE,
+                    row_array_size as Pointer,
+                    0
+                ),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            exec_direct_default_query(stmt_handle);
+
+            fetch_and_bind_cols(
+                stmt_handle,
+                vec![CDataType::SQL_C_SLONG, CDataType::SQL_C_SBIGINT],
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_UNBIND),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
+        }
+    }
+}

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -148,7 +148,7 @@ mod integration {
                 let (a1, a2) = expected_a_data[i];
                 assert_eq!(a1, *(a_buffer as *mut i64));
                 assert_eq!(a2, *((a_buffer as ULen + 8) as *mut i64));
-                assert_eq!(8, *id_indicator);
+                assert_eq!(8, *a_indicator);
 
                 i += 1;
             }

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -2,8 +2,8 @@ mod common;
 
 mod integration {
     use crate::common::{
-        bind_cols, default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
-        exec_direct_default_query, get_sql_diagnostics,
+        bind_cols, default_setup_connect_and_alloc_stmt, exec_direct_default_query,
+        get_sql_diagnostics,
     };
     use definitions::{
         AttrOdbcVersion, CDataType, FetchOrientation, FreeStmtOption, Handle, HandleType, Integer,

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -7,7 +7,7 @@ mod integration {
     };
     use definitions::{
         AttrOdbcVersion, CDataType, FetchOrientation, FreeStmtOption, Handle, HandleType, Integer,
-        Pointer, SQLFetchScroll, SQLFreeStmt, SQLSetStmtAttrW, SmallInt, SqlReturn,
+        Len, Pointer, SQLFetchScroll, SQLFreeStmt, SQLSetStmtAttrW, SmallInt, SqlReturn,
         StatementAttribute, ULen,
     };
 
@@ -29,12 +29,24 @@ mod integration {
             exec_direct_default_query(stmt_handle);
 
             let id_buffer = &mut [0u8; 4] as *mut _;
+            let id_indicator = &mut [0isize; 2] as *mut Len;
             let a_buffer = &mut [0u8; 8] as *mut _;
+            let a_indicator = &mut [0isize; 2] as *mut Len;
             bind_cols(
                 stmt_handle,
                 vec![
-                    (CDataType::SQL_C_SLONG, id_buffer as Pointer, 4),
-                    (CDataType::SQL_C_SBIGINT, a_buffer as Pointer, 8),
+                    (
+                        CDataType::SQL_C_SLONG,
+                        id_buffer as Pointer,
+                        4,
+                        id_indicator,
+                    ),
+                    (
+                        CDataType::SQL_C_SBIGINT,
+                        a_buffer as Pointer,
+                        8,
+                        a_indicator,
+                    ),
                 ],
             );
 
@@ -88,12 +100,24 @@ mod integration {
 
             // Since ROW_ARRAY_SIZE is set to 2, we double the buffer lengths.
             let id_buffer = &mut [0u8; 8] as *mut _;
+            let id_indicator = &mut [0isize; 2] as *mut Len;
             let a_buffer = &mut [0u8; 16] as *mut _;
+            let a_indicator = &mut [0isize; 2] as *mut Len;
             bind_cols(
                 stmt_handle,
                 vec![
-                    (CDataType::SQL_C_SLONG, id_buffer as Pointer, 8),
-                    (CDataType::SQL_C_SBIGINT, a_buffer as Pointer, 16),
+                    (
+                        CDataType::SQL_C_SLONG,
+                        id_buffer as Pointer,
+                        4,
+                        id_indicator,
+                    ),
+                    (
+                        CDataType::SQL_C_SBIGINT,
+                        a_buffer as Pointer,
+                        8,
+                        a_indicator,
+                    ),
                 ],
             );
 
@@ -119,10 +143,12 @@ mod integration {
                 let (id1, id2) = expected_id_data[i];
                 assert_eq!(id1, *(id_buffer as *mut i32));
                 assert_eq!(id2, *((id_buffer as ULen + 4) as *mut i32));
+                assert_eq!(4, *id_indicator);
 
                 let (a1, a2) = expected_a_data[i];
                 assert_eq!(a1, *(a_buffer as *mut i64));
                 assert_eq!(a2, *((a_buffer as ULen + 8) as *mut i64));
+                assert_eq!(8, *id_indicator);
 
                 i += 1;
             }

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -2,54 +2,81 @@ mod common;
 
 mod integration {
     use crate::common::{
-        default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
-        exec_direct_default_query, fetch_and_bind_cols, get_sql_diagnostics,
+        bind_cols, default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
+        exec_direct_default_query, get_sql_diagnostics,
     };
     use definitions::{
-        AttrOdbcVersion, BindType, CDataType, FreeStmtOption, Handle, HandleType, Pointer,
-        SQLFreeStmt, SQLSetStmtAttrW, SqlReturn, StatementAttribute,
+        AttrOdbcVersion, CDataType, FetchOrientation, FreeStmtOption, Handle, HandleType, Integer,
+        Pointer, SQLFetchScroll, SQLFreeStmt, SQLSetStmtAttrW, SmallInt, SqlReturn,
+        StatementAttribute, ULen,
     };
 
     /// This test is inspired by the SSIS Query flow. It is altered to be
     /// more general than that specific flow, with a focus on freeing the
-    /// statement handle after calling SQLBindCol. This flow depends on
+    /// bound columns after calling SQLBindCol. This flow depends on
     /// default_setup_connect_and_alloc_stmt.
     /// After allocating a statement handle, the flow is:
-    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN)
-    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_ARRAY_SIZE, 1000)
     ///     - SQLExecDirectW(<query>)
-    ///     - <loop: until SQLFetchScroll returns SQL_NO_DATA>
-    ///         - SQLBindCol for each column
-    ///         - SQLFetchScroll
+    ///     - SQLBindCol
+    ///     - SQLFetchScroll
     ///     - SQLFreeStmt(SQL_UNBIND)
-    ///     - SQLDisconnect
-    ///     - SQLFreeHandle(SQL_HANDLE_DBC)
-    ///     - SQLFreeHandle(SQL_HANDLE_ENV)
     #[test]
-    fn test_free_stmt_after_bind_col() {
+    fn test_unbind_cols() {
         let (env_handle, conn_handle, stmt_handle) =
             default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
-            let bind_type = BindType::SQL_BIND_BY_COLUMN as i32;
+            exec_direct_default_query(stmt_handle);
+
+            let id_buffer = &mut [0u8; 4] as *mut _;
+            let a_buffer = &mut [0u8; 8] as *mut _;
+            bind_cols(
+                stmt_handle,
+                vec![
+                    (CDataType::SQL_C_SLONG, id_buffer as Pointer, 4),
+                    (CDataType::SQL_C_SBIGINT, a_buffer as Pointer, 8),
+                ],
+            );
+
             assert_eq!(
                 SqlReturn::SUCCESS,
-                SQLSetStmtAttrW(
-                    stmt_handle,
-                    StatementAttribute::SQL_ATTR_ROW_BIND_TYPE,
-                    bind_type as Pointer,
-                    0,
-                ),
+                SQLFetchScroll(stmt_handle, FetchOrientation::SQL_FETCH_NEXT as SmallInt, 0,)
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_UNBIND as SmallInt),
                 "{}",
                 get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
             );
 
-            let row_array_size = 1000;
+            // clean up
+            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
+        }
+    }
+
+    /// This test is inspired by the SSIS Query flow. It is altered to be more
+    /// general than that specific flow, with a focus on binding columns and
+    /// then retrieving the next rowset. This flow depends on
+    /// default_setup_connect_and_alloc_stmt.
+    /// After allocating a statement handle, the flow is:
+    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_ARRAY_SIZE, xxx)
+    ///     - SQLExecDirectW(<query>)
+    ///     - SQLBindCol
+    ///     - <loop: until SQLFetchScroll returns SQL_NO_DATA>
+    ///         - SQLFetchScroll
+    #[test]
+    fn test_bind_cols_and_fetch_next_rowset() {
+        let (env_handle, conn_handle, stmt_handle) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+
+        unsafe {
+            let row_array_size = 2;
             assert_eq!(
                 SqlReturn::SUCCESS,
                 SQLSetStmtAttrW(
                     stmt_handle,
-                    StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE,
+                    StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE as Integer,
                     row_array_size as Pointer,
                     0
                 ),
@@ -59,18 +86,48 @@ mod integration {
 
             exec_direct_default_query(stmt_handle);
 
-            fetch_and_bind_cols(
+            // Since ROW_ARRAY_SIZE is set to 2, we double the buffer lengths.
+            let id_buffer = &mut [0u8; 8] as *mut _;
+            let a_buffer = &mut [0u8; 16] as *mut _;
+            bind_cols(
                 stmt_handle,
-                vec![CDataType::SQL_C_SLONG, CDataType::SQL_C_SBIGINT],
+                vec![
+                    (CDataType::SQL_C_SLONG, id_buffer as Pointer, 8),
+                    (CDataType::SQL_C_SBIGINT, a_buffer as Pointer, 16),
+                ],
             );
 
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_UNBIND),
-                "{}",
-                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-            );
+            // Data:
+            // - {_id: 0, a: {$numberLong: "42"}}
+            // - {_id: 1, a: {$numberLong: "13"}}
+            // - {_id: 2, a: {$numberLong: "100"}}
+            let mut i = 0;
+            let expected_id_data = [(0i32, 1i32), (2, 1)];
+            let expected_a_data = [(42i64, 13i64), (100, 13)];
+            loop {
+                let result =
+                    SQLFetchScroll(stmt_handle, FetchOrientation::SQL_FETCH_NEXT as SmallInt, 0);
+                if result == SqlReturn::NO_DATA {
+                    break;
+                }
+                assert_eq!(SqlReturn::SUCCESS, result);
 
+                // After fetching the data, check that the buffers contain the
+                // expected values. As shown above, the data only has 3 rows.
+                assert!(i < 2, "too much data fetched");
+
+                let (id1, id2) = expected_id_data[i];
+                assert_eq!(id1, *(id_buffer as *mut i32));
+                assert_eq!(id2, *((id_buffer as ULen + 4) as *mut i32));
+
+                let (a1, a2) = expected_a_data[i];
+                assert_eq!(a1, *(a_buffer as *mut i64));
+                assert_eq!(a2, *((a_buffer as ULen + 8) as *mut i64));
+
+                i += 1;
+            }
+
+            // cleanup
             disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
         }
     }

--- a/integration_test/tests/bind_cols_tests.rs
+++ b/integration_test/tests/bind_cols_tests.rs
@@ -28,7 +28,7 @@ mod integration {
     ///     - SQLFreeStmt(SQL_UNBIND)
     #[test]
     fn test_unbind_cols() {
-        let (env_handle, conn_handle, stmt_handle) =
+        let (_, _, stmt_handle) =
             default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
@@ -70,9 +70,6 @@ mod integration {
                 "{}",
                 get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
             );
-
-            // clean up
-            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
         }
     }
 
@@ -88,7 +85,7 @@ mod integration {
     ///         - SQLFetchScroll
     #[test]
     fn test_bind_cols_and_fetch_next_rowset() {
-        let (env_handle, conn_handle, stmt_handle) =
+        let (_, _, stmt_handle) =
             default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
 
         unsafe {
@@ -177,9 +174,6 @@ mod integration {
 
                 i += 1;
             }
-
-            // cleanup
-            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
         }
     }
 }

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -1,11 +1,10 @@
 use constants::DRIVER_NAME;
 use cstr::{self, WideChar};
 use definitions::{
-    AttrOdbcVersion, CDataType, Desc, DriverConnectOption, EnvironmentAttribute, FetchOrientation,
-    HDbc, HEnv, HStmt, Handle, HandleType, Len, Pointer, SQLAllocHandle, SQLBindCol,
-    SQLColAttributeW, SQLDisconnect, SQLDriverConnectW, SQLExecDirectW, SQLFetch, SQLFetchScroll,
-    SQLFreeHandle, SQLGetData, SQLGetDiagRecW, SQLMoreResults, SQLNumResultCols, SQLSetEnvAttr,
-    SmallInt, SqlReturn, USmallInt, SQL_NTS,
+    AttrOdbcVersion, CDataType, Desc, DriverConnectOption, EnvironmentAttribute, HDbc, HEnv, HStmt,
+    Handle, HandleType, Len, Pointer, SQLAllocHandle, SQLBindCol, SQLColAttributeW, SQLDisconnect,
+    SQLDriverConnectW, SQLExecDirectW, SQLFetch, SQLFreeHandle, SQLGetData, SQLGetDiagRecW,
+    SQLMoreResults, SQLNumResultCols, SQLSetEnvAttr, SmallInt, SqlReturn, USmallInt, SQL_NTS,
 };
 use std::ptr::null_mut;
 use std::{env, slice};
@@ -428,37 +427,27 @@ pub fn get_column_attributes(stmt: Handle, expected_col_count: SmallInt) {
 }
 
 #[allow(dead_code)]
-/// Helper function for binding columns in a result set.
-/// - loop:
-///    - SQLBindCol for each column (determined by target_types vector)
-///    - SQLFetchScroll until SQL_NO_DATA is returned
-pub fn fetch_and_bind_cols(stmt_handle: HStmt, target_types: Vec<CDataType>) {
-    let binding_buffer = &mut [0u16; 4] as *mut _;
-    unsafe {
-        loop {
-            for (i, target_type) in target_types.iter().enumerate() {
-                assert_eq!(
-                    SqlReturn::SUCCESS,
-                    SQLBindCol(
-                        stmt_handle,
-                        (i + 1) as u16,
-                        *target_type,
-                        binding_buffer as Pointer,
-                        4,
-                        null_mut(),
-                    )
-                );
-            }
-
-            let result = SQLFetchScroll(stmt_handle, FetchOrientation::SQL_FETCH_NEXT, 0);
-            if result == SqlReturn::NO_DATA {
-                return;
-            }
-            assert_eq!(SqlReturn::SUCCESS, result);
-        }
+/// Helper function to bind columns.
+pub unsafe fn bind_cols(stmt_handle: HStmt, target_types: Vec<(CDataType, Pointer, Len)>) {
+    for (i, (target_type, binding_buffer, buffer_length)) in target_types.iter().enumerate() {
+        assert_eq!(
+            SqlReturn::SUCCESS,
+            SQLBindCol(
+                stmt_handle,
+                (i + 1) as USmallInt,
+                *target_type as SmallInt,
+                *binding_buffer,
+                *buffer_length,
+                null_mut(),
+            )
+        )
     }
 }
 
+#[allow(dead_code)]
+/// Helper function to execute the default query
+///    SELECT * FROM integration_test.foo
+/// via SQLExecDirectW.
 pub unsafe fn exec_direct_default_query(stmt_handle: HStmt) {
     let mut query: Vec<WideChar> = cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
     query.push(0);

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -444,7 +444,9 @@ pub unsafe fn bind_cols(
                 *binding_buffer,
                 *buffer_length,
                 *indicator,
-            )
+            ),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
         )
     }
 }

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -3,9 +3,9 @@ use cstr::{self, WideChar};
 use definitions::{
     AttrOdbcVersion, CDataType, Desc, DriverConnectOption, EnvironmentAttribute, FetchOrientation,
     HDbc, HEnv, HStmt, Handle, HandleType, Len, Pointer, SQLAllocHandle, SQLBindCol,
-    SQLColAttributeW, SQLDisconnect, SQLDriverConnectW, SQLFetch, SQLFetchScroll, SQLFreeHandle,
-    SQLGetData, SQLGetDiagRecW, SQLMoreResults, SQLNumResultCols, SQLSetEnvAttr, SmallInt,
-    SqlReturn, USmallInt, SQL_NTS,
+    SQLColAttributeW, SQLDisconnect, SQLDriverConnectW, SQLExecDirectW, SQLFetch, SQLFetchScroll,
+    SQLFreeHandle, SQLGetData, SQLGetDiagRecW, SQLMoreResults, SQLNumResultCols, SQLSetEnvAttr,
+    SmallInt, SqlReturn, USmallInt, SQL_NTS,
 };
 use std::ptr::null_mut;
 use std::{env, slice};
@@ -457,4 +457,15 @@ pub fn fetch_and_bind_cols(stmt_handle: HStmt, target_types: Vec<CDataType>) {
             assert_eq!(SqlReturn::SUCCESS, result);
         }
     }
+}
+
+pub unsafe fn exec_direct_default_query(stmt_handle: HStmt) {
+    let mut query: Vec<WideChar> = cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
+    query.push(0);
+    assert_eq!(
+        SqlReturn::SUCCESS,
+        SQLExecDirectW(stmt_handle, query.as_ptr(), SQL_NTS as i32),
+        "{}",
+        get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+    );
 }

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -428,8 +428,13 @@ pub fn get_column_attributes(stmt: Handle, expected_col_count: SmallInt) {
 
 #[allow(dead_code)]
 /// Helper function to bind columns.
-pub unsafe fn bind_cols(stmt_handle: HStmt, target_types: Vec<(CDataType, Pointer, Len)>) {
-    for (i, (target_type, binding_buffer, buffer_length)) in target_types.iter().enumerate() {
+pub unsafe fn bind_cols(
+    stmt_handle: HStmt,
+    target_types: Vec<(CDataType, Pointer, Len, *mut Len)>,
+) {
+    for (i, (target_type, binding_buffer, buffer_length, indicator)) in
+        target_types.iter().enumerate()
+    {
         assert_eq!(
             SqlReturn::SUCCESS,
             SQLBindCol(
@@ -438,7 +443,7 @@ pub unsafe fn bind_cols(stmt_handle: HStmt, target_types: Vec<(CDataType, Pointe
                 *target_type as SmallInt,
                 *binding_buffer,
                 *buffer_length,
-                null_mut(),
+                *indicator,
             )
         )
     }

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -10,13 +10,13 @@ mod common;
 mod integration {
     use crate::common::{
         default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
-        fetch_and_bind_cols, fetch_and_get_data, get_sql_diagnostics,
+        exec_direct_default_query, fetch_and_get_data, get_sql_diagnostics,
     };
     use cstr::WideChar;
     use definitions::{
-        AttrOdbcVersion, BindType, CDataType, FreeStmtOption, HStmt, Handle, HandleType, Pointer,
-        SQLCancel, SQLExecDirectW, SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn,
-        StatementAttribute, SQL_NTS,
+        AttrOdbcVersion, CDataType, FreeStmtOption, HStmt, Handle, HandleType, Pointer, SQLCancel,
+        SQLExecDirectW, SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn, StatementAttribute,
+        SQL_NTS,
     };
 
     /// This test is inspired by the SSIS Preview Data result set metadata flow.
@@ -48,82 +48,6 @@ mod integration {
             assert_eq!(
                 SqlReturn::SUCCESS,
                 SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_CLOSE as i16),
-                "{}",
-                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-            );
-
-            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
-        }
-    }
-
-    unsafe fn exec_direct_default_query(stmt_handle: HStmt) {
-        let mut query: Vec<WideChar> = cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
-        query.push(0);
-        assert_eq!(
-            SqlReturn::SUCCESS,
-            SQLExecDirectW(stmt_handle, query.as_ptr(), SQL_NTS as i32),
-            "{}",
-            get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-        );
-    }
-
-    /// This test is inspired by the SSIS Query flow. It is altered to be
-    /// more general than that specific flow, with a focus on freeing the
-    /// statement handle after calling SQLBindCol. This flow depends on
-    /// default_setup_connect_and_alloc_stmt.
-    /// After allocating a statement handle, the flow is:
-    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN)
-    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_ARRAY_SIZE, 1000)
-    ///     - SQLExecDirectW(<query>)
-    ///     - <loop: until SQLFetchScroll returns SQL_NO_DATA>
-    ///         - SQLBindCol for each column
-    ///         - SQLFetchScroll
-    ///     - SQLFreeStmt(SQL_UNBIND)
-    ///     - SQLDisconnect
-    ///     - SQLFreeHandle(SQL_HANDLE_DBC)
-    ///     - SQLFreeHandle(SQL_HANDLE_ENV)
-    #[test]
-    fn test_free_stmt_after_bind_col() {
-        let (env_handle, conn_handle, stmt_handle) =
-            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
-
-        unsafe {
-            let bind_type = BindType::SQL_BIND_BY_COLUMN as i32;
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLSetStmtAttrW(
-                    stmt_handle,
-                    StatementAttribute::SQL_ATTR_ROW_BIND_TYPE,
-                    bind_type as Pointer,
-                    0,
-                ),
-                "{}",
-                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-            );
-
-            let row_array_size = 1000;
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLSetStmtAttrW(
-                    stmt_handle,
-                    StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE,
-                    row_array_size as Pointer,
-                    0
-                ),
-                "{}",
-                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-            );
-
-            exec_direct_default_query(stmt_handle);
-
-            fetch_and_bind_cols(
-                stmt_handle,
-                vec![CDataType::SQL_C_SLONG, CDataType::SQL_C_SBIGINT],
-            );
-
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_UNBIND),
                 "{}",
                 get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
             );

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -14,9 +14,8 @@ mod integration {
     };
     use cstr::WideChar;
     use definitions::{
-        AttrOdbcVersion, CDataType, FreeStmtOption, HStmt, Handle, HandleType, Pointer, SQLCancel,
-        SQLExecDirectW, SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn, StatementAttribute,
-        SQL_NTS,
+        AttrOdbcVersion, CDataType, FreeStmtOption, Handle, HandleType, Pointer, SQLCancel,
+        SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn, StatementAttribute, SQL_NTS,
     };
 
     /// This test is inspired by the SSIS Preview Data result set metadata flow.

--- a/integration_test/tests/free_and_cancel_tests.rs
+++ b/integration_test/tests/free_and_cancel_tests.rs
@@ -10,13 +10,13 @@ mod common;
 mod integration {
     use crate::common::{
         default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
-        fetch_and_get_data, get_sql_diagnostics,
+        fetch_and_bind_cols, fetch_and_get_data, get_sql_diagnostics,
     };
     use cstr::WideChar;
     use definitions::{
-        AttrOdbcVersion, CDataType, FreeStmtOption, Handle, HandleType, Pointer, SQLCancel,
-        SQLExecDirectW, SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn, StatementAttribute,
-        SQL_NTS,
+        AttrOdbcVersion, BindType, CDataType, FreeStmtOption, HStmt, Handle, HandleType, Pointer,
+        SQLCancel, SQLExecDirectW, SQLFreeStmt, SQLPrepareW, SQLSetStmtAttrW, SqlReturn,
+        StatementAttribute, SQL_NTS,
     };
 
     /// This test is inspired by the SSIS Preview Data result set metadata flow.
@@ -56,6 +56,82 @@ mod integration {
         }
     }
 
+    unsafe fn exec_direct_default_query(stmt_handle: HStmt) {
+        let mut query: Vec<WideChar> = cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
+        query.push(0);
+        assert_eq!(
+            SqlReturn::SUCCESS,
+            SQLExecDirectW(stmt_handle, query.as_ptr(), SQL_NTS as i32),
+            "{}",
+            get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+        );
+    }
+
+    /// This test is inspired by the SSIS Query flow. It is altered to be
+    /// more general than that specific flow, with a focus on freeing the
+    /// statement handle after calling SQLBindCol. This flow depends on
+    /// default_setup_connect_and_alloc_stmt.
+    /// After allocating a statement handle, the flow is:
+    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN)
+    ///     - SQLSetStmtAttrW(SQL_ATTR_ROW_ARRAY_SIZE, 1000)
+    ///     - SQLExecDirectW(<query>)
+    ///     - <loop: until SQLFetchScroll returns SQL_NO_DATA>
+    ///         - SQLBindCol for each column
+    ///         - SQLFetchScroll
+    ///     - SQLFreeStmt(SQL_UNBIND)
+    ///     - SQLDisconnect
+    ///     - SQLFreeHandle(SQL_HANDLE_DBC)
+    ///     - SQLFreeHandle(SQL_HANDLE_ENV)
+    #[test]
+    fn test_free_stmt_after_bind_col() {
+        let (env_handle, conn_handle, stmt_handle) =
+            default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+
+        unsafe {
+            let bind_type = BindType::SQL_BIND_BY_COLUMN as i32;
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLSetStmtAttrW(
+                    stmt_handle,
+                    StatementAttribute::SQL_ATTR_ROW_BIND_TYPE,
+                    bind_type as Pointer,
+                    0,
+                ),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            let row_array_size = 1000;
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLSetStmtAttrW(
+                    stmt_handle,
+                    StatementAttribute::SQL_ATTR_ROW_ARRAY_SIZE,
+                    row_array_size as Pointer,
+                    0
+                ),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            exec_direct_default_query(stmt_handle);
+
+            fetch_and_bind_cols(
+                stmt_handle,
+                vec![CDataType::SQL_C_SLONG, CDataType::SQL_C_SBIGINT],
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_handle, FreeStmtOption::SQL_UNBIND),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
+            );
+
+            disconnect_and_free_dbc_and_env_handles(env_handle, conn_handle);
+        }
+    }
+
     /// This test is inspired by the SSIS Preview Data data retrieval flow.
     /// It is altered to be more general than that specific flow, with a focus
     /// on canceling the query after getting some data. This flow depends on
@@ -87,15 +163,7 @@ mod integration {
                 get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
             );
 
-            let mut query: Vec<WideChar> =
-                cstr::to_widechar_vec("SELECT * FROM integration_test.foo");
-            query.push(0);
-            assert_eq!(
-                SqlReturn::SUCCESS,
-                SQLExecDirectW(stmt_handle, query.as_ptr(), SQL_NTS as i32),
-                "{}",
-                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, stmt_handle as Handle)
-            );
+            exec_direct_default_query(stmt_handle);
 
             fetch_and_get_data(
                 stmt_handle as Handle,


### PR DESCRIPTION
This PR adds an integration test for the SSIS query flow. ~This builds on top of #194. Feel free to ignore the first commit -- for convenience, I'll rebase it away once #194 is merged into master.~

I created just one test since really only one unique new behavior is done by running a query in SSIS. The test calls `SQLBindCol` after executing a query, and calls `SQLFreeStmt` after those calls to `SQLBindCol`. This is different from the previous `SQLFreeStmt` test since the previous one did not bind columns prior to freeing the statement.

This is optionally blocked on #192 since I set the `ROW_ARRAY_SIZE` attribute to 1000 (just like SSIS). Technically, I can omit that and we can observe this test passing now. I figure it is ok to leave this in review until after #192 is merged, though.