### PR TITLE
SQL-2290: Differentiate between cluster types on connection

### DIFF
--- a/core/src/cluster_type.rs
+++ b/core/src/cluster_type.rs
@@ -27,6 +27,7 @@ pub async fn determine_cluster_type(client: &Client) -> MongoClusterType {
     // if "ok" is not 1, then the target type could not be determined.
     match cmd_res.get("ok") {
         Some(Bson::Double(f)) if *f == 1.0 => {}
+        Some(Bson::Int64(i)) if *i == 1 => {}
         Some(Bson::Int32(i)) if *i == 1 => {}
         _ => {
             log::error!(

--- a/core/src/cluster_type.rs
+++ b/core/src/cluster_type.rs
@@ -1,0 +1,53 @@
+use mongodb::bson::{doc, Document};
+use mongodb::Client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum MongoClusterType {
+    AtlasDataFederation,
+    Community,
+    Enterprise,
+    UnknownTarget,
+}
+
+pub async fn determine_cluster_type(client: &Client) -> MongoClusterType {
+    let db = client.database("admin");
+    let build_info_cmd = doc! { "buildInfo": 1 };
+
+    // Run the command and handle any errors internally
+    let cmd_res: Document = match db.run_command(build_info_cmd).await {
+        Ok(res) => res,
+        Err(e) => {
+            log::error!("Failed to run buildInfo command: {:?}", e);
+            return MongoClusterType::UnknownTarget;
+        }
+    };
+
+    // Check if the "ok" field is 1
+    if cmd_res.get_f64("ok").unwrap_or(0.0) != 1.0 {
+        log::error!(
+            "buildInfo command returned a non-ok response: {:?}",
+            cmd_res
+        );
+        return MongoClusterType::UnknownTarget;
+    }
+
+    // Determine the cluster type based on the response
+    if cmd_res.get_document("dataLake").is_ok() {
+        MongoClusterType::AtlasDataFederation
+    } else {
+        match cmd_res.get_array("modules") {
+            Ok(modules) => {
+                if modules
+                    .iter()
+                    .any(|mod_name| mod_name.as_str() == Some("enterprise"))
+                {
+                    MongoClusterType::Enterprise
+                } else {
+                    MongoClusterType::Community
+                }
+            }
+            Err(_) => MongoClusterType::Community,
+        }
+    }
+}

--- a/core/src/conn.rs
+++ b/core/src/conn.rs
@@ -197,16 +197,7 @@ impl MongoConnection {
             uuid_repr,
             runtime,
         };
-        // Verify that the connection is working and the user has access to the default DB
-        // ADF is supposed to check permissions on this
-        MongoQuery::prepare(
-            &connection,
-            current_db,
-            None,
-            "select 1",
-            type_mode,
-            max_string_length,
-        )?;
+
         Ok(connection)
     }
 

--- a/core/src/conn.rs
+++ b/core/src/conn.rs
@@ -1,8 +1,8 @@
 use crate::cluster_type::{determine_cluster_type, MongoClusterType};
 use crate::load_library::{get_mongosqltranslate_library, load_mongosqltranslate_library};
 use crate::odbc_uri::UserOptions;
+use crate::TypeMode;
 use crate::{err::Result, Error};
-use crate::{MongoQuery, TypeMode};
 use lazy_static::lazy_static;
 use mongodb::{
     bson::{doc, Bson, UuidRepresentation},
@@ -145,12 +145,12 @@ impl MongoConnection {
     /// setting specified in the uri if any.
     pub fn connect(
         mut user_options: UserOptions,
-        current_db: Option<String>,
+        _current_db: Option<String>,
         operation_timeout: Option<u32>,
         login_timeout: Option<u32>,
-        type_mode: TypeMode,
+        _type_mode: TypeMode,
         mut runtime: Option<Runtime>,
-        max_string_length: Option<u16>,
+        _max_string_length: Option<u16>,
     ) -> Result<Self> {
         let runtime = Arc::new(runtime.take().unwrap_or_else(|| {
             tokio::runtime::Builder::new_current_thread()

--- a/core/src/conn.rs
+++ b/core/src/conn.rs
@@ -1,3 +1,5 @@
+use crate::cluster_type::{determine_cluster_type, MongoClusterType};
+use crate::load_library::{get_mongosqltranslate_library, load_mongosqltranslate_library};
 use crate::odbc_uri::UserOptions;
 use crate::{err::Result, Error};
 use crate::{MongoQuery, TypeMode};
@@ -160,6 +162,35 @@ impl MongoConnection {
             login_timeout.map(|to| Duration::new(u64::from(to), 0));
         let uuid_repr = user_options.uuid_representation;
         let (client, runtime) = Self::get_client_and_runtime(user_options, runtime)?;
+
+        load_mongosqltranslate_library();
+
+        let type_of_cluster = runtime.block_on(async { determine_cluster_type(&client).await });
+        match type_of_cluster {
+            MongoClusterType::AtlasDataFederation => {}
+            MongoClusterType::Community => {
+                // Community edition is not supported
+                return Err(Error::UnsupportedClusterConfiguration(
+                    "Community edition detected. The driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation.".to_string(),
+                ));
+            }
+            MongoClusterType::Enterprise => {
+                // Ensure the library is loaded if Enterprise edition is detected
+                if get_mongosqltranslate_library().is_none() {
+                    return Err(Error::UnsupportedClusterConfiguration(
+                        "Enterprise edition detected, but mongosqltranslate library not found."
+                            .to_string(),
+                    ));
+                }
+            }
+            MongoClusterType::UnknownTarget => {
+                // Unknown cluster type is not supported
+                return Err(Error::UnsupportedClusterConfiguration(
+                    "Unknown cluster/target type detected. The driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation.".to_string(),
+                ));
+            }
+        }
+
         let connection = MongoConnection {
             client,
             operation_timeout: operation_timeout.map(|to| Duration::new(u64::from(to), 0)),

--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -48,6 +48,8 @@ pub enum Error {
     ValueAccess(String, mongodb::bson::document::ValueAccessError),
     #[error("Missing connection {0}")]
     MissingConnection(&'static str),
+    #[error("Unsupported cluster configuration: {0}")]
+    UnsupportedClusterConfiguration(String),
     #[error("Unsupported operation {0}")]
     UnsupportedOperation(&'static str),
     #[error("Statement not executed")]
@@ -81,6 +83,7 @@ impl Error {
             | Error::QueryDeserialization(_)
             | Error::UnknownColumn(_)
             | Error::ValueAccess(_, _)
+            | Error::UnsupportedClusterConfiguration(_)
             | Error::UnsupportedOperation(_) => GENERAL_ERROR,
             Error::StatementNotExecuted => FUNCTION_SEQUENCE_ERROR,
             Error::QueryCancelled => OPERATION_CANCELLED,
@@ -120,6 +123,7 @@ impl Error {
             | Error::UnknownColumn(_)
             | Error::ValueAccess(_, _)
             | Error::UnsupportedOperation(_)
+            | Error::UnsupportedClusterConfiguration(_)
             | Error::StatementNotExecuted => 0,
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,3 +36,5 @@ pub use foreign_keys::MongoForeignKeys;
 pub mod load_library;
 pub mod oidc_auth;
 pub mod test_config;
+
+pub mod cluster_type;

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -130,7 +130,7 @@ mod test {
                     Some("example.net:30000".into()),
                     None,
                 ))
-                .0 as *const cstr::WideChar,
+                    .0 as *const cstr::WideChar,
                 buffer.as_ptr(),
                 buffer.len(),
                 &mut buffer_len,
@@ -143,8 +143,8 @@ mod test {
                 isize::try_from(buffer_len)
                     .expect("buffer length is too large for {isize::MAX} on this platform"),
             )
-            .to_lowercase()
-            .contains("server selection timeout")
+                .to_lowercase()
+                .contains("unsupported cluster configuration: unknown cluster/target type detected.")
         });
     }
 

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -130,7 +130,7 @@ mod test {
                     Some("example.net:30000".into()),
                     None,
                 ))
-                    .0 as *const cstr::WideChar,
+                .0 as *const cstr::WideChar,
                 buffer.as_ptr(),
                 buffer.len(),
                 &mut buffer_len,
@@ -143,8 +143,8 @@ mod test {
                 isize::try_from(buffer_len)
                     .expect("buffer length is too large for {isize::MAX} on this platform"),
             )
-                .to_lowercase()
-                .contains("unsupported cluster configuration: unknown cluster/target type detected.")
+            .to_lowercase()
+            .contains("unsupported cluster configuration: unknown cluster/target type detected.")
         });
     }
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1536,11 +1536,11 @@ functions:
         arch="x64"
         
         # Start MongoDB instances
-        bash -x ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
+        ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
         
         # Enterprise test without library
         cargo test --features cluster_type_tests -- \
-          cluster_type::test_determine_cluster_type_enterprise_fails_no_library --nocapture
+          cluster_type::test_determine_cluster_type_enterprise_fails_without_library --nocapture
         ENTERPRISE_NOLIB_EXITCODE=$?
         
         # Build and move mock mongosqltranslate library
@@ -1550,7 +1550,7 @@ functions:
         
         # Enterprise test with library
         cargo test --features cluster_type_tests -- \
-          cluster_type::test_determine_cluster_type_enterprise_gets_no_sqlgetresultschema_with_library --nocapture
+          cluster_type::test_enterprise_with_library_fails_due_to_missing_sql_get_result_schema_command --nocapture
         ENTERPRISE_LIB_EXITCODE=$?
         
         # Community test

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1535,35 +1535,44 @@ functions:
         mdb_version_ent="mongodb-linux-x86_64-enterprise-ubuntu2204-7.0.14"
         arch="x64"
         
+        # Start MongoDB instances
         bash -x ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
-  
+        
+        # Enterprise test without library
+        cargo test --features cluster_type_tests -- \
+          cluster_type::test_determine_cluster_type_enterprise_fails_no_library --nocapture
+        ENTERPRISE_NOLIB_EXITCODE=$?
+        
         # Build and move mock mongosqltranslate library
         cargo build --package mock_mongosqltranslate
         sudo mkdir -p /opt/mongodb/atlas-sql-odbc-driver/
         sudo mv -f ./target/debug/libmock_mongosqltranslate.so /opt/mongodb/atlas-sql-odbc-driver/libmongosqltranslate.so
         
-        # Enterprise test
-        cargo test --features cluster_type_tests -- cluster_type::test_determine_cluster_type_enterprise_succeeds --nocapture
-        ENTERPRISE_EXITCODE=$?
+        # Enterprise test with library
+        cargo test --features cluster_type_tests -- \
+          cluster_type::test_determine_cluster_type_enterprise_gets_no_sqlgetresultschema_with_library --nocapture
+        ENTERPRISE_LIB_EXITCODE=$?
         
         # Community test
         cargo test --features cluster_type_tests -- cluster_type::test_determine_cluster_type_community_fails --nocapture
         COMMUNITY_EXITCODE=$?
         
+        # Stop MongoDB instances
         pkill mongod
-  
+        
         # Determine overall exit code
-        if [ $ENTERPRISE_EXITCODE -eq 0 ] && [ $COMMUNITY_EXITCODE -eq 0 ]; then
-        OVERALL_EXITCODE=0
+        if [ $ENTERPRISE_NOLIB_EXITCODE -eq 0 ] && [ $ENTERPRISE_LIB_EXITCODE -eq 0 ] && [ $COMMUNITY_EXITCODE -eq 0 ]; then
+          OVERALL_EXITCODE=0
         else
-        OVERALL_EXITCODE=1
+          OVERALL_EXITCODE=1
         fi
-  
+        
         echo "Cluster test results:"
-        echo "Enterprise test exit code: $ENTERPRISE_EXITCODE"
+        echo "Enterprise test without library exit code: $ENTERPRISE_NOLIB_EXITCODE"
+        echo "Enterprise test with library exit code: $ENTERPRISE_LIB_EXITCODE"
         echo "Community test exit code: $COMMUNITY_EXITCODE"
         echo "Overall exit code: $OVERALL_EXITCODE"
-  
+        
         exit $OVERALL_EXITCODE
 
   "run macos result-set tests":

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -84,6 +84,10 @@ functions:
             export PATH="$PATH"
             export CARGO_NET_GIT_FETCH_WITH_CLI="$CARGO_NET_GIT_FETCH_WITH_CLI"
             git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
+            export LOCAL_MDB_PORT_COM=${local_mdb_port_com}
+            export LOCAL_MDB_PORT_ENT=${local_mdb_port_ent}
+            export LOCAL_MDB_USER=${local_mdb_user}
+            export LOCAL_MDB_PWD=${local_mdb_pwd}
             export ADF_TEST_LOCAL_USER="${adf_test_local_user}"
             export ADF_TEST_LOCAL_PWD="${adf_test_local_pwd}"
             export ADF_TEST_LOCAL_AUTH_DB="${adf_test_local_auth_db}"
@@ -1516,6 +1520,51 @@ functions:
           # Stop the local ADF
           ./resources/run_adf.sh stop
           exit $EXITCODE
+          
+
+  "run ubuntu cluster type integration test":
+    command: shell.exec
+    type: test
+    params:
+      shell: bash
+      working_dir: mongosql-odbc-driver
+      script: |
+        ${prepare_shell}
+        
+        mdb_version_com="mongodb-linux-x86_64-ubuntu2204-7.0.14"
+        mdb_version_ent="mongodb-linux-x86_64-enterprise-ubuntu2204-7.0.14"
+        arch="x64"
+        
+        bash -x ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
+  
+        # Build and move mock mongosqltranslate library
+        cargo build --package mock_mongosqltranslate
+        sudo mkdir -p /opt/mongodb/atlas-sql-odbc-driver/
+        sudo mv -f ./target/debug/libmock_mongosqltranslate.so /opt/mongodb/atlas-sql-odbc-driver/libmongosqltranslate.so
+        
+        # Enterprise test
+        cargo test --features cluster_type_tests -- cluster_type::test_determine_cluster_type_enterprise_succeeds --nocapture
+        ENTERPRISE_EXITCODE=$?
+        
+        # Community test
+        cargo test --features cluster_type_tests -- cluster_type::test_determine_cluster_type_community_fails --nocapture
+        COMMUNITY_EXITCODE=$?
+        
+        pkill mongod
+  
+        # Determine overall exit code
+        if [ $ENTERPRISE_EXITCODE -eq 0 ] && [ $COMMUNITY_EXITCODE -eq 0 ]; then
+        OVERALL_EXITCODE=0
+        else
+        OVERALL_EXITCODE=1
+        fi
+  
+        echo "Cluster test results:"
+        echo "Enterprise test exit code: $ENTERPRISE_EXITCODE"
+        echo "Community test exit code: $COMMUNITY_EXITCODE"
+        echo "Overall exit code: $OVERALL_EXITCODE"
+  
+        exit $OVERALL_EXITCODE
 
   "run macos result-set tests":
     - command: shell.exec
@@ -2027,6 +2076,8 @@ tasks:
         variants: [macos, macos-arm]
       - func: "run ubuntu integration tests"
         variants: [ubuntu2204]
+      - func: "run ubuntu cluster type integration test"
+        variants: [ ubuntu2204 ]
       # Commenting out because the following task only detects
       # memory leaks in the tests
       # - func: "run asan integration tests"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -26,5 +26,6 @@ tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "net"] }
 
 
 [features]
+cluster_type_tests = []
 result_set = []
 evergreen_tests = []

--- a/integration_test/tests/cluster_type_test.rs
+++ b/integration_test/tests/cluster_type_test.rs
@@ -83,22 +83,14 @@ mod cluster_type {
         }
     }
 
-    // Tests that connection with enterprise edition will continue to the sqlGetResultSchema error
+    // Tests that connection with enterprise edition and library loaded will succeed
     #[tokio::test]
-    async fn test_determine_cluster_type_enterprise_gets_no_sqlgetresultschema_with_library() {
+    async fn test_determine_cluster_type_enterprise_with_library_success() {
         let result = run_cluster_type_test(PortType::Enterprise).await;
         assert!(
-            result.is_err(),
-            "Expected an error for enterprise edition, but got success"
+            result.is_ok(),
+            "Expected success with enterprise edition and library loaded"
         );
-        if let Err(e) = result {
-            assert!(
-                e.contains("CommandNotFound")
-                    && e.contains("no such command: 'sqlGetResultSchema'"),
-                "Unexpected error message for enterprise edition: {}",
-                e
-            );
-        }
     }
 
     // Test that connecting with enterprise edition cluster type fails without mongosqltranslate library

--- a/integration_test/tests/cluster_type_test.rs
+++ b/integration_test/tests/cluster_type_test.rs
@@ -83,14 +83,22 @@ mod cluster_type {
         }
     }
 
-    // Tests that connection with enterprise edition and library loaded will succeed
+    // Tests that connection with enterprise edition and library loaded fails
+    // due to missing 'sqlGetResultSchema' command in MongoDB
     #[tokio::test]
-    async fn test_determine_cluster_type_enterprise_with_library_success() {
+    async fn test_enterprise_with_library_fails_due_to_missing_sql_get_result_schema_command() {
         let result = run_cluster_type_test(PortType::Enterprise).await;
         assert!(
-            result.is_ok(),
-            "Expected success with enterprise edition and library loaded"
+            result.is_err(),
+            "Expected an error with enterprise edition and library loaded, but got success"
         );
+        if let Err(e) = result {
+            assert!(
+                e.contains("no such command: 'sqlGetResultSchema'"),
+                "Unexpected error message for enterprise edition: {}",
+                e
+            );
+        }
     }
 
     // Test that connecting with enterprise edition cluster type fails without mongosqltranslate library

--- a/integration_test/tests/cluster_type_test.rs
+++ b/integration_test/tests/cluster_type_test.rs
@@ -65,7 +65,7 @@ mod cluster_type {
         })
     }
 
-    /// Test that determining cluster type fails for community edition
+    // Tests that connection with community edition fails
     #[tokio::test]
     async fn test_determine_cluster_type_community_fails() {
         let result = run_cluster_type_test(PortType::Community).await;
@@ -83,9 +83,9 @@ mod cluster_type {
         }
     }
 
-    /// Test that determining cluster type fails for enterprise edition with sqlGetResultSchema error
+    // Tests that connection with enterprise edition will continue to the sqlGetResultSchema error
     #[tokio::test]
-    async fn test_determine_cluster_type_enterprise_fails() {
+    async fn test_determine_cluster_type_enterprise_gets_no_sqlgetresultschema_with_library() {
         let result = run_cluster_type_test(PortType::Enterprise).await;
         assert!(
             result.is_err(),
@@ -96,6 +96,23 @@ mod cluster_type {
                 e.contains("CommandNotFound")
                     && e.contains("no such command: 'sqlGetResultSchema'"),
                 "Unexpected error message for enterprise edition: {}",
+                e
+            );
+        }
+    }
+
+    // Test that connecting with enterprise edition cluster type fails without mongosqltranslate library
+    #[tokio::test]
+    async fn test_determine_cluster_type_enterprise_fails_without_library() {
+        let result = run_cluster_type_test(PortType::Enterprise).await;
+        assert!(
+            result.is_err(),
+            "Expected an error for enterprise edition without mongosqltranslate library, but got success"
+        );
+        if let Err(e) = result {
+            assert!(
+                e.contains("Enterprise edition detected, but mongosqltranslate library not found."),
+                "Unexpected error message for enterprise edition without library: {}",
                 e
             );
         }

--- a/integration_test/tests/cluster_type_test.rs
+++ b/integration_test/tests/cluster_type_test.rs
@@ -1,0 +1,103 @@
+mod common;
+
+#[cfg(feature = "cluster_type_tests")]
+mod cluster_type {
+    use crate::common::{allocate_env, connect_with_conn_string};
+    use definitions::AttrOdbcVersion;
+    use std::panic;
+    use tokio;
+
+    use constants::DRIVER_NAME;
+    use std::env;
+
+    #[derive(Debug)]
+    enum PortType {
+        Enterprise,
+        Community,
+    }
+
+    fn connect_for_mdb_test(port_type: PortType) -> Result<(), String> {
+        let connection_string = generate_mdb_connection_str(port_type);
+
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
+        match connect_with_conn_string(env_handle, Some(connection_string)) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    fn generate_mdb_connection_str(port_type: PortType) -> String {
+        let user_name = env::var("LOCAL_MDB_USER").expect("LOCAL_MDB_USER is not set");
+        let pwd = env::var("LOCAL_MDB_PWD").expect("LOCAL_MDB_PWD is not set");
+
+        let port_var = match port_type {
+            PortType::Enterprise => "LOCAL_MDB_PORT_ENT",
+            PortType::Community => "LOCAL_MDB_PORT_COM",
+        };
+        let port = env::var(port_var).expect(&format!("{} is not set", port_var));
+
+        let server = format!("localhost:{}", port);
+
+        let db = env::var("ADF_TEST_LOCAL_DB");
+        let driver = env::var("ADF_TEST_LOCAL_DRIVER").unwrap_or_else(|_| DRIVER_NAME.to_string());
+
+        let mut connection_string =
+            format!("Driver={{{driver}}};USER={user_name};PWD={pwd};SERVER={server};");
+
+        if let Ok(val) = db {
+            connection_string.push_str(&format!("DATABASE={};", val));
+        }
+
+        connection_string
+    }
+
+    async fn run_cluster_type_test(port_type: PortType) -> Result<(), String> {
+        let result = panic::catch_unwind(|| connect_for_mdb_test(port_type));
+
+        result.unwrap_or_else(|panic_info| {
+            if let Some(s) = panic_info.downcast_ref::<String>() {
+                Err(s.clone())
+            } else if let Some(s) = panic_info.downcast_ref::<&str>() {
+                Err(s.to_string())
+            } else {
+                Err("Unknown panic occurred".to_string())
+            }
+        })
+    }
+
+    /// Test that determining cluster type fails for community edition
+    #[tokio::test]
+    async fn test_determine_cluster_type_community_fails() {
+        let result = run_cluster_type_test(PortType::Community).await;
+        assert!(
+            result.is_err(),
+            "Expected an error for community edition, but got success"
+        );
+        if let Err(e) = result {
+            assert!(
+                e.contains("Unsupported cluster configuration: Community edition detected") &&
+                    e.contains("The driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation"),
+                "Unexpected error message for community edition: {}",
+                e
+            );
+        }
+    }
+
+    /// Test that determining cluster type fails for enterprise edition with sqlGetResultSchema error
+    #[tokio::test]
+    async fn test_determine_cluster_type_enterprise_fails() {
+        let result = run_cluster_type_test(PortType::Enterprise).await;
+        assert!(
+            result.is_err(),
+            "Expected an error for enterprise edition, but got success"
+        );
+        if let Err(e) = result {
+            assert!(
+                e.contains("CommandNotFound")
+                    && e.contains("no such command: 'sqlGetResultSchema'"),
+                "Unexpected error message for enterprise edition: {}",
+                e
+            );
+        }
+    }
+}

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -25,7 +25,6 @@ use definitions::{
 use function_name::named;
 use log::{debug, error, info};
 use logger::Logger;
-use mongo_odbc_core::load_library::load_mongosqltranslate_library;
 use mongo_odbc_core::{
     odbc_uri::ODBCUri, Error, MongoColMetadata, MongoCollections, MongoConnection, MongoDatabases,
     MongoFields, MongoForeignKeys, MongoPrimaryKeys, MongoQuery, MongoStatement, MongoTableTypes,
@@ -255,8 +254,6 @@ fn sql_alloc_handle(
     input_handle: *mut MongoHandle,
     output_handle: *mut Handle,
 ) -> Result<()> {
-    load_mongosqltranslate_library();
-
     match handle_type {
         HandleType::SQL_HANDLE_ENV => {
             let env = Env::with_state(EnvState::Allocated);

--- a/resources/start_local_mdb.sh
+++ b/resources/start_local_mdb.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Usage start_local_mdb.sh <community version> <enterprise version> <architecture>
+# architecture: "arm64" or "x64"
+#
+# This script will download each version of mongodb, start a mongod
+# for each, and create a user for each.
+
+# Usage: download_and_extract_tgz <root url> <file base name>
+download_and_extract_tgz() {
+  tgz_file="$2.tgz"
+  full_url="$1$tgz_file"
+
+  echo "downloading $3 from $full_url"
+  curl -O $full_url
+
+  echo "extracting $tgz_file"
+  tar zxvf $tgz_file
+}
+
+# Usage: download_mongod <download_host> <file base name> <type>
+# type: "community" or "enterprise"
+download_mongod() {
+  root_url="https://$1/linux/"
+  download_and_extract_tgz $root_url $2 $3
+}
+
+# Usage: download_mongosh <architecture>
+# architecture: "arm64" or "x64"
+download_mongosh() {
+  root_url="https://downloads.mongodb.com/compass/"
+  file_name="mongosh-2.3.0-linux-$1"
+  download_and_extract_tgz $root_url $file_name "mongosh"
+
+  # copy mongosh to the current directory and ensure it is executable
+  cp $file_name/bin/mongosh .
+  chmod +x mongosh
+}
+
+# Usage: start_mdb_and_create_user <type> <port> <user> <pwd> <mongod dir>
+# type: "community" or "enterprise"
+start_mdb_and_create_user() {
+  echo "starting mongodb $1 on port $2"
+  db_path="$1_db"
+  mkdir -p $db_path
+  $5/bin/mongod --dbpath $db_path --port $2 &
+
+  echo "waiting 5 seconds to allow mongod to finish starting before connecting"
+  sleep 5
+
+  echo "creating user for $1"
+  ./mongosh admin --port $2 --eval "db.createUser({user: '$3', pwd: '$4', roles: ['readWrite']})"
+}
+
+community_mdb_version="$1"
+enterprise_mdb_version="$2"
+arch="$3"
+
+community_base_url="fastdl.mongodb.org"
+enterprise_base_url="downloads.mongodb.com"
+
+download_mongod $community_base_url $community_mdb_version "community"
+download_mongod $enterprise_base_url $enterprise_mdb_version "enterprise"
+
+download_mongosh $arch
+
+start_mdb_and_create_user "community" $LOCAL_MDB_PORT_COM $LOCAL_MDB_USER $LOCAL_MDB_PWD $community_mdb_version
+start_mdb_and_create_user "enterprise" $LOCAL_MDB_PORT_ENT $LOCAL_MDB_USER $LOCAL_MDB_PWD $enterprise_mdb_version
+


### PR DESCRIPTION
Adds change to check whether the cluster connected to is community edition, enterprise, or ADF.  
Removes the `SELECT 1` query and instead uses the check for buildinfo. 
Added integration test that has a script to start `mongod` community and enterprise versions taken from `mongo-jdbc-driver` repo. 
