### PR TITLE
SQL-2135: update display size of column

### DIFF
--- a/win_setupgui/src/gui.rs
+++ b/win_setupgui/src/gui.rs
@@ -83,11 +83,11 @@ pub struct ConfigGui {
     database_input: nwg::TextInput,
 
     #[nwg_control(flags: "VISIBLE", text: "Enable maximum string length")]
-    #[nwg_layout_item(layout: grid,  row: 6, col: 0, col_span: 2)]
+    #[nwg_layout_item(layout: grid,  row: 6, col: 0, col_span: 4)]
     enable_max_string_length_field: nwg::Label,
 
     #[nwg_control(flags: "VISIBLE", text: "")]
-    #[nwg_layout_item(layout: grid,  row: 6, col: 2, col_span: 7)]
+    #[nwg_layout_item(layout: grid,  row: 6, col: 4, col_span: 3)]
     enable_max_string_length_input: nwg::CheckBox,
 
     #[nwg_control(flags: "VISIBLE", text: "Test")]


### PR DESCRIPTION
This updates the effective display size of the column containg the maximum string length setting by altering the column count the text is allowed to fill.

![Screenshot 2024-06-17 075313](https://github.com/mongodb/mongo-odbc-driver/assets/1911390/df6c7a42-661b-43c2-80d7-5841d44518cb)
