### PR TITLE
SQL-1933: Add oidc_call_back function

### DIFF
--- a/core/src/bin/test_oidc_call_back.rs
+++ b/core/src/bin/test_oidc_call_back.rs
@@ -1,0 +1,25 @@
+use mongo_odbc_core::oidc_auth::*;
+
+#[tokio::main]
+async fn main() {
+    let c = CallbackContext {
+        idp_info: Some(IdpServerInfo {
+            issuer: "https://mongodb-dev.okta.com/oauth2/ausqrxbcr53xakaRR357".to_string(),
+            client_id: Some("0oarvap2r7PmNIBsS357".to_string()),
+            // show that we get a refresh_token even when we don't ask for it here
+            request_scopes: Some(vec!["openid".to_string()]),
+        }),
+        refresh_token: None,
+        timeout_seconds: None,
+        version: 1,
+    };
+    let mut refresh_c = c.clone();
+    let IdpServerResponse {
+        access_token,
+        expires: _,
+        refresh_token,
+    } = oidc_call_back(c).await.unwrap();
+    println!("initial access token: {:access_token?}");
+    refresh_c.refresh_token = refresh_token;
+    println!("second response: {:?}", oidc_call_back(refresh_c).await.unwrap());
+}

--- a/core/src/bin/test_oidc_call_back.rs
+++ b/core/src/bin/test_oidc_call_back.rs
@@ -1,7 +1,7 @@
 use mongo_odbc_core::oidc_auth::*;
 
 // This shows that the oidc_call_back function works. The second call will use the refresh token,
