### PR TITLE
SQL-2106: Add compliance report for odbc driver

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2081,14 +2081,13 @@ tasks:
         variant: code-quality-security
       - name: semgrep
         variant: code-quality-security
-      - name: compliance-report
-        variant: code-quality-security
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "publish static code analysis"
-      - func: "publish compliance report"
       - func: "pull augmented SBOM from Silk"
       - func: "publish augmented SBOM"
+       - func: "generate compliance report"
+       - func: "publish compliance report"
 
 
 task_groups:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -388,7 +388,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
         bucket: mciuploads
     - command: s3.put

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -93,6 +93,7 @@ functions:
             export SBOM_LICENSES="mongo-odbc-driver.licenses.cdx.json"
             export SBOM_VULN="mongo-odbc-driver.merge.grype.cdx.json"
             export SBOM_FINAL="mongo-odbc-driver.full.cdx.json"
+            export COMPLIANCE_REPORT_NAME="mongo-odbc-driver_compliance_report.md"
             export ALLOW_VULNS="${AllowVulns}"
 
             # Windows variables
@@ -332,6 +333,67 @@ functions:
           ./$SBOM_DIR/grype sbom:$SBOM_LICENSES --fail-on low
           echo "---------------------------------------------"
           echo "<<<< Done scanning SBOM"
+  
+  "generate compliance report":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: mongosql-odbc-driver
+        env:
+          IS_TAG_TRIGGERED: "${triggered_by_git_tag}"
+          AUTHOR: "${author}"
+          AUTHOR_EMAIL: "${author_email}"
+        script: |
+          ${prepare_shell}
+          echo "Author = $AUTHOR"
+          echo "Author email = $AUTHOR_EMAIL"
+          echo "Version = $RELEASE_VERSION"
+          SBOM_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}.sbom.json"
+          SARIF_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongo-odbc-$RELEASE_VERSION.sast.sarif"
+          echo "Sbom url = $SBOM_URL"
+          echo "Sarif Url = $SARIF_URL"
+
+          # Copy template
+          cp resources/ssdlc/mongo-odbc-driver_compliance_report_template.md $COMPLIANCE_REPORT_NAME
+
+          # Update the version
+          sed -i.bu "s,%VERSION%,$RELEASE_VERSION,g" $COMPLIANCE_REPORT_NAME
+          # Update the SBOM link
+          sed -i.bu "s,%SBOM_URL%,$SBOM_URL,g" $COMPLIANCE_REPORT_NAME
+          # Update the SARIF link
+          sed -i.bu "s,%SARIF_URL%,$SARIF_URL,g" $COMPLIANCE_REPORT_NAME
+          # Update the author information
+          sed -i.bu "s,%AUTHOR%,$AUTHOR,g" $COMPLIANCE_REPORT_NAME
+          sed -i.bu "s,%AUTHOR_EMAIL%,$AUTHOR_EMAIL,g" $COMPLIANCE_REPORT_NAME
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/mongo-odbc-driver_compliance_report.md
+        content_type: application/json
+        bucket: mciuploads
+        permissions: public-read
+
+  "publish compliance report":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/mongo-odbc-driver_compliance_report.md
+        content_type: application/json
+        bucket: mciuploads
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
+        remote_file: mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
+        content_type: application/json
+        bucket: translators-connectors-releases
+        permissions: public-read
+        display_name: mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
 
   "set and check packages version":
     - command: shell.exec
@@ -1686,6 +1748,11 @@ tasks:
       - func: set and check packages version
       - func: "generate SBOM and scan"
 
+  - name: compliance-report
+    commands:
+      - func: "generate compliance report"
+      - func: "publish compliance report"
+
   - name: compile
     commands:
       - func: "install iODBC"
@@ -1932,6 +1999,7 @@ buildvariants:
     tasks:
       - name: semgrep
       - name: sbom
+      - name: compliance-report
 
   - name: windows-64
     tags: ["release-variant"]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1853,8 +1853,6 @@ tasks:
       - func: "generate SBOM"
       - func: "scan SBOM"
       - func: "push SBOM Lite to Silk"
-      - func: "pull augmented SBOM from Silk"
-      - func: "publish augmented SBOM"
 
   - name: compliance-report
     depends_on:
