### PR TITLE
SQL-2420: Fix ubuntu signing task for on-prem-eap branch

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -627,7 +627,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o $UBUNTU_FILENAME.sig --detach-sign $UBUNTU_FILENAME"
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o ${UBUNTU_FILENAME}.sig --detach-sign ${UBUNTU_FILENAME}"
     - command: shell.exec
       type: system
       params:
@@ -643,7 +643,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --verify $UBUNTU_FILENAME.sig $UBUNTU_FILENAME"
+            /bin/bash -c "gpgloader && gpg --verify ${UBUNTU_FILENAME}.sig ${UBUNTU_FILENAME}"
 
   "compile ubuntu and win release":
     - command: shell.exec


### PR DESCRIPTION
Patch showing the ubuntu signing task passing: https://spruce.mongodb.com/version/671ff639fc46880007190ff4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC