### PR TITLE
SQL-2527: Handle possible null string_length_2 parameter

### DIFF
--- a/integration_test/src/test_runner/mod.rs
+++ b/integration_test/src/test_runner/mod.rs
@@ -163,7 +163,7 @@ pub fn run_resultset_tests(generate: bool) -> Result<()> {
                     if let Some(true) = test.is_standard_type {
                         conn_str.push_str("SIMPLE_TYPES_ONLY=0;");
                     }
-                    let conn_handle = connect_with_conn_string(env, Some(conn_str)).unwrap();
+                    let conn_handle = connect_with_conn_string(env, Some(conn_str), true).unwrap();
                     let test_result = match test.test_definition {
                         TestDef::Query(ref q) => run_query_test(q, &test, conn_handle, generate),
                         TestDef::Function(ref f) => {
@@ -207,7 +207,7 @@ pub fn run_resultset_tests_odbc_2(generate: bool) -> Result<()> {
                     if let Some(true) = test.is_standard_type {
                         conn_str.push_str("SIMPLE_TYPES_ONLY=0;");
                     }
-                    let conn_handle = connect_with_conn_string(env, Some(conn_str)).unwrap();
+                    let conn_handle = connect_with_conn_string(env, Some(conn_str), true).unwrap();
                     let test_result = match test.test_definition {
                         TestDef::Query(ref q) => run_query_test(q, &test, conn_handle, generate),
                         TestDef::Function(ref f) => {

--- a/integration_test/tests/cluster_type_test.rs
+++ b/integration_test/tests/cluster_type_test.rs
@@ -21,7 +21,7 @@ mod cluster_type {
         let connection_string = generate_mdb_connection_str(port_type);
 
         let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
-        match connect_with_conn_string(env_handle, Some(connection_string)) {
+        match connect_with_conn_string(env_handle, Some(connection_string), true) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),
         }

--- a/integration_test/tests/common/mod.rs
+++ b/integration_test/tests/common/mod.rs
@@ -200,7 +200,7 @@ pub fn connect_and_allocate_statement(
     env_handle: HEnv,
     in_connection_string: Option<String>,
 ) -> (HDbc, HStmt) {
-    let conn_handle = connect_with_conn_string(env_handle, in_connection_string).unwrap();
+    let conn_handle = connect_with_conn_string(env_handle, in_connection_string, true).unwrap();
     (conn_handle, allocate_statement(conn_handle).unwrap())
 }
 
@@ -209,6 +209,7 @@ pub fn connect_and_allocate_statement(
 pub fn connect_with_conn_string(
     env_handle: HEnv,
     in_connection_string: Option<String>,
+    use_str_len_ptr: bool,
 ) -> Result<HDbc> {
     // Allocate a DBC handle
     let mut dbc: Handle = null_mut();
@@ -225,7 +226,12 @@ pub fn connect_with_conn_string(
             in_connection_string.unwrap_or_else(generate_default_connection_str);
         let mut in_connection_string_encoded = cstr::to_widechar_vec(&in_connection_string);
         in_connection_string_encoded.push(0);
-        let str_len_ptr = &mut 0;
+        let mut len_buffer: i16 = 0;
+        let str_len_ptr = if use_str_len_ptr {
+            &mut len_buffer as *mut _
+        } else {
+            null_mut()
+        };
         match SQLDriverConnectW(
             dbc as HDbc,
             null_mut(),

--- a/integration_test/tests/connection_tests.rs
+++ b/integration_test/tests/connection_tests.rs
@@ -26,7 +26,7 @@ mod integration {
         let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         // Missing PWD
         let conn_str = "Driver=MongoDB Atlas SQL ODBC Driver;USER=N_A;SERVER=N_A";
-        let result = connect_with_conn_string(env_handle, Some(conn_str.to_string()));
+        let result = connect_with_conn_string(env_handle, Some(conn_str.to_string()), true);
 
         assert!(
             result.is_err(),
@@ -39,7 +39,7 @@ mod integration {
     fn test_default_connection() {
         let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_default_connection_str();
-        let _ = connect_with_conn_string(env_handle, Some(conn_str)).unwrap();
+        let _ = connect_with_conn_string(env_handle, Some(conn_str), true).unwrap();
         let _ = unsafe { Box::from_raw(env_handle) };
     }
 
@@ -47,7 +47,7 @@ mod integration {
     fn test_srv_style_uri_connection() {
         let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
         let conn_str = crate::common::generate_srv_style_connection_string();
-        let result = connect_with_conn_string(env_handle, Some(conn_str));
+        let result = connect_with_conn_string(env_handle, Some(conn_str), true);
 
         // TODO: SQL-2291: Uncomment the below assert!() and remove the uncommented one.
         // assert!(connection_result.is_ok(), "Expected successful connection, got error: {:?}", connection_result);
@@ -62,7 +62,7 @@ mod integration {
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=csharpLegacy",
         );
-        let _ = connect_with_conn_string(env_handle, Some(conn_str)).unwrap();
+        let _ = connect_with_conn_string(env_handle, Some(conn_str), true).unwrap();
         let _ = unsafe { Box::from_raw(env_handle) };
     }
 
@@ -72,7 +72,7 @@ mod integration {
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=javaLegacy",
         );
-        let _ = connect_with_conn_string(env_handle, Some(conn_str)).unwrap();
+        let _ = connect_with_conn_string(env_handle, Some(conn_str), true).unwrap();
         let _ = unsafe { Box::from_raw(env_handle) };
     }
 
@@ -82,7 +82,17 @@ mod integration {
         let conn_str = crate::common::generate_uri_with_default_connection_string(
             "uuidRepresentation=pythonLegacy",
         );
-        let _ = connect_with_conn_string(env_handle, Some(conn_str)).unwrap();
+        let _ = connect_with_conn_string(env_handle, Some(conn_str), true).unwrap();
+        let _ = unsafe { Box::from_raw(env_handle) };
+    }
+
+    #[test]
+    fn test_str_len_ptr_null() {
+        let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
+        let conn_str = crate::common::generate_default_connection_str();
+
+        // Test with str_len_ptr as null (use_str_len_ptr = false)
+        let _ = connect_with_conn_string(env_handle, Some(conn_str.clone()), false).unwrap();
         let _ = unsafe { Box::from_raw(env_handle) };
     }
 
@@ -97,7 +107,7 @@ mod integration {
         fn test_valid_dsn_connection() {
             let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
             let conn_str = "DSN=ADF_Test";
-            connect_with_conn_string(env_handle, Some(conn_str.to_string())).unwrap();
+            connect_with_conn_string(env_handle, Some(conn_str.to_string()), true).unwrap();
             let _ = unsafe { Box::from_raw(env_handle) };
         }
 
@@ -105,7 +115,7 @@ mod integration {
         fn test_uri_opts_override_dsn() {
             let env_handle = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
             let conn_str = "PWD=wrong;DSN=ADF_Test";
-            let result = connect_with_conn_string(env_handle, Some(conn_str.to_string()));
+            let result = connect_with_conn_string(env_handle, Some(conn_str.to_string()), true);
             assert!(
                 result.is_err(),
                 "The connection should have failed, but it was successful."

--- a/integration_test/tests/disconnect_tests.rs
+++ b/integration_test/tests/disconnect_tests.rs
@@ -21,7 +21,7 @@ mod integration {
     #[test]
     fn sql_disconnect_handles_many_statement_states_properly() {
         let env = allocate_env(AttrOdbcVersion::SQL_OV_ODBC3);
-        let dbc = connect_with_conn_string(env, None)
+        let dbc = connect_with_conn_string(env, None, true)
             .expect("Failed to connect with default connection string");
         // The following statements will be allocated and interacted with in the following ways:
         // stmt_1 will be closed

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1209,10 +1209,13 @@ pub unsafe extern "C" fn SQLDriverConnectW(
             // given that we only currently support DriverConnectOption::SQL_DRIVER_NO_PROMPT.
             // given that we only currently support DriverConnectOption::NoPrompt.
             if buffer_length <= 0 || out_connection_string.is_null() {
-                *string_length_2 = odbc_uri_string
-                    .len()
-                    .try_into()
-                    .expect("odbc_uri_string.len exceeds i16");
+                // Only assign to string_length_2 if it is not null
+                if !string_length_2.is_null() {
+                    *string_length_2 = odbc_uri_string
+                        .len()
+                        .try_into()
+                        .expect("odbc_uri_string.len exceeds i16");
+                }
                 return SqlReturn::SUCCESS;
             }
             let buffer_len = usize::try_from(buffer_length).unwrap();


### PR DESCRIPTION
Add null checking for `string_length_2` in the `SQLDriverConnectW()` function. 

This allowed the `iusql -v MongoDB_Atlas_SQL` command on Ubuntu to succeed. 

```
$ iusql -v MongoDB_Atlas_SQL
+---------------------------------------+
| Connected!                            |
|                                       |
| sql-statement                         |
| help [tablename]                      |
| quit                                  |
|                                       |
+---------------------------------------+
SQL> 
```

Added a test to confirm that the connection works with the `string_length_2` parameter is null and confirmed the test fails without the change. 