### PR TITLE
SQL-2499: Add support for InfoType::SQL_KEYWORDS

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -45,7 +45,6 @@ lazy_static! {
         "NUMBER".to_string(),
         "OBJECTID".to_string(),
         "OFFSET".to_string(),
-        "ORDER".to_string(),
         "PATH".to_string(),
         "REGEX".to_string(),
         "SEPARATOR".to_string(),

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -22,6 +22,39 @@ lazy_static! {
     pub static ref DEFAULT_APP_NAME: String =
         format!("{}+{}", DRIVER_SHORT_NAME, DRIVER_METRICS_VERSION.as_str());
     pub static ref DRIVER_ODBC_VERSION: String = format_driver_version();
+    pub static ref KEYWORDS: String = [
+        "AGGREGATE".to_string(),
+        "ARRAY".to_string(),
+        "BINDATA".to_string(),
+        "BOOL".to_string(),
+        "BOOLEAN".to_string(),
+        "BSON_DATE".to_string(),
+        "BSON_TIMESTAMP".to_string(),
+        "DBPOINTER".to_string(),
+        "DEPTH".to_string(),
+        "DOCUMENT".to_string(),
+        "ERROR".to_string(),
+        "FLATTEN".to_string(),
+        "JAVASCRIPT".to_string(),
+        "JAVASCRIPTWITHSCOPE".to_string(),
+        "LIMIT".to_string(),
+        "LONG".to_string(),
+        "MAXKEY".to_string(),
+        "MINKEY".to_string(),
+        "MISSING".to_string(),
+        "NUMBER".to_string(),
+        "OBJECTID".to_string(),
+        "OFFSET".to_string(),
+        "ORDER".to_string(),
+        "PATH".to_string(),
+        "REGEX".to_string(),
+        "SEPARATOR".to_string(),
+        "STRING".to_string(),
+        "SYMBOL".to_string(),
+        "UNDEFINED".to_string(),
+        "UNWIND".to_string(),
+    ]
+    .join(",");
 }
 
 // The default max string length if a user enables max string length.

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -2887,6 +2887,14 @@ macro_rules! sql_get_info_helper {
                         string_length_ptr,
                     )
                 }
+                InfoType::SQL_KEYWORDS => {
+                    i16_len::set_output_wstring_as_bytes(
+                        KEYWORDS.as_str(),
+                        info_value_ptr,
+                        buffer_length as usize,
+                        string_length_ptr,
+                    )
+                }
                 _ => {
                     err = Some(ODBCError::UnsupportedInfoTypeRetrieval(
                         info_type.to_string(),


### PR DESCRIPTION
This PR adds support for `InfoType::SQL_KEYWORDS` by returning a `lazy_static` string representing MongoSQL-specific keywords. I took the `mongosql-rs` list of keywords ([here](https://github.com/10gen/mongosql-rs/blob/921ea1b6df6d2d9df360c12bcd49a46acddadacc/mongosql/src/parser/mongosql.lalrpop#L754)) and removed anything already included in the [ODBC Reserved Keywords list](https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/reserved-keywords?view=sql-server-ver16).