### PR TITLE
DEVPROD-13313: template authenticode key name

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -605,7 +605,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jsign_image} \
-            /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 ${MSI_FILENAME}"
+            /bin/bash -c "jsign -a ${authenticode_key_name} --replace --tsaurl http://timestamp.digicert.com -d SHA-256 ${MSI_FILENAME}"
 
           # Generating checksums
           if [ -e $msi_filename ]; then


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our Evergreen project as mongo-authenticode-2024.