### PR TITLE
Add rust toolchain

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2026,6 +2026,7 @@ tasks:
     #   - name: sbom
     #     variant: code-quality-security
     commands:
+      - func: "install rust toolchain"
       - func: "install iODBC"
         variants: [macos, macos-arm]
       - func: "install rust toolchain"
@@ -2381,22 +2382,10 @@ buildvariants:
       # - name: integration-test
       - name: result-set-test
 
-  - name: eap-release
-    display_name: "EAP Release"
-    run_on: [ubuntu2004-medium]
-    tasks:
-      - name: rustfmt
-      - name: compile
-      - name: make-odbc-docs
-      - name: release
-      - name: snapshot
-
-
   - name: release
     display_name: "Release"
     run_on: [ubuntu2004-medium]
     tasks:
-      - name: rustfmt
       - name: compile
       - name: make-odbc-docs
       - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2385,6 +2385,7 @@ buildvariants:
     display_name: "EAP Release"
     run_on: [ubuntu2004-medium]
     tasks:
+      - name: rustfmt
       - name: compile
       - name: make-odbc-docs
       - name: release
@@ -2395,6 +2396,7 @@ buildvariants:
     display_name: "Release"
     run_on: [ubuntu2004-medium]
     tasks:
+      - name: rustfmt
       - name: compile
       - name: make-odbc-docs
       - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2026,7 +2026,6 @@ tasks:
     #   - name: sbom
     #     variant: code-quality-security
     commands:
-      - func: "install rust toolchain"
       - func: "install iODBC"
         variants: [macos, macos-arm]
       - func: "install rust toolchain"
@@ -2386,7 +2385,6 @@ buildvariants:
     display_name: "Release"
     run_on: [ubuntu2004-medium]
     tasks:
-      - name: compile
       - name: make-odbc-docs
       - name: release
       - name: snapshot


### PR DESCRIPTION
The rust toolchain needed to be added. The integration test issue was due to someone writing to the source database, and happening to write to the exact collection we expect not to exists.

https://spruce.mongodb.com/version/6734d908150c5700079b6c79/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC