### PR TITLE
SQL-2466: handle changing databases for power bi on prem

### DIFF
--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -8,7 +8,6 @@ use crate::{
         TranslateCommandResponse,
     },
     stmt::MongoStatement,
-    util::DISALLOWED_DB_NAMES,
     Error, TypeMode,
 };
 use constants::SQL_SCHEMAS_COLLECTION;
@@ -42,23 +41,16 @@ pub struct MongoQuery {
 }
 
 impl MongoQuery {
-    fn get_sql_query_namespaces(
-        sql_query: &str,
-        databases: BTreeSet<String>,
-    ) -> Result<BTreeSet<Namespace>> {
-        let mut namespaces = BTreeSet::new();
-        databases.iter().for_each(|db| {
-            let command = GetNamespaces::new(sql_query.to_string(), db.to_string());
-            let command_response = libmongosqltranslate_run_command(command).unwrap();
-            if let CommandResponse::GetNamespaces(response) = command_response {
-                response.namespaces.iter().for_each(|ns| {
-                    namespaces.insert(ns.clone());
-                });
-            } else {
-                unreachable!()
-            }
-        });
-        Ok(namespaces)
+    fn get_sql_query_namespaces(sql_query: &str, db: &String) -> Result<BTreeSet<Namespace>> {
+        let command = GetNamespaces::new(sql_query.to_string(), db.to_string());
+
+        let command_response = libmongosqltranslate_run_command(command)?;
+
+        if let CommandResponse::GetNamespaces(response) = command_response {
+            Ok(response.namespaces)
+        } else {
+            unreachable!()
+        }
     }
 
     fn translate_sql(
@@ -256,23 +248,8 @@ impl MongoQuery {
                     )
                 }
                 MongoClusterType::Enterprise => {
-                    // Get relevant namespaces
-                    let database_names: BTreeSet<String> = client
-                        .runtime
-                        .block_on(async {
-                            client
-                                .client
-                                .list_database_names()
-                                .authorized_databases(true)
-                                .await
-                        })
-                        .unwrap()
-                        .iter()
-                        .filter(|&db_name| !DISALLOWED_DB_NAMES.contains(&db_name.as_str()))
-                        .map(|s| s.to_string())
-                        .collect();
                     let namespaces: BTreeSet<Namespace> =
-                        Self::get_sql_query_namespaces(query, database_names)?;
+                        Self::get_sql_query_namespaces(query, working_db)?;
 
                     // Translate sql
                     let mongosql_translation = if namespaces.is_empty() {


### PR DESCRIPTION
I struggled to find a clean way to get a list of databases to the schema pulling, so rather, I just used the client to pull all databases at the time of querying. The reason it was an issue is that we create new HDbc handles, and MongoConnections, frequently enough that the only way to persist the databases from the initial listing was to push all the way down to the env handle (which didn't seem right). I'm very open to alternative implementations if there's an easier way!

I also needed to update the db set on the MongoQuery returned from mongoprepare in order to get the execute function working properly.

This seems to work in power bi, though would love a second set of eyes in case I missed anything! 