### PR TITLE
SQL-2051: clean up statements in disconnect if necessary

### DIFF
--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -158,7 +158,7 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
                     if let Some(true) = test.is_standard_type {
                         conn_str.push_str("SIMPLE_TYPES_ONLY=0;");
                     }
-                    let conn_handle = connect_with_conn_string(env, conn_str).unwrap();
+                    let conn_handle = connect_with_conn_string(env, Some(conn_str)).unwrap();
                     let test_result = match test.test_definition {
                         TestDef::Query(ref q) => run_query_test(q, &test, conn_handle, generate),
                         TestDef::Function(ref f) => {
@@ -202,7 +202,7 @@ pub fn run_resultset_tests_odbc_2(generate: bool) -> Result<()> {
                     if let Some(true) = test.is_standard_type {
                         conn_str.push_str("SIMPLE_TYPES_ONLY=0;");
                     }
-                    let conn_handle = connect_with_conn_string(env, conn_str).unwrap();
+                    let conn_handle = connect_with_conn_string(env, Some(conn_str)).unwrap();
                     let test_result = match test.test_definition {
                         TestDef::Query(ref q) => run_query_test(q, &test, conn_handle, generate),
                         TestDef::Function(ref f) => {

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -179,13 +179,16 @@ pub fn connect_and_allocate_statement(
     in_connection_string: Option<String>,
 ) -> (HDbc, HStmt) {
     let conn_str = in_connection_string.unwrap_or_else(generate_default_connection_str);
-    let conn_handle = connect_with_conn_string(env_handle, conn_str).unwrap();
+    let conn_handle = connect_with_conn_string(env_handle, Some(conn_str)).unwrap();
     (conn_handle, allocate_statement(conn_handle).unwrap())
 }
 
 #[allow(dead_code)]
-/// Connects to database with provided connection string
-pub fn connect_with_conn_string(env_handle: HEnv, in_connection_string: String) -> Result<HDbc> {
+/// Connects to database with provided connection string, or default connection string
+pub fn connect_with_conn_string(
+    env_handle: HEnv,
+    in_connection_string: Option<String>,
+) -> Result<HDbc> {
     // Allocate a DBC handle
     let mut dbc: Handle = null_mut();
     unsafe {
@@ -197,6 +200,8 @@ pub fn connect_with_conn_string(env_handle: HEnv, in_connection_string: String) 
             SqlReturn::SUCCESS => (),
             sql_return => return Err(Error::HandleAllocation(sql_return_to_string(sql_return))),
         }
+        let in_connection_string =
+            in_connection_string.unwrap_or_else(generate_default_connection_str);
         let mut in_connection_string_encoded = cstr::to_widechar_vec(&in_connection_string);
         in_connection_string_encoded.push(0);
         let str_len_ptr = &mut 0;

--- a/integration_test/tests/disconnect_tests.rs
+++ b/integration_test/tests/disconnect_tests.rs
@@ -1,0 +1,130 @@
+mod common;
+
+mod integration {
+    use crate::common::{
+        allocate_env, allocate_statement, connect_with_conn_string,
+        default_setup_connect_and_alloc_stmt, disconnect_and_free_dbc_and_env_handles,
+        get_sql_diagnostics,
+    };
+    use definitions::{
+        AttrOdbcVersion, FreeStmtOption, Handle, HandleType, SQLExecDirectW, SQLFreeHandle,
+        SQLFreeStmt, SqlReturn, SQL_NTS,
+    };
+
+    #[test]
+    fn sql_disconnect_closes_statement_implicitly() {
+        let (env, dbc, stmt) = default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+        let query = b"SELECT * FROM integration_test.foo\0".map(|b| b as u16);
+        unsafe {
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLExecDirectW(stmt, query.as_ptr(), SQL_NTS as i32,),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+
+            // we will not free the statement, instead proceeding directly to disconnect and freeing the dbc and env handles
+            disconnect_and_free_dbc_and_env_handles(env, dbc)
+        }
+    }
+
+    #[test]
+    fn sql_disconnect_implicitly_closing_statment_cursors_is_safe_for_closed_statements() {
+        let (env, dbc, stmt) = default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+        let query = b"SELECT * FROM integration_test.foo\0".map(|b| b as u16);
+        unsafe {
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLExecDirectW(stmt, query.as_ptr(), SQL_NTS as i32,),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt, FreeStmtOption::SQL_CLOSE as i16),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+
+            // we will not free the statement, instead proceeding directly to disconnect and freeing the dbc and env handles
+            disconnect_and_free_dbc_and_env_handles(env, dbc)
+        }
+    }
+
+    #[test]
+    fn sql_disconnect_implicitly_closing_statment_cursors_is_safe_for_unbound_statemens() {
+        let (env, dbc, stmt) = default_setup_connect_and_alloc_stmt(AttrOdbcVersion::SQL_OV_ODBC3);
+        let query = b"SELECT * FROM integration_test.foo\0".map(|b| b as u16);
+        unsafe {
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLExecDirectW(stmt, query.as_ptr(), SQL_NTS as i32,),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+
+            // we didn't actually bind a statement, so this should be a no-op
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt, FreeStmtOption::SQL_UNBIND as i16),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+
+            // we will not free the statement, instead proceeding directly to disconnect and freeing the dbc and env handles
+            disconnect_and_free_dbc_and_env_handles(env, dbc)
+        }
+    }
+
+    #[test]
+    fn sql_disconnect_handles_many_statements_properly() {
+        let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
+        let dbc = connect_with_conn_string(env, None)
+            .expect("Failed to connect with default connection string");
+        let stmt_1 = allocate_statement(dbc).expect("Failed to allocate statement 1");
+        let stmt_2 = allocate_statement(dbc).expect("Failed to allocate statement 2");
+        let stmt_3 = allocate_statement(dbc).expect("Failed to allocate statement 3");
+        let stmt_4 = allocate_statement(dbc).expect("Failed to allocate statement 4");
+        let stmt_5 = allocate_statement(dbc).expect("Failed to allocate statement 5");
+        let statements = [stmt_1, stmt_2, stmt_3, stmt_4, stmt_5];
+
+        let query = b"SELECT * FROM integration_test.foo\0".map(|b| b as u16);
+        statements.iter().for_each(|stmt| unsafe {
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLExecDirectW(*stmt, query.as_ptr(), SQL_NTS as i32,),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt.cast::<Handle>()),
+            );
+        });
+
+        // we will close statements 1 and 3
+        unsafe {
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_1, FreeStmtOption::SQL_CLOSE as i16),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt_1.cast::<Handle>()),
+            );
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt_3, FreeStmtOption::SQL_CLOSE as i16),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt_3.cast::<Handle>()),
+            );
+
+            // and we'll free statement 3 handle
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                // interestingly, rust doesn't like the cast here, so we'll just use the raw value
+                SQLFreeHandle(HandleType::SQL_HANDLE_STMT as i16, stmt_3 as *mut _),
+                "{}",
+                get_sql_diagnostics(HandleType::SQL_HANDLE_STMT, *stmt_3.cast::<Handle>())
+            );
+        }
+
+        disconnect_and_free_dbc_and_env_handles(env, dbc);
+    }
+}


### PR DESCRIPTION
SQLDisconnect now closes cursors on any open statements as part of its internal logic. This is safe to do since the cursor is an option, and closing it sets the option to None, which will allow Rust to clean up its resources automatically. Iterating over the statements is as safe as possible with no unwraps. The nesting gets a bit deep but it's not too unwieldy.

Additionally, as part of this PR I made a few changes to the common test infra to make it easier to get the default connection string.