### PR TITLE
SQL-2502: port from other PR

### DIFF
--- a/core/src/mongosqltranslate.rs
+++ b/core/src/mongosqltranslate.rs
@@ -96,7 +96,10 @@ pub fn get_run_command_fn_ptr(
 }
 
 pub fn get_mongosqltranslate_library() -> Option<&'static Library> {
-    unsafe { MONGOSQLTRANSLATE_LIBRARY.as_ref() }
+    #[allow(static_mut_refs)]
+    unsafe {
+        MONGOSQLTRANSLATE_LIBRARY.as_ref()
+    }
 }
 
 pub trait CommandName {

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -54,8 +54,8 @@ pub(crate) fn is_match(name: &str, filter: &str, accept_search_patterns: bool) -
 
 // Create the list of Collection types to filter on
 pub(crate) fn table_type_filter_to_vec(table_type: &str) -> Option<Vec<CollectionType>> {
-    return match table_type {
-        SQL_ALL_TABLE_TYPES => None,
+    match table_type {
+        SQL_ALL_TABLE_TYPES | "" => None,
         _ => {
             let table_type_entries = table_type
                 .split(',')
@@ -75,7 +75,7 @@ pub(crate) fn table_type_filter_to_vec(table_type: &str) -> Option<Vec<Collectio
 
             Some(table_type_filters)
         }
-    };
+    }
 }
 
 #[macro_export]
@@ -102,63 +102,92 @@ macro_rules! set {
 
 #[cfg(test)]
 mod filtering {
-    use super::{is_match, to_name_regex};
+    use super::{is_match, table_type_filter_to_vec, to_name_regex};
 
-    #[test]
-    fn test_to_name_regex() {
-        assert!(to_name_regex("%").is_none());
-        assert!(to_name_regex("").is_none());
-        assert!(to_name_regex("filter").is_some());
+    mod table_type_filter_to_vec {
+        use super::table_type_filter_to_vec;
+        use mongodb::results::CollectionType;
+        #[test]
+        fn test_table_type_filter_to_vec() {
+            assert_eq!(
+                table_type_filter_to_vec("table"),
+                Some(vec![CollectionType::Collection])
+            );
+            assert_eq!(
+                table_type_filter_to_vec("view"),
+                Some(vec![CollectionType::View])
+            );
+            assert_eq!(
+                table_type_filter_to_vec("table,view"),
+                Some(vec![CollectionType::Collection, CollectionType::View])
+            );
+            assert_eq!(table_type_filter_to_vec(""), None);
+            assert_eq!(table_type_filter_to_vec("%"), None);
+        }
     }
 
-    #[test]
-    fn test_is_positive_match_literal() {
-        assert!(is_match("%", "%", false));
-        assert!(is_match("%test", "%test", false));
-        assert!(is_match("down_times", "down_times", false));
-        assert!(is_match("filter", "filter", false));
-        assert!(is_match("downtimes", "downtimes", false));
-        assert!(is_match("money$$bags", "money$$bags", false));
-        assert!(is_match("money$.bags", "money$.bags", false));
+    mod to_name_regex {
+        use super::to_name_regex;
+        #[test]
+        fn test_to_name_regex() {
+            assert!(to_name_regex("%").is_none());
+            assert!(to_name_regex("").is_none());
+            assert!(to_name_regex("filter").is_some());
+        }
     }
 
-    #[test]
-    fn test_is_negative_match_literal() {
-        assert!(!is_match("filter", "%", false));
-        assert!(!is_match("customerssales", "customer_sales", false));
-        assert!(!is_match("conversions2022", "conversions%", false));
-        assert!(!is_match("integration_test", "%test", false));
-        assert!(!is_match("integration_test", "integrationstest", false));
-    }
+    mod is_match {
+        use super::is_match;
 
-    #[test]
-    fn test_is_positive_match_pattern() {
-        assert!(is_match("filter", "%", true));
-        assert!(is_match("filter", "filter", true));
-        assert!(is_match("downtimes", "downtimes", true));
-        assert!(is_match("customerssales", "customer_sales", true));
-        assert!(is_match("myiphone", "my_phone", true));
-        assert!(is_match("conversions2022", "conversions%", true));
-        assert!(is_match("integration_test", "%test", true));
-        assert!(is_match("money$$bags", "money$$bags", true));
-        assert!(is_match("money$.bags", "money$.bags", true));
-    }
+        #[test]
+        fn test_is_positive_match_literal() {
+            assert!(is_match("%", "%", false));
+            assert!(is_match("%test", "%test", false));
+            assert!(is_match("down_times", "down_times", false));
+            assert!(is_match("filter", "filter", false));
+            assert!(is_match("downtimes", "downtimes", false));
+            assert!(is_match("money$$bags", "money$$bags", false));
+            assert!(is_match("money$.bags", "money$.bags", false));
+        }
 
-    #[test]
-    fn test_is_negative_match_odbc_pattern() {
-        assert!(!is_match("filter", "filt", true));
-        assert!(!is_match("filter", r"filt_er", true));
-        assert!(!is_match("downtimestatus", "downtimes", true));
-        assert!(!is_match("downtimestatus", "status", true));
-        assert!(!is_match("integration_test_2", "%test", true));
-        assert!(!is_match("money$$bags", "money$.bags", true));
-    }
+        #[test]
+        fn test_is_negative_match_literal() {
+            assert!(!is_match("filter", "%", false));
+            assert!(!is_match("customerssales", "customer_sales", false));
+            assert!(!is_match("conversions2022", "conversions%", false));
+            assert!(!is_match("integration_test", "%test", false));
+            assert!(!is_match("integration_test", "integrationstest", false));
+        }
 
-    #[test]
-    fn test_escaped_chars_in_pattern() {
-        assert!(is_match("my_phone", r"my\_phone", true));
-        assert!(!is_match("myiphone", r"my\_phone", true));
-        assert!(is_match("conversion%2022", r"conversion\%2022", true));
-        assert!(!is_match("conversions2022", r"conversion\%2022", true));
+        #[test]
+        fn test_is_positive_match_pattern() {
+            assert!(is_match("filter", "%", true));
+            assert!(is_match("filter", "filter", true));
+            assert!(is_match("downtimes", "downtimes", true));
+            assert!(is_match("customerssales", "customer_sales", true));
+            assert!(is_match("myiphone", "my_phone", true));
+            assert!(is_match("conversions2022", "conversions%", true));
+            assert!(is_match("integration_test", "%test", true));
+            assert!(is_match("money$$bags", "money$$bags", true));
+            assert!(is_match("money$.bags", "money$.bags", true));
+        }
+
+        #[test]
+        fn test_is_negative_match_odbc_pattern() {
+            assert!(!is_match("filter", "filt", true));
+            assert!(!is_match("filter", r"filt_er", true));
+            assert!(!is_match("downtimestatus", "downtimes", true));
+            assert!(!is_match("downtimestatus", "status", true));
+            assert!(!is_match("integration_test_2", "%test", true));
+            assert!(!is_match("money$$bags", "money$.bags", true));
+        }
+
+        #[test]
+        fn test_escaped_chars_in_pattern() {
+            assert!(is_match("my_phone", r"my\_phone", true));
+            assert!(!is_match("myiphone", r"my\_phone", true));
+            assert!(is_match("conversion%2022", r"conversion\%2022", true));
+            assert!(!is_match("conversions2022", r"conversion\%2022", true));
+        }
     }
 }

--- a/core/src/util/test_connection.rs
+++ b/core/src/util/test_connection.rs
@@ -16,7 +16,6 @@ use definitions::{Integer, SQL_NTS_ISIZE};
 /// # Safety
 /// Because this function is called from C, it is unsafe.
 ///
-
 #[no_mangle]
 pub unsafe extern "C" fn atlas_sql_test_connection(
     connection_string: *const WideChar,

--- a/cstr/src/lib.rs
+++ b/cstr/src/lib.rs
@@ -116,6 +116,25 @@ pub unsafe fn input_text_to_string_w(text: *const WideChar, len: isize) -> Strin
         _ => unreachable!("input_text_to_string_w: len was neither negative, zero, nor positive."),
     }
 }
+
+///
+/// input_text_to_string_w_allow_null converts a u16 cstring to a rust String.
+/// It assumes null termination if the supplied length is negative.
+///
+/// This function will return an empty string if passed a null pointer.
+///
+/// # Safety
+/// This converts raw C-pointers to rust Strings, which requires unsafe operations
+///
+#[allow(clippy::uninit_vec)]
+pub unsafe fn input_text_to_string_w_allow_null(text: *const WideChar, len: isize) -> String {
+    if text.is_null() {
+        String::new()
+    } else {
+        input_text_to_string_w(text, len)
+    }
+}
+
 ///
 /// parse_attribute_string_w converts a null-separated doubly null terminated *Widechar string to a Rust
 /// string separated by `;`.
@@ -488,6 +507,22 @@ mod test {
         let test = "".as_bytes();
         let test = test.as_ptr();
         let test = unsafe { input_text_to_string_a(test, 0) };
+        assert_eq!(expected, test);
+    }
+
+    #[test]
+    fn test_null_ptr_input_text_to_string_w() {
+        let expected = "";
+        let test = std::ptr::null();
+        let test = unsafe { input_text_to_string_w_allow_null(test, 0) };
+        assert_eq!(expected, test);
+    }
+    #[test]
+    fn test_nonnull_ptr_input_text_to_string_w() {
+        let expected = "test";
+        let test = to_widechar_vec("test");
+        let test = test.as_ptr();
+        let test = unsafe { input_text_to_string_w_allow_null(test, expected.len() as isize) };
         assert_eq!(expected, test);
     }
 }

--- a/definitions/src/desc.rs
+++ b/definitions/src/desc.rs
@@ -194,7 +194,6 @@ pub enum Desc {
     /// -----------------------------------------------------------------------------------------
     /// ODBC 2.x field identifiers which must be supported by an ODBC 3.x driver
     /// ODBC 2.0 specification can be found here for more details: https://download.oracle.com/otn_hosted_doc/timesten/703/TimesTen-Documentation/ms.odbc.pdf
-
     /// ODBC 2.x field identifier for the Transfer Octet.
     /// The length of a column is the maximum number of bytes returned to the application when data
     /// is transferred to its default C data type. For character data, the length does not include

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -12,7 +12,7 @@ use crate::{
 use constants::*;
 use mongodb::bson::{doc, Bson};
 
-use cstr::{input_text_to_string_w, Charset, WideChar};
+use cstr::{input_text_to_string_w, input_text_to_string_w_allow_null, Charset, WideChar};
 
 use definitions::{
     AllocType, AsyncEnable, AttrConnectionPooling, AttrCpMatch, AttrOdbcVersion, BindType,
@@ -844,20 +844,23 @@ pub unsafe extern "C" fn SQLColumnsW(
             let mongo_handle = MongoHandleRef::from(statement_handle);
             let odbc_3_data_types = has_odbc_3_behavior!(mongo_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
-            let catalog_string = input_text_to_string_w(catalog_name, catalog_name_length.into());
+            let catalog_string =
+                input_text_to_string_w_allow_null(catalog_name, catalog_name_length.into());
             let catalog = if catalog_name.is_null() || catalog_string.is_empty() {
                 None
             } else {
                 Some(catalog_string.as_str())
             };
             // ignore schema
-            let table_string = input_text_to_string_w(table_name, table_name_length.into());
+            let table_string =
+                input_text_to_string_w_allow_null(table_name, table_name_length.into());
             let table = if table_name.is_null() {
                 None
             } else {
                 Some(table_string.as_str())
             };
-            let column_name_string = input_text_to_string_w(column_name, column_name_length.into());
+            let column_name_string =
+                input_text_to_string_w_allow_null(column_name, column_name_length.into());
             let column = if column_name.is_null() {
                 None
             } else {
@@ -972,7 +975,6 @@ pub unsafe extern "C" fn SQLDataSourcesW(
     unsupported_function!(environment_handle)
 }
 */
-
 ///
 /// [`SQLDescribeColW`]: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/SQLDescribeCol-function
 ///
@@ -1265,7 +1267,6 @@ pub unsafe extern "C" fn SQLDriversW(
     unsupported_function!(henv)
 }
 **/
-
 ///
 /// [`SQLEndTran`]: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/SQLEndTran-function
 ///
@@ -4174,8 +4175,8 @@ pub unsafe extern "C" fn SQLTablesW(
             let odbc_behavior = has_odbc_3_behavior!(mongo_handle);
             let stmt = must_be_valid!((*mongo_handle).as_statement());
             let catalog = input_text_to_string_w(catalog_name, name_length_1.into());
-            let schema = input_text_to_string_w(schema_name, name_length_2.into());
-            let table = input_text_to_string_w(table_name, name_length_3.into());
+            let schema = input_text_to_string_w_allow_null(schema_name, name_length_2.into());
+            let table = input_text_to_string_w_allow_null(table_name, name_length_3.into());
             let table_t = input_text_to_string_w(table_type, name_length_4.into());
             let connection = (*stmt.connection).as_connection().unwrap();
             let max_string_length = *connection.max_string_length.read().unwrap();


### PR DESCRIPTION
This addresses the following JIRAs in the main branch, and is a carbon copy of the fixes introduced in PR #276 

- SQL-2496: handle null pointer parameters in SQLTablesW
- SQL-2497 handle null pointer parameters in SQLColumnsW
- SQL-2500: treat emptry string as no filter in table_type_filter_to_vec
- SQL-2505: address clippy warnings/errors that are causing the waterfall to not be green