### PR TITLE
SQL-2422: replace get_adf_version

### DIFF
--- a/core/src/conn.rs
+++ b/core/src/conn.rs
@@ -310,7 +310,7 @@ impl MongoConnection {
         Ok(())
     }
 
-    /// Gets the ADF version the client is connected to.
+    /// Gets the server version the client is connected to.
     pub fn get_server_version(&self) -> Result<String> {
         self.runtime.block_on(async {
             let db = self.client.database("admin");

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -2423,7 +2423,7 @@ macro_rules! sql_get_info_helper {
                         .unwrap()
                         .as_ref()
                         .unwrap()
-                        .get_adf_version();
+                        .get_server_version();
                     match version {
                         Ok(version) => i16_len::set_output_wstring_as_bytes(
                             version.as_str(),


### PR DESCRIPTION
Switching out `get_adf_version` for `get_server_version`. Datalake is now optional so it's universal. If for some reason the command fails it'll be automatically handled.