### PR TITLE
 SQL-2299: Use github token for cloning instead of ssh

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -122,6 +122,13 @@ functions:
       params:
         file: mongosql-odbc-driver/expansions.yml
 
+  "generate github token":
+    command: github.generate_token
+    params:
+      owner: 10gen
+      repo: mongohouse
+      expansion_name: github_token
+
   "install rust toolchain":
     - command: shell.exec
       params:
@@ -1377,6 +1384,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1487,6 +1496,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1522,6 +1533,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1563,6 +1576,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1597,6 +1612,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1641,6 +1658,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1679,6 +1698,8 @@ functions:
       type: test
       params:
         shell: bash
+        env:
+          GITHUB_TOKEN: "${github_token}"
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
@@ -1710,6 +1731,8 @@ functions:
     type: test
     params:
       shell: bash
+      env:
+        GITHUB_TOKEN: "${github_token}"
       working_dir: mongosql-odbc-driver
       script: |
         ${prepare_shell}
@@ -2025,6 +2048,7 @@ tasks:
         variants: [ubuntu2204]
       - func: "setup driver with iODBC"
         variants: [macos, macos-arm]
+      - func: "generate github token"
       - func: "run ubuntu integration tests"
         variants: [ubuntu2204]
       # Commenting out because the following task only detects
@@ -2071,6 +2095,7 @@ tasks:
         variants: [ubuntu2204]
       # - func: "setup driver with iODBC"
       #   variants: [macos, macos-arm]
+      - func: "generate github token"
       - func: "run windows result set test"
         variants: [windows-64]
       - func: "run ubuntu result-set tests"

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -49,9 +49,18 @@ GO="$GOBINDIR/go"
 
 PATH=$GOBINDIR:$PATH
 
+# GITHUB_TOKEN must be set for cloning 10gen/mongohouse repository from Evergreen hosts, and the
+# dependencies needed to build it.
+# If unset, it will default to using the SSH private key on the local system.
+if [[ ${GITHUB_TOKEN} ]]; then
+  MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+else
+  MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
+fi
+
 MACHINE_ARCH=$(uname -m)
 LOCAL_INSTALL_DIR=$(pwd)/local_adf
-MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
 MONGO_DB_PATH=$LOCAL_INSTALL_DIR/test_db
 LOGS_PATH=$LOCAL_INSTALL_DIR/logs
 DB_CONFIG_PATH=$(pwd)/resources/integration_test/testdata/adf_db_config.json

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -53,8 +53,14 @@ PATH=$GOBINDIR:$PATH
 # dependencies needed to build it.
 # If unset, it will default to using the SSH private key on the local system.
 if [[ ${GITHUB_TOKEN} ]]; then
+  # Clear git url configurations if they exist
+  git config --global --get-regexp '^url\.' | while read -r key _; do
+      git config --global --unset "$key"
+  done
+
   MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git
-  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/".insteadOf https://github.com/10gen/
+
 else
   MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
 fi
@@ -398,7 +404,6 @@ if [ $ARG = $START ]; then
           MONGOHOUSE_DIR=$LOCAL_INSTALL_DIR/mongohouse
         fi
         # Install and start mongohoused
-        git config --global url.git@github.com:.insteadOf https://github.com/
         # Clone the mongohouse repo
         if [ ! -d "$MONGOHOUSE_DIR" ]; then
             git clone $MONGOHOUSE_URI $MONGOHOUSE_DIR

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -63,6 +63,7 @@ if [[ ${GITHUB_TOKEN} ]]; then
 
 else
   MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
+  git config --global url.git@github.com:.insteadOf https://github.com/
 fi
 
 MACHINE_ARCH=$(uname -m)


### PR DESCRIPTION
Copying changes from the [mongo-jdbc-repo](https://github.com/mongodb/mongo-jdbc-driver/pull/283) over. 

Running test on host without ssh keys [here](https://spruce.mongodb.com/version/66e8c5754198dd000734ee38/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=success). 