### PR TITLE
SQL-2104: add papertrail tracing to odbc

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1365,8 +1365,8 @@ functions:
         product: mongo-odbc-driver
         version: ${version_id}
         filenames:
-          - installer/msi/mongoodbc.msi
-          - installer/tgz/mongoodbc.tar.gz
+          - release/mongoodbc-signed.msi
+          - target/release/mongoodbc.tar.gz
 
   "update download center feed":
     # Download the current json feed used by the download center

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1616,8 +1616,8 @@ tasks:
     depends_on:
       - name: release
     commands:
-      - func: "update download center feed"
       - func: "trace artifacts"
+      - func: "update download center feed"
 
   - name: release
     git_tag_only: true

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1356,6 +1356,18 @@ functions:
         content_type: application/octet-stream
         display_name: crash-dump-
 
+  "trace artifacts":
+    - command: papertrail.trace
+      params:
+        work_dir: mongosql-odbc-driver
+        key_id: ${papertrail_id}
+        secret_key: ${papertrail_key}
+        product: mongo-odbc-driver
+        version: ${version_id}
+        filenames:
+          - installer/msi/mongoodbc.msi
+          - installer/tgz/mongoodbc.tar.gz
+
   "update download center feed":
     # Download the current json feed used by the download center
     - command: s3.get
@@ -1605,6 +1617,7 @@ tasks:
       - name: release
     commands:
       - func: "update download center feed"
+      - func: "trace artifacts"
 
   - name: release
     git_tag_only: true


### PR DESCRIPTION
Successful run: https://spruce.mongodb.com/task/mongosql_odbc_driver_release_trace_artifacts_test_patch_40ad9d02424a297f5baae4657fd2d869cd2bcc17_666a1af864e1ae0007c8faac_24_06_12_22_02_44/logs?execution=0

Producing the following (testing) trace: https://papertrail.devprod-infra.prod.corp.mongodb.com/product-version?product=mongo-odbc-driver-testing&version=666a1af864e1ae0007c8faac