### PR TITLE
SQL-2533: add third party notices

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -789,11 +789,10 @@ functions:
           rm target/release/mock_mongosqltranslate.dll
 
           cp target/release/*.dll installer/msi
-          cp THIRD_PARTY_LICENSES.txt installer/msi
           # TODO: Uncomment prior to merging back into master
-          # cp ./README.md ./mongo-odbc-driver.augmented.sbom.json installer/msi
+          # cp ./THIRD_PARTY_LICENSES.txt ./README.md ./mongo-odbc-driver.augmented.sbom.json installer/msi
           # TODO: Delete the following line prior to merging back into master
-          cp ./README.md installer/msi
+          cp ./THIRD_PARTY_LICENSES.txt ./README.md installer/msi
           cd installer/msi
           if [ "$RELEASE_VERSION" == "snapshot" ]; then
               MINOR_VERSION="0.1"
@@ -2043,6 +2042,8 @@ tasks:
       - func: "install unix odbc"
         variants: [ubuntu2204]
       - func: "set and check packages version"
+      - func: "generate third party licenses"
+        variants: [ubuntu2204, windows-64, macos, macos-arm]
       - func: "compile ubuntu and win release"
         variants: [ubuntu2204, windows-64]
       - func: "compile macos release"
@@ -2054,7 +2055,6 @@ tasks:
           platform: "win"
           lib_prefix: ""
           ext: "dll"
-      - func: "generate third party licenses"
       - func: "build msi"
         variants: [windows-64]
       - func: "fetch mongosqltranslate"

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -22,6 +22,15 @@ timeout:
         ls -la
 
 functions:
+  "generate third party licenses":
+    - command: subprocess.exec
+      params:
+        binary: bash
+        working_dir: mongosql-odbc-driver
+        args:
+          - "./evergreen/generate_licenses.sh"
+        add_expansions_to_env: true
+
   "build odbc documentation":
     - command: subprocess.exec
       params:
@@ -780,6 +789,7 @@ functions:
           rm target/release/mock_mongosqltranslate.dll
 
           cp target/release/*.dll installer/msi
+          cp THIRD_PARTY_LICENSES.txt installer/msi
           # TODO: Uncomment prior to merging back into master
           # cp ./README.md ./mongo-odbc-driver.augmented.sbom.json installer/msi
           # TODO: Delete the following line prior to merging back into master
@@ -1167,7 +1177,7 @@ functions:
           # TODO: Uncomment prior to merging back into master
           # cp ./LICENSE ./README.md ./mongo-odbc-driver.augmented.sbom.json release/mongoodbc/
           # TODO: Delete the following line prior merging back into master
-          cp ./LICENSE ./README.md release/mongoodbc/
+          cp ./LICENSE ./THIRD_PARTY_LICENSES.txt ./README.md release/mongoodbc/
           cd release
           tar -czvf $UBUNTU_FILENAME mongoodbc/
 
@@ -2044,6 +2054,7 @@ tasks:
           platform: "win"
           lib_prefix: ""
           ext: "dll"
+      - func: "generate third party licenses"
       - func: "build msi"
         variants: [windows-64]
       - func: "fetch mongosqltranslate"

--- a/evergreen/generate_licenses.sh
+++ b/evergreen/generate_licenses.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+LICENSE_FILE_NAME="THIRD_PARTY_LICENSES.txt"
+
+# Install the cargo-bundle-licenses tool
+cargo install cargo-bundle-licenses
+
+# Generate the license file
+cargo bundle-licenses --format yaml --output resources/licenses.yaml
+
+# Ensure a clean slate by deleting the existing THIRD_PARTY_LICENSES.txt file
+rm -f "$LICENSE_FILE_NAME"
+
+# Concatenate the third_party_header.txt file and the licenses.yaml file to create the THIRD_PARTY_LICENSES.txt file
+cat resources/third_party_header.txt >"$LICENSE_FILE_NAME"
+cat resources/licenses.yaml >>"$LICENSE_FILE_NAME"

--- a/evergreen/generate_licenses.sh
+++ b/evergreen/generate_licenses.sh
@@ -6,7 +6,7 @@ LICENSE_FILE_NAME="THIRD_PARTY_LICENSES.txt"
 cargo install cargo-bundle-licenses
 
 # Generate the license file
-cargo bundle-licenses --format yaml --output resources/licenses.yaml
+cargo-bundle-licenses --format yaml --output resources/licenses.yaml
 
 # Ensure a clean slate by deleting the existing THIRD_PARTY_LICENSES.txt file
 rm -f "$LICENSE_FILE_NAME"
@@ -14,3 +14,5 @@ rm -f "$LICENSE_FILE_NAME"
 # Concatenate the third_party_header.txt file and the licenses.yaml file to create the THIRD_PARTY_LICENSES.txt file
 cat resources/third_party_header.txt >"$LICENSE_FILE_NAME"
 cat resources/licenses.yaml >>"$LICENSE_FILE_NAME"
+
+rm -f resources/licenses.yaml

--- a/installer/msi/LicensingFragment.wxs
+++ b/installer/msi/LicensingFragment.wxs
@@ -17,6 +17,13 @@
                     Source="$(var.SourceDir)\README.md"
                     DiskId="1" />
             </Component>
+            <Component Id="c_ThirdParty"
+                Guid="2804697e-9086-4f8c-ba4a-6a28fa814600">
+                <File Id="f_Third_Party_Licenses"
+                    Name="THIRD_PARTY_LICENSES.txt"
+                    Source="$(var.SourceDir)\THIRD_PARTY_LICENSES.txt"
+                    DiskId="1" />
+            </Component>
             <!-- TODO: Uncommented the following before merging eap into master -->
             <!-- <Component Id="c_Sbom"
                 Guid="f40564ba-a569-4567-895b-f720b816638c">
@@ -29,6 +36,7 @@
         <ComponentGroup Id="cg_License">
             <ComponentRef Id="c_Readme" />
             <ComponentRef Id="c_License" />
+            <ComponentRef Id="c_ThirdParty"/>
             <!-- TODO: Uncomment the following before merging back into master -->
             <!-- <ComponentRef Id="c_Sbom" /> -->
         </ComponentGroup>

--- a/resources/third_party_header.txt
+++ b/resources/third_party_header.txt
@@ -1,0 +1,12 @@
+MongoDB uses third-party libraries or other resources that may
+be distributed under licenses different than the MongoDB software.
+
+In the event that we accidentally failed to list a required notice,
+please bring it to our attention through our JIRA system at:
+
+    https://jira.mongodb.org
+
+The attached notices are provided for information only.
+
+
+


### PR DESCRIPTION
This adds the 3rd party notices to both the linux distributable tar and the windows msi.

It will in fact regenerate them every time, but I've also included a (static) one that we can update from time to time for compliance.