### PR TITLE
SQL-2066: Update SQLFreeStmt to check that mongo_statement exists before closing cursor

### DIFF
--- a/odbc/src/api/free_stmt_tests.rs
+++ b/odbc/src/api/free_stmt_tests.rs
@@ -165,4 +165,22 @@ mod unit {
             );
         }
     }
+
+    #[test]
+    fn test_free_stmt_close_no_mongo_statement() {
+        let env = &mut MongoHandle::Env(Env::with_state(EnvState::Allocated));
+        let conn =
+            &mut MongoHandle::Connection(Connection::with_state(env, ConnectionState::Allocated));
+        let stmt: *mut _ =
+            &mut MongoHandle::Statement(Statement::with_state(conn, StatementState::Allocated));
+
+        unsafe {
+            // By default, the mongo_statement is set to None. In this case, SQLFreeStmt should
+            // result in a no-op, not an error.
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLFreeStmt(stmt as *mut _, FreeStmtOption::SQL_CLOSE as i16)
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR updates `SQLFreeStmt` to handle the case when the `FreeStmtOption` is `SQL_CLOSE` and `mongo_statement` is `None`. Previously, we would return an error that wrapped a panic. Now, we no-op. I added a unit test to demonstrate we no longer panic/error.