### PR TITLE
Add `retry_on_failure: true` to ODBC MacOS compile and unit test functions

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -728,6 +728,7 @@ functions:
   "compile macos release":
     - command: shell.exec
       type: test
+      retry_on_failure: true
       params:
         shell: bash
         working_dir: mongosql-odbc-driver
@@ -752,6 +753,7 @@ functions:
 
   "compile macos release with debug info":
     - command: shell.exec
+      retry_on_failure: true
       params:
         shell: bash
         working_dir: mongosql-odbc-driver
@@ -1610,6 +1612,7 @@ functions:
   "run macos unit tests":
     - command: shell.exec
       type: test
+      retry_on_failure: true
       params:
         shell: bash
         working_dir: mongosql-odbc-driver


### PR DESCRIPTION
This is cherry-picked from master. 