### PR TITLE
SQL-2312: Migration of Evergreen Static Host Fleets to Secure Private Data Centers

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -465,7 +465,7 @@ functions:
           docker run -i --platform="linux/amd64" --rm -v "$PWD":/pwd \
           --env-file silkbomb.env \
           artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
-          upload --silk-asset-group ${SILK_ASSET_GROUP} --sbom-in /pwd/$SBOM_FINAL
+          upload --silk-asset-group ${SILK_ASSET_GROUP} --sbom-in /pwd/$SBOM_FINAL --force
           echo "-------------------------------"
 
   "pull augmented SBOM from Silk":

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2355,7 +2355,7 @@ buildvariants:
 
   - name: macos
     display_name: "macOS 11.0"
-    run_on: [macos-1100]
+    run_on: [macos-11]
     tasks:
       - name: compile
       - name: compile-debug
@@ -2366,7 +2366,7 @@ buildvariants:
 
   - name: macos-arm
     display_name: "macOS 11.0 ARM 64"
-    run_on: [macos-1100-arm64]
+    run_on: [macos-11-arm64]
     tasks:
       - name: compile
       - name: compile-debug

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2354,8 +2354,8 @@ buildvariants:
       - name: sign
 
   - name: macos
-    display_name: "macOS 11.0"
-    run_on: [macos-11]
+    display_name: "macOS"
+    run_on: [macos-14]
     tasks:
       - name: compile
       - name: compile-debug
@@ -2365,8 +2365,8 @@ buildvariants:
       - name: result-set-test
 
   - name: macos-arm
-    display_name: "macOS 11.0 ARM 64"
-    run_on: [macos-11-arm64]
+    display_name: "macOS arm64"
+    run_on: [macos-14-arm64]
     tasks:
       - name: compile
       - name: compile-debug


### PR DESCRIPTION
Also added changes for Silk upload to work described in [SQL-2322](https://jira.mongodb.org/browse/SQL-2322)