### PR TITLE
Migrate Lazy Initialization from Once_Cell to Std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "lazy_static",
  "serde_json",
 ]
 

--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -10,7 +10,6 @@ authors = [
 edition = "2021"
 
 [dependencies]
-lazy_static = "1.4.0"
 cargo_toml = "0.15.2"
 anyhow = "*"
 serde_json = "1.0.64"

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 pub const VENDOR_IDENTIFIER: &str = "MongoDB";
 pub const DRIVER_NAME: &str = "MongoDB Atlas SQL ODBC Driver";
@@ -6,22 +6,27 @@ pub const DBMS_NAME: &str = "MongoDB Atlas";
 pub const ODBC_VERSION: &str = "03.80";
 pub const DRIVER_SHORT_NAME: &str = "mongodb-odbc";
 
-lazy_static! {
-    pub static ref DRIVER_METRICS_VERSION: String = format!(
+pub static DRIVER_METRICS_VERSION: LazyLock<String> = LazyLock::new(|| {
+    format!(
         "{}.{}.{}",
         env!("CARGO_PKG_VERSION_MAJOR"),
         env!("CARGO_PKG_VERSION_MINOR"),
         env!("CARGO_PKG_VERSION_PATCH")
-    );
-    pub static ref DRIVER_LOG_VERSION: String = format!(
+    )
+});
+
+pub static DRIVER_LOG_VERSION: LazyLock<String> = LazyLock::new(|| {
+    format!(
         "{}.{}",
         env!("CARGO_PKG_VERSION_MAJOR"),
         env!("CARGO_PKG_VERSION_MINOR")
-    );
-    pub static ref DEFAULT_APP_NAME: String =
-        format!("{}+{}", DRIVER_SHORT_NAME, DRIVER_METRICS_VERSION.as_str());
-    pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
-}
+    )
+});
+
+pub static DEFAULT_APP_NAME: LazyLock<String> =
+LazyLock::new(|| format!("{}+{}", DRIVER_SHORT_NAME, DRIVER_METRICS_VERSION.as_str()));
+
+pub static DRIVER_ODBC_VERSION: LazyLock<String> = LazyLock::new(|| format_driver_version());
 
 // The default max string length if a user enables max string length.
 // Typically, the Atlas SQL ODBC driver does not specify a max string


### PR DESCRIPTION





## What was changed
According to the official stable  Rust 1.80.0 release.  we now have LazyLock and LazyCell as part of the Standard Library(https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html). This PR upgrades all the `once_cell::sync::Lazy` to `std::sync::LazyLock` to ensure the code is current.

## Why?
- Keep code up to date

> [!WARNING]
This should only be merged after upgrading to `Rust 1.80.0` otherwise the merge will introduce a breaking change


## Checklist

- **How was this tested**: Still compiles. 
- **Any docs updates needed**: Don't think so.