-// which will be obvious in that the webbrower only opens once.
+// which will be obvious in that the web browser only opens once.
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = CallbackContext {

--- a/core/src/bin/test_oidc_call_back.rs
+++ b/core/src/bin/test_oidc_call_back.rs
@@ -1,6 +1,6 @@
 use mongo_odbc_core::oidc_auth::*;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = CallbackContext {
         idp_info: Some(IdpServerInfo {

--- a/core/src/bin/test_oidc_call_back.rs
+++ b/core/src/bin/test_oidc_call_back.rs
@@ -15,11 +15,14 @@ async fn main() {
     };
     let mut refresh_c = c.clone();
     let IdpServerResponse {
-        access_token,
+        access_token: _,
         expires: _,
         refresh_token,
     } = oidc_call_back(c).await.unwrap();
-    println!("initial access token: {:access_token?}");
+    println!("initial refresh token: {refresh_token:?}");
     refresh_c.refresh_token = refresh_token;
-    println!("second response: {:?}", oidc_call_back(refresh_c).await.unwrap());
+    println!(
+        "second response: {:?}",
+        oidc_call_back(refresh_c).await.unwrap()
+    );
 }

--- a/core/src/bin/test_oidc_call_back.rs
+++ b/core/src/bin/test_oidc_call_back.rs
@@ -1,5 +1,7 @@
 use mongo_odbc_core::oidc_auth::*;
 
+// This shows that the oidc_call_back function works. The second call will use the refresh token,
+// which will be obvious in that the webbrower only opens once.
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = CallbackContext {

--- a/core/src/bin/test_oidc_call_back_short_timeout.rs
+++ b/core/src/bin/test_oidc_call_back_short_timeout.rs
@@ -1,6 +1,6 @@
 use mongo_odbc_core::oidc_auth::*;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = CallbackContext {
         idp_info: Some(IdpServerInfo {

--- a/core/src/bin/test_oidc_call_back_short_timeout.rs
+++ b/core/src/bin/test_oidc_call_back_short_timeout.rs
@@ -1,0 +1,20 @@
+use mongo_odbc_core::oidc_auth::*;
+
+#[tokio::main]
+async fn main() {
+    let c = CallbackContext {
+        idp_info: Some(IdpServerInfo {
+            issuer: "https://mongodb-dev.okta.com/oauth2/ausqrxbcr53xakaRR357".to_string(),
+            client_id: Some("0oarvap2r7PmNIBsS357".to_string()),
+            // show that we get a refresh_token even when we don't ask for it here
+            request_scopes: Some(vec!["openid".to_string()]),
+        }),
+        refresh_token: None,
+        // 2 seconds works well on my laptop. 1 second results in the request dying before the
+        //   server can redirect
+        timeout_seconds: Some(std::time::Instant::now() + std::time::Duration::from_secs(2)),
+        version: 1,
+    };
+    println!("This is very timing dependent, but we should see a timeout, if we play with the value: {:?}", oidc_call_back(c).await.unwrap_err().get_custom::<Error>());
+    // example output from my laptop: `This is very timing dependent, but we should see a timeout, if we play with the value: Some(Timedout)`
+}

--- a/core/src/bin/test_oidc_call_back_short_timeout.rs
+++ b/core/src/bin/test_oidc_call_back_short_timeout.rs
@@ -6,7 +6,6 @@ async fn main() {
         idp_info: Some(IdpServerInfo {
             issuer: "https://mongodb-dev.okta.com/oauth2/ausqrxbcr53xakaRR357".to_string(),
             client_id: Some("0oarvap2r7PmNIBsS357".to_string()),
-            // show that we get a refresh_token even when we don't ask for it here
             request_scopes: Some(vec!["openid".to_string()]),
         }),
         refresh_token: None,

--- a/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
+++ b/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
@@ -6,7 +6,6 @@ async fn main() {
         idp_info: Some(IdpServerInfo {
             issuer: "https://mongodb-dev.okta.com/oauth2/ausqrxbcr53xakaRR357".to_string(),
             client_id: Some("0oarvap2r7PmNIBsS357".to_string()),
-            // show that we get a refresh_token even when we don't ask for it here
             request_scopes: Some(vec!["openid".to_string()]),
         }),
         refresh_token: Some("PnWePzgf-4BqC048C5Q7BhtBxfu3nId9e72y5T5-PLj".to_string()),

--- a/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
+++ b/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
@@ -1,0 +1,19 @@
+use mongo_odbc_core::oidc_auth::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let c = CallbackContext {
+        idp_info: Some(IdpServerInfo {
+            issuer: "https://mongodb-dev.okta.com/oauth2/ausqrxbcr53xakaRR357".to_string(),
+            client_id: Some("0oarvap2r7PmNIBsS357".to_string()),
+            // show that we get a refresh_token even when we don't ask for it here
+            request_scopes: Some(vec!["openid".to_string()]),
+        }),
+        refresh_token: Some("PnWePzgf-4BqC048C5Q7BhtBxfu3nId9e72y5T5-PLj".to_string()),
+        // 2 seconds works well on my laptop. 1 second results in the request dying before the
+        //   server can redirect
+        timeout_seconds: Some(std::time::Instant::now() + std::time::Duration::from_secs(2)),
+        version: 1,
+    };
+    println!("This will result in an error: {:?}", oidc_call_back(c).await.unwrap_err().get_custom::<Error>());
+}

--- a/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
+++ b/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
@@ -14,6 +14,9 @@ async fn main() {
         timeout_seconds: Some(std::time::Instant::now() + std::time::Duration::from_secs(2)),
         version: 1,
     };
+    // this should return something similar to: Some(Other("OpenID Connect: code exchange failed:
+    // Server returned error response: StandardErrorResponse { error: invalid_grant,
+    // error_description: Some(\"The refresh token is invalid or expired.\"), error_uri: None }"))
     println!(
         "This will result in an error: {:?}",
         oidc_call_back(c).await.unwrap_err().get_custom::<Error>()

--- a/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
+++ b/core/src/bin/test_oidc_call_back_with_bad_refresh_token.rs
@@ -14,5 +14,8 @@ async fn main() {
         timeout_seconds: Some(std::time::Instant::now() + std::time::Duration::from_secs(2)),
         version: 1,
     };
-    println!("This will result in an error: {:?}", oidc_call_back(c).await.unwrap_err().get_custom::<Error>());
+    println!(
+        "This will result in an error: {:?}",
+        oidc_call_back(c).await.unwrap_err().get_custom::<Error>()
+    );
 }

--- a/core/src/oidc_auth.rs
+++ b/core/src/oidc_auth.rs
@@ -61,9 +61,13 @@ pub async fn oidc_call_back(params: CallbackContext) -> mongodb::error::Result<I
 
     // If there is a refresh token, we refresh, otherwise we do not
     if params.refresh_token.is_some() {
-        Ok(time::timeout(sleep_duration, do_refresh(params)).await.map_err(|_| Error::Timedout)??)
+        Ok(time::timeout(sleep_duration, do_refresh(params))
+            .await
+            .map_err(|_| Error::Timedout)??)
     } else {
-        Ok(time::timeout(sleep_duration, do_auth_flow(params)).await.map_err(|_| Error::Timedout)??)
+        Ok(time::timeout(sleep_duration, do_auth_flow(params))
+            .await
+            .map_err(|_| Error::Timedout)??)
     }
 }
 

--- a/core/src/oidc_auth.rs
+++ b/core/src/oidc_auth.rs
@@ -9,7 +9,7 @@ use std::{collections::HashSet, hash::RandomState, time::Instant};
 use tokio::time::{self, Duration};
 
 const DEFAULT_REDIRECT_URI: &str = "http://localhost:27097/redirect";
-const DEFAULT_SLEEP_DURATION: Duration = Duration::from_secs(5 * 60); // from_mins is unstable
+const DEFAULT_SLEEP_DURATION: Duration = Duration::from_secs(5 * 60); // from_mins is unstable, so we use from_secs with a multiplication. The multiplication is performed at compile time, anyway
 
 // temporary until rust driver OIDC support is released
 // TODO Remove Me.


### PR DESCRIPTION
Note that this also handles the timeout. The test function with timeout works on my laptop. I'm still waiting forever and a half for my desktop harddrive to finish encrypting, but I imagine it will work on windows, also.