@@ -2072,6 +2070,8 @@ tasks:
     commands:
       - func: "publish static code analysis"
       - func: "publish compliance report"
+      - func: "pull augmented SBOM from Silk"
+      - func: "publish augmented SBOM"
 
   - name: ssdlc-artifacts-snapshot
     run_on: ubuntu2204-small
@@ -2087,6 +2087,8 @@ tasks:
     commands:
       - func: "publish static code analysis"
       - func: "publish compliance report"
+      - func: "pull augmented SBOM from Silk"
+      - func: "publish augmented SBOM"
 
 
 task_groups:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1791,7 +1791,6 @@ tasks:
       - name: semgrep
     commands:
       - func: "generate compliance report"
-      - func: "publish compliance report"
 
   - name: compile
     commands:
@@ -1985,7 +1984,38 @@ tasks:
     exec_timeout_secs: 3600 # 1h
     commands:
       - func: "generate static code analysis"
+
+  - name: ssdlc-artifacts-release
+    run_on: ubuntu2204-small
+    git_tag_only: true
+    depends_on:
+      - name: "release"
+        variant: "release"
+      - name: sbom
+        variant: code-quality-security
+      - name: semgrep
+        variant: code-quality-security
+      - name: compliance-report
+        variant: code-quality-security
+    exec_timeout_secs: 300 # 5m
+    commands:
       - func: "publish static code analysis"
+      - func: "publish compliance report"
+
+  - name: ssdlc-artifacts-snapshot
+    run_on: ubuntu2204-small
+    depends_on:
+      - name: sbom
+        variant: code-quality-security
+      - name: semgrep
+        variant: code-quality-security
+      - name: compliance-report
+        variant: code-quality-security
+    exec_timeout_secs: 300 # 5m
+    commands:
+      - func: "publish static code analysis"
+      - func: "publish compliance report"
+
 
 task_groups:
   - name: windows-windows-test-unit-group
@@ -2042,6 +2072,7 @@ buildvariants:
       - name: semgrep
       - name: sbom
       - name: compliance-report
+      - name: ssdlc-artifacts-snapshot
 
   - name: windows-64
     tags: ["release-variant"]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -377,7 +377,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
         bucket: mciuploads
         permissions: public-read

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2075,6 +2075,7 @@ tasks:
 
   - name: ssdlc-artifacts-snapshot
     run_on: ubuntu2204-small
+    allow_for_git_tag: false
     depends_on:
       - name: sbom
         variant: code-quality-security

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -59,6 +59,8 @@ functions:
           export LOCAL_DUMP_ORIGINAL_REG_VAL=local_dump_original_value.reg
           export MONGOODBC_DEBUGGING_INFO_ARCHIVE=crashDebuggingInfo
           export SCRIPT_FOLDER=resources
