### PR TITLE
 SQL-2403: Obtain path for mongosqltranslate lib from DriverSettings

### DIFF
--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -86,6 +86,8 @@ pub enum Error {
     MultipleSchemaDocumentsReturned(usize),
     #[error("The buildInfo command failed with the following error: `{0}`")]
     BuildInfoCmdExecutionFailed(mongodb::error::Error),
+    #[error("Library path error: {0}")]
+    LibraryPathError(String),
 }
 
 impl Error {
@@ -131,6 +133,7 @@ impl Error {
             | Error::BuildInfoCmdExecutionFailed(_) => GENERAL_ERROR,
             Error::StatementNotExecuted => FUNCTION_SEQUENCE_ERROR,
             Error::QueryCancelled => OPERATION_CANCELLED,
+            Error::LibraryPathError(_) => GENERAL_ERROR,
         }
     }
 
@@ -179,6 +182,7 @@ impl Error {
             | Error::TranslationPipelineNotArray
             | Error::TranslationPipelineArrayContainsNonDocument
             | Error::BsonDocumentToCommandResponseDeserialization(_)
+            | Error::LibraryPathError(_)
             | Error::MultipleSchemaDocumentsReturned(_)
             | Error::BuildInfoCmdExecutionFailed(_) => 0,
         }

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1469,8 +1469,7 @@ functions:
         working_dir: mongosql-odbc-driver
         script: |
           ${prepare_shell}
-          sudo mkdir -p /opt/mongodb/atlas-sql-odbc-driver/
-          sudo mv -f libmongosqltranslate.so /opt/mongodb/atlas-sql-odbc-driver/libmongosqltranslate.so
+          sudo mv -f libmongosqltranslate.so target/release/libmongosqltranslate.so
           cargo test mongosqltranslate_tests -- --nocapture        
 
   "run ubuntu cluster type integration tests":
@@ -1502,8 +1501,7 @@ functions:
           ENTERPRISE_NOLIB_EXITCODE=$?
         
           # Move mongosqltranslate library to the correct location
-          sudo mkdir -p /opt/mongodb/atlas-sql-odbc-driver/
-          sudo mv -f libmongosqltranslate.so /opt/mongodb/atlas-sql-odbc-driver/libmongosqltranslate.so
+          sudo mv -f libmongosqltranslate.so target/release/libmongosqltranslate.so
         
           # Enterprise test with library
           cargo test --features cluster_type_tests -- \


### PR DESCRIPTION
I had trouble rebasing my [previous PR ](https://github.com/mongodb/mongo-odbc-driver/pull/252) which is already approved.  It was initially pointing to the wrong branch so I am opening this. 

Removes the hard-coded values and uses the driver property from DriverSettings to get the directory of the ODBC driver.