### PR TITLE
SQL-2502: handle null pointers and empty strings

### DIFF
--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -64,7 +64,7 @@ pub(crate) fn is_match(name: &str, filter: &str, accept_search_patterns: bool) -
 // Create the list of Collection types to filter on
 pub(crate) fn table_type_filter_to_vec(table_type: &str) -> Option<Vec<CollectionType>> {
     return match table_type {
-        SQL_ALL_TABLE_TYPES => None,
+        SQL_ALL_TABLE_TYPES | "" => None,
         _ => {
             let table_type_entries = table_type
                 .split(',')

--- a/cstr/src/lib.rs
+++ b/cstr/src/lib.rs
@@ -85,6 +85,24 @@ pub unsafe fn input_text_to_string_a(text: *const Char, len: isize) -> String {
 }
 
 ///
+/// input_text_to_string_a_allow_null converts a u8 cstring to a rust String.
+/// It assumes null termination if the supplied length is negative.
+///
+/// This function will return an empty string if passed a null pointer.
+///
+/// # Safety
+/// This converts raw C-pointers to rust Strings, which requires unsafe operations
+///
+#[allow(clippy::uninit_vec)]
+pub unsafe fn input_text_to_string_a_allow_null(text: *const Char, len: isize) -> String {
+    if text.is_null() {
+        String::new()
+    } else {
+        input_text_to_string_a(text, len)
+    }
+}
+
+///
 /// input_text_to_string_w converts a u16 cstring to a rust String.
 /// It assumes null termination if the supplied length is negative.
 ///
@@ -116,6 +134,25 @@ pub unsafe fn input_text_to_string_w(text: *const WideChar, len: isize) -> Strin
         _ => unreachable!("input_text_to_string_w: len was neither negative, zero, nor positive."),
     }
 }
+
+///
+/// input_text_to_string_w_allow_null converts a u16 cstring to a rust String.
+/// It assumes null termination if the supplied length is negative.
+///
+/// This function will return an empty string if passed a null pointer.
+///
+/// # Safety
+/// This converts raw C-pointers to rust Strings, which requires unsafe operations
+///
+#[allow(clippy::uninit_vec)]
+pub unsafe fn input_text_to_string_w_allow_null(text: *const WideChar, len: isize) -> String {
+    if text.is_null() {
+        String::new()
+    } else {
+        input_text_to_string_w(text, len)
+    }
+}
+
 ///
 /// parse_attribute_string_w converts a null-separated doubly null terminated *Widechar string to a Rust
 /// string separated by `;`.
@@ -488,6 +525,40 @@ mod test {
         let test = "".as_bytes();
         let test = test.as_ptr();
         let test = unsafe { input_text_to_string_a(test, 0) };
+        assert_eq!(expected, test);
+    }
+
+    #[test]
+    fn test_null_ptr_input_text_to_string() {
+        let expected = "";
+        let test = std::ptr::null();
+        let test = unsafe { input_text_to_string_a_allow_null(test, 0) };
+        assert_eq!(expected, test);
+    }
+
+    #[test]
+    fn test_nonnull_ptr_input_text_to_string() {
+        let expected = "test";
+        let test = "test\0".as_bytes();
+        let test = test.as_ptr();
+        let test = unsafe { input_text_to_string_a_allow_null(test, expected.len() as isize) };
+        assert_eq!(expected, test);
+    }
+
+    #[test]
+    fn test_null_ptr_input_text_to_string_w() {
+        let expected = "";
+        let test = std::ptr::null();
+        let test = unsafe { input_text_to_string_w_allow_null(test, 0) };
+        assert_eq!(expected, test);
+    }
+
+    #[test]
+    fn test_nonnull_ptr_input_text_to_string_w() {
+        let expected = "test";
+        let test = to_widechar_vec("test");
+        let test = test.as_ptr();
+        let test = unsafe { input_text_to_string_w_allow_null(test, expected.len() as isize) };
         assert_eq!(expected, test);
     }
 }

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -12,7 +12,7 @@ use crate::{
 use constants::*;
 use mongodb::bson::{doc, Bson};
 
-use cstr::{input_text_to_string_w, Charset, WideChar};
+use cstr::{input_text_to_string_w, input_text_to_string_w_allow_null, Charset, WideChar};
 
 use definitions::{
     AllocType, AsyncEnable, AttrConnectionPooling, AttrCpMatch, AttrOdbcVersion, BindType,
@@ -844,20 +844,23 @@ pub unsafe extern "C" fn SQLColumnsW(
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let odbc_3_data_types = has_odbc_3_behavior!(mongo_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
-            let catalog_string = input_text_to_string_w(catalog_name, catalog_name_length.into());
+            let catalog_string =
+                input_text_to_string_w_allow_null(catalog_name, catalog_name_length.into());
             let catalog = if catalog_name.is_null() || catalog_string.is_empty() {
                 None
             } else {
                 Some(catalog_string.as_str())
             };
             // ignore schema
-            let table_string = input_text_to_string_w(table_name, table_name_length.into());
+            let table_string =
+                input_text_to_string_w_allow_null(table_name, table_name_length.into());
             let table = if table_name.is_null() {
                 None
             } else {
                 Some(table_string.as_str())
             };
-            let column_name_string = input_text_to_string_w(column_name, column_name_length.into());
+            let column_name_string =
+                input_text_to_string_w_allow_null(column_name, column_name_length.into());
             let column = if column_name.is_null() {
                 None
             } else {
@@ -4174,8 +4177,8 @@ pub unsafe extern "C" fn SQLTablesW(
             let odbc_behavior = has_odbc_3_behavior!(mongo_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
             let catalog = input_text_to_string_w(catalog_name, name_length_1.into());
-            let schema = input_text_to_string_w(schema_name, name_length_2.into());
-            let table = input_text_to_string_w(table_name, name_length_3.into());
+            let schema = input_text_to_string_w_allow_null(schema_name, name_length_2.into());
+            let table = input_text_to_string_w_allow_null(table_name, name_length_3.into());
             let table_t = input_text_to_string_w(table_type, name_length_4.into());
             let connection = (*stmt.connection).as_connection().unwrap();
             let max_string_length = *connection.max_string_length.read().unwrap();


### PR DESCRIPTION
This PR address SQL-2496, SQL-2497, and SQL-2500 as they are all closely related. I was a bit hesitant to make changes across all functions in our API, so I only introduced supporting null pointers as empty strings in SQLTables and SQLColumns.