### PR TITLE
SQL-2109: publish 3rd party dependency report for ODBC

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -679,6 +679,15 @@ functions:
         file: mongosql-odbc-driver/expansions.yml
 
   "build msi":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver.augmented.sbom.json
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/mongo-odbc-driver.augmented.sbom.json
+        content_type: application/json
+        bucket: mciuploads
+        permissions: public-read
     - command: shell.exec
       params:
         shell: bash
@@ -687,6 +696,7 @@ functions:
           ${prepare_shell}
           cp target/release/*.dll installer/msi
           cp ./README.md installer/msi
+          cp ./mongo-odbc-driver.augmented.sbom.json installer/msi
           cd installer/msi
           if [ "$RELEASE_VERSION" == "snapshot" ]; then
               MINOR_VERSION="0.1"
@@ -1130,6 +1140,15 @@ functions:
         bucket: mciuploads
 
   "tar linux artifacts":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver.augmented.sbom.json
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/mongo-odbc-driver.augmented.sbom.json
+        content_type: application/json
+        bucket: mciuploads
+        permissions: public-read
     - command: shell.exec
       params:
         shell: bash
@@ -1137,7 +1156,7 @@ functions:
         script: |
           mkdir -p release/mongoodbc/bin
           cp  target/release/libatsql.so release/mongoodbc/bin/
-          cp ./LICENSE ./README.md release/mongoodbc/
+          cp ./LICENSE ./README.md ./mongo-odbc-driver.augmented.sbom.json release/mongoodbc/
           cd release
           tar -czvf mongoodbc.tar.gz mongoodbc/
 
@@ -1862,9 +1881,13 @@ tasks:
       - func: set and check packages version
       - func: "generate SBOM"
       - func: "scan SBOM"
-      - func: "push SBOM Lite to Silk"      
+      - func: "push SBOM Lite to Silk"
+      - func: "pull augmented SBOM from Silk"
 
   - name: compile
+    depends_on:
+      - name: sbom
+        variant: code-quality-security
     commands:
       - func: "install iODBC"
         variants: [macos, macos-arm]
@@ -2070,7 +2093,6 @@ tasks:
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "publish static code analysis"
-      - func: "pull augmented SBOM from Silk"
       - func: "publish augmented SBOM"
       - func: "generate compliance report"
       - func: "publish compliance report"
@@ -2086,7 +2108,6 @@ tasks:
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "publish static code analysis"
-      - func: "pull augmented SBOM from Silk"
       - func: "publish augmented SBOM"
       - func: "generate compliance report"
       - func: "publish compliance report"

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -695,8 +695,7 @@ functions:
         script: |
           ${prepare_shell}
           cp target/release/*.dll installer/msi
-          cp ./README.md installer/msi
-          cp ./mongo-odbc-driver.augmented.sbom.json installer/msi
+          cp ./README.md ./mongo-odbc-driver.augmented.sbom.json installer/msi
           cd installer/msi
           if [ "$RELEASE_VERSION" == "snapshot" ]; then
               MINOR_VERSION="0.1"
@@ -719,6 +718,15 @@ functions:
               -VersionLabel "$VERSION_LABEL"\
 
   "build dmg":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongosql-odbc-driver/mongo-odbc-driver.augmented.sbom.json
+        remote_file: mongosql-odbc-driver/artifacts/${version_id}/ssdlc/mongo-odbc-driver.augmented.sbom.json
+        content_type: application/json
+        bucket: mciuploads
+        permissions: public-read
     - command: shell.exec
       params:
         shell: bash

--- a/installer/dmg/build-dmg.sh
+++ b/installer/dmg/build-dmg.sh
@@ -12,6 +12,7 @@ cp ./libatsql.dylib components/"$ROOT"/
 cp ./macos_postinstall scripts/postinstall
 cp ./resources/*.rtf components/"$ROOT"/
 cp ../../README.md components/"$ROOT"/
+cp ../../mongo-odbc-driver.augmented.sbom.json components/"$ROOT"/
 
 # build component pkg
 pkgbuild --root=components/ --scripts=scripts/ --identifier='MongoDB Atlas SQL ODBC' 'mongoodbc-component.pkg'

--- a/installer/msi/LicensingFragment.wxs
+++ b/installer/msi/LicensingFragment.wxs
@@ -17,10 +17,18 @@
                     Source="$(var.SourceDir)\README.md"
                     DiskId="1" />
             </Component>
+            <Component Id="c_Sbom"
+                Guid="f40564ba-a569-4567-895b-f720b816638c">
+                <File Id="f_Sbom"
+                    Name="mongo-odbc-driver.augmented.sbom.json"
+                    Source="$(var.SourceDir)\mongo-odbc-driver.augmented.sbom.json"
+                    DiskId="1" />
+            </Component>
         </DirectoryRef>
         <ComponentGroup Id="cg_License">
             <ComponentRef Id="c_Readme" />
             <ComponentRef Id="c_License" />
+            <ComponentRef Id="c_Sbom" />
         </ComponentGroup>
         <WixVariable Id="WixUILicenseRtf"
             Value="$(var.ResourceDir)\LICENSE.rtf" />


### PR DESCRIPTION
Moved the pulling of sbom from silk to so it will be in mciuploads; then, we can pull prior to building msi/tarring linux artifacts.