### PR TITLE
SQL-2615: Add null check for handle in panic_safe_exec_keep_diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2426,9 +2426,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Fix for the ASAN test failure. 

I also added an update to the `openssl` dependency since it was failing the `sbom` check.

@EthanHardyMongo The fix I mentioned to you for the sbom failure is here, I ran `cargo update -p openssl` to update it.