+          export COMPLIANCE_REPORT_NAME="mongo-odbc-driver_compliance_report.md"
+          export STATIC_CODE_ANALYSIS_NAME="mongo-odbc-driver.sast.sarif"
           if [[ "${triggered_by_git_tag}" != "" ]]; then
             export RELEASE_VERSION=$(echo ${triggered_by_git_tag} | sed s/v//)
           else
@@ -71,6 +73,8 @@ functions:
           MSI_FILENAME: "$MSI_FILENAME"
           WINDOWS_INSTALLER_PATH: "mongosql-odbc-driver/windows/$RELEASE_VERSION/release/$MSI_FILENAME"
           UBUNTU2204_INSTALLER_PATH: "mongosql-odbc-driver/ubuntu2204/$RELEASE_VERSION/release/mongoodbc.tar.gz"
+          COMPLIANCE_REPORT_NAME: "$COMPLIANCE_REPORT_NAME"
+          STATIC_CODE_ANALYSIS_NAME: "$STATIC_CODE_ANALYSIS_NAME"
           prepare_shell: |
             set -o errexit
             export RELEASE_VERSION="$RELEASE_VERSION"
@@ -93,7 +97,8 @@ functions:
             export SBOM_LICENSES="mongo-odbc-driver.licenses.cdx.json"
             export SBOM_VULN="mongo-odbc-driver.merge.grype.cdx.json"
             export SBOM_FINAL="mongo-odbc-driver.full.cdx.json"
-            export COMPLIANCE_REPORT_NAME="mongo-odbc-driver_compliance_report.md"
+            export COMPLIANCE_REPORT_NAME="$COMPLIANCE_REPORT_NAME"
+            export STATIC_CODE_ANALYSIS_NAME="$STATIC_CODE_ANALYSIS_NAME"
             export ALLOW_VULNS="${AllowVulns}"
 
             # Windows variables
@@ -369,9 +374,9 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/mongo-odbc-driver_compliance_report.md
-        content_type: application/json
+        local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/${COMPLIANCE_REPORT_NAME}
+        content_type: text/markdown
         bucket: mciuploads
         permissions: public-read
 
@@ -380,17 +385,17 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/mongo-odbc-driver_compliance_report.md
-        content_type: application/json
+        local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/${COMPLIANCE_REPORT_NAME}
+        content_type: text/markdown
         bucket: mciuploads
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-odbc-driver/mongo-odbc-driver_compliance_report.md
+        local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
         remote_file: mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
-        content_type: application/json
+        content_type: text/markdown
         bucket: translators-connectors-releases
         permissions: public-read
         display_name: mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
@@ -1684,7 +1689,7 @@ functions:
         permissions: public-read
         content_type: application/json
 
-  "static code analysis":
+  "generate static code analysis":
     - command: shell.exec
       type: test
       params:
@@ -1724,6 +1729,26 @@ functions:
         content_type: text/plain
         bucket: mciuploads
         permissions: public-read
+  
+  "publish static code analysis":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/${STATIC_CODE_ANALYSIS_NAME}
+        remote_file:  mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
+        content_type: application/json
+        bucket: mciuploads
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-odbc-driver/${STATIC_CODE_ANALYSIS_NAME}
+        remote_file: mongosql-odbc-driver/mongo-odbc-${RELEASE_VERSION}.sast.sarif
+        content_type: application/json
+        bucket: translators-connectors-releases
+        permissions: public-read
+        display_name: mongo-odbc-${RELEASE_VERSION}.sast.sarif
 
 pre:
   - func: "fetch source"
@@ -1749,6 +1774,9 @@ tasks:
       - func: "generate SBOM and scan"
 
   - name: compliance-report
+    depends_on:
+      - name: sbom
+      - name: semgrep
     commands:
       - func: "generate compliance report"
       - func: "publish compliance report"
@@ -1943,7 +1971,8 @@ tasks:
   - name: semgrep
     exec_timeout_secs: 3600 # 1h
     commands:
-      - func: "static code analysis"
+      - func: "generate static code analysis"
+      - func: "publish static code analysis"
 
 task_groups:
   - name: windows-windows-test-unit-group

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -340,7 +340,8 @@ functions:
           ./$SBOM_DIR/grype sbom:$SBOM_LICENSES --fail-on low
           echo "---------------------------------------------"
           echo "<<<< Done scanning SBOM"
-      "generate compliance report":
+  
+  "generate compliance report":
     - command: shell.exec
       params:
         shell: bash
@@ -400,10 +401,7 @@ functions:
         bucket: translators-connectors-releases
         permissions: public-read
         display_name: mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
-  
-<<<<<<< HEAD
 
-=======
   "push SBOM Lite to Silk":
     - command: shell.exec
       type: test

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2064,14 +2064,13 @@ tasks:
         variant: code-quality-security
       - name: semgrep
         variant: code-quality-security
-      - name: compliance-report
-        variant: code-quality-security
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "publish static code analysis"
-      - func: "publish compliance report"
       - func: "pull augmented SBOM from Silk"
       - func: "publish augmented SBOM"
+      - func: "generate compliance report"
+      - func: "publish compliance report"
 
   - name: ssdlc-artifacts-snapshot
     run_on: ubuntu2204-small

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -306,7 +306,7 @@ functions:
         aws_secret: ${aws_secret}
         local_files_include_filter:
           - mongosql-odbc-driver/*.cdx.json
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/
         content_type: text/plain
         bucket: mciuploads
         permissions: public-read
@@ -377,7 +377,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
         bucket: mciuploads
         permissions: public-read
@@ -388,7 +388,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/${COMPLIANCE_REPORT_NAME}
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
         bucket: mciuploads
     - command: s3.put
@@ -449,7 +449,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/mongo-odbc-driver.augmented.sbom.json
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/mongo-odbc-driver.augmented.sbom.json
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/mongo-odbc-driver.augmented.sbom.json
         content_type: application/json
         bucket: mciuploads
         permissions: public-read
@@ -1804,7 +1804,7 @@ functions:
         aws_secret: ${aws_secret}
         local_files_include_filter:
           - mongo-odbc-driver.sast.*
-        remote_file: mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/
         content_type: text/plain
         bucket: mciuploads
         permissions: public-read
@@ -1815,7 +1815,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: mongosql-odbc-driver/${STATIC_CODE_ANALYSIS_NAME}
-        remote_file:  mongosql-odbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
+        remote_file:  mongosql-odbc-driver/artifacts/${version_id}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
         content_type: application/json
         bucket: mciuploads
     - command: s3.put
@@ -1852,14 +1852,7 @@ tasks:
       - func: set and check packages version
       - func: "generate SBOM"
       - func: "scan SBOM"
-      - func: "push SBOM Lite to Silk"
-
-  - name: compliance-report
-    depends_on:
-      - name: sbom
-      - name: semgrep
-    commands:
-      - func: "generate compliance report"
+      - func: "push SBOM Lite to Silk"      
 
   - name: compile
     commands:
@@ -2085,8 +2078,8 @@ tasks:
       - func: "publish static code analysis"
       - func: "pull augmented SBOM from Silk"
       - func: "publish augmented SBOM"
-       - func: "generate compliance report"
-       - func: "publish compliance report"
+      - func: "generate compliance report"
+      - func: "publish compliance report"
 
 
 task_groups:
@@ -2143,7 +2136,6 @@ buildvariants:
     tasks:
       - name: semgrep
       - name: sbom
-      - name: compliance-report
       - name: ssdlc-artifacts-snapshot
 
   - name: windows-64
@@ -2201,3 +2193,4 @@ buildvariants:
       - name: release
       - name: snapshot
       - name: download-center-update
+      - name: ssdlc-artifacts-release

--- a/resources/ssdlc/mongo-odbc-driver_compliance_report_template.md
+++ b/resources/ssdlc/mongo-odbc-driver_compliance_report_template.md
@@ -1,0 +1,30 @@
+
+# Atlas SQL ODBC Driver SSDLC Compliance Report - %VERSION%
+
+**Release Creator**  
+%AUTHOR% - %AUTHOR_EMAIL%
+
+**Process Document**  
+https://www.mongodb.com/resources/products/capabilities/supply-chain-security-in-mongodb-s-software-development-lifecycle
+
+**Tool used to track third party vulnerabilities**  
+Silk Security
+
+**Third-Party Dependency Information**  
+See SBOM at URL: %SBOM_URL%
+
+**Static Analysis Findings**  
+See report at URL: %SARIF_URL%
+
+**Signature Information**
+Product is signed with signatures available which can be verified by following the instructions below :  
+
+1. Download the [MongoDB ODBC Driver](https://www.mongodb.com/try/download/odbc-driver) from MongoDB Download Center.   
+2. Select the platform and version you want to verify on that page.
+3. Click `Copy link` and use the URL while following the instructions to validate MongoDB packages described [here](https://www.mongodb.com/docs/manual/tutorial/verify-mongodb-packages/).
+
+> :warning:  
+> For this [step](!https://www.mongodb.com/docs/manual/tutorial/verify-mongodb-packages/#download-then-import-the-key-file), download and import the MongoDB ODBC Driver public key using this url : `https://pgp.mongodb.com/atlas-sql-odbc.asc`
+
+**Known Vulnerabilities**  
+Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate reviewers.


### PR DESCRIPTION
example patch: https://spruce.mongodb.com/version/6675e88c1a4be000079017d2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

creates a compliance report: https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongosql-odbc-snapshot-compliance-report.md

Followed the same template used by bic / provided by devprod, removed security testing section