### PR TITLE
SQL-2660: additional logging for ODBC

### DIFF
--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -6,6 +6,23 @@ use constants::{
 use mongodb::error::{ErrorKind, WriteFailure};
 use thiserror::Error;
 
+#[derive(Debug, Clone)]
+pub struct Diagnostics {
+    pub query: String,
+    pub schema: String,
+    pub translation: String,
+}
+
+impl Diagnostics {
+    pub fn new(query: String, schema: String, translation: String) -> Self {
+        Self {
+            query,
+            schema,
+            translation,
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug, Clone)]

--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -13,7 +13,7 @@ pub struct QueryDiagnostics {
     pub translation: String,
 }
 
-impl Diagnostics {
+impl QueryDiagnostics {
     pub fn new(query: String, schema: String, translation: String) -> Self {
         Self {
             query,

--- a/core/src/err.rs
+++ b/core/src/err.rs
@@ -7,7 +7,7 @@ use mongodb::error::{ErrorKind, WriteFailure};
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
-pub struct Diagnostics {
+pub struct QueryDiagnostics {
     pub query: String,
     pub schema: String,
     pub translation: String,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use databases::MongoDatabases;
 mod table_types;
 pub use table_types::MongoTableTypes;
 mod err;
-pub use err::{Diagnostics, Error, Result};
+pub use err::{Error, QueryDiagnostics, Result};
 mod fields;
 pub use fields::MongoFields;
 pub mod col_metadata;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use databases::MongoDatabases;
 mod table_types;
 pub use table_types::MongoTableTypes;
 mod err;
-pub use err::{Error, Result};
+pub use err::{Diagnostics, Error, Result};
 mod fields;
 pub use fields::MongoFields;
 pub mod col_metadata;

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -2,7 +2,7 @@ use crate::{
     cluster_type::MongoClusterType,
     col_metadata::{MongoColMetadata, ResultSetSchema, SqlGetSchemaResponse},
     conn::MongoConnection,
-    err::{Diagnostics, Result},
+    err::{QueryDiagnostics, Result},
     mongosqltranslate::{
         libmongosqltranslate_run_command, CommandResponse, GetNamespaces, Namespace, Translate,
         TranslateCommandResponse,
@@ -212,7 +212,7 @@ impl MongoQuery {
         query: &str,
         type_mode: TypeMode,
         max_string_length: Option<u16>,
-    ) -> Result<(Self, Diagnostics)> {
+    ) -> Result<(Self, QueryDiagnostics)> {
         log::debug!("Preparing query with metadata - query: {query}");
         let working_db = current_db.as_ref().ok_or(Error::NoDatabase)?;
         let db = client.client.database(working_db);
@@ -298,7 +298,8 @@ impl MongoQuery {
             "Prepared query with metadata - pipeline: {pipeline:?}, json_schema: {json_schema:?}, result_set_schema: {result_set_schema:?}",
         );
 
-        let diagnostics = Diagnostics::new(query.to_string(), json_schema, format!("{pipeline:?}"));
+        let diagnostics =
+            QueryDiagnostics::new(query.to_string(), json_schema, format!("{pipeline:?}"));
 
         Ok((
             Self {

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -295,7 +295,7 @@ impl MongoQuery {
             result_set_schema.process_result_metadata(working_db, type_mode, max_string_length)?;
 
         log::debug!(
-            "Prepared query with metadata - pipeline: {pipeline:?}, json_schema: {json_schema:?}",
+            "Prepared query with metadata - pipeline: {pipeline:?}, json_schema: {json_schema:?}, result_set_schema: {result_set_schema:?}",
         );
 
         let diagnostics = Diagnostics::new(query.to_string(), json_schema, format!("{pipeline:?}"));

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -2,7 +2,7 @@ use crate::{
     cluster_type::MongoClusterType,
     col_metadata::{MongoColMetadata, ResultSetSchema, SqlGetSchemaResponse},
     conn::MongoConnection,
-    err::Result,
+    err::{Diagnostics, Result},
     mongosqltranslate::{
         libmongosqltranslate_run_command, CommandResponse, GetNamespaces, Namespace, Translate,
         TranslateCommandResponse,
@@ -59,7 +59,7 @@ impl MongoQuery {
         namespaces: BTreeSet<Namespace>,
         client: &MongoConnection,
         db: &Database,
-    ) -> Result<TranslateCommandResponse> {
+    ) -> Result<(TranslateCommandResponse, Document)> {
         let collection_names: Vec<String> = client.runtime.block_on(async {
             db.list_collection_names()
                 .await
@@ -192,13 +192,13 @@ impl MongoQuery {
         let command = Translate::new(
             sql_query.to_string(),
             current_db.to_string(),
-            schema_catalog_doc,
+            schema_catalog_doc.clone(),
         );
 
         let command_response = libmongosqltranslate_run_command(command)?;
 
         if let CommandResponse::Translate(response) = command_response {
-            Ok(response)
+            Ok((response, schema_catalog_doc))
         } else {
             unreachable!()
         }
@@ -212,10 +212,11 @@ impl MongoQuery {
         query: &str,
         type_mode: TypeMode,
         max_string_length: Option<u16>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, Diagnostics)> {
+        log::debug!("Preparing query with metadata - query: {query}");
         let working_db = current_db.as_ref().ok_or(Error::NoDatabase)?;
         let db = client.client.database(working_db);
-        let (pipeline, current_db, current_collection, result_set_schema) =
+        let (pipeline, current_db, current_collection, result_set_schema, json_schema) =
             match client.cluster_type {
                 MongoClusterType::AtlasDataFederation => {
                     // 1. Run the sqlGetResultSchema command to get the result set
@@ -245,6 +246,7 @@ impl MongoQuery {
                         working_db.to_string(),
                         None,
                         ResultSetSchema::from(get_result_schema_response),
+                        String::from("ADF schema..."),
                     )
                 }
                 MongoClusterType::Enterprise => {
@@ -252,7 +254,7 @@ impl MongoQuery {
                         Self::get_sql_query_namespaces(query, working_db)?;
 
                     // Translate sql
-                    let mongosql_translation = if namespaces.is_empty() {
+                    let (mongosql_translation, schema) = if namespaces.is_empty() {
                         Self::translate_sql(query, working_db, namespaces, client, &db)?
                     } else {
                         let query_db = &namespaces.first().unwrap().database.clone();
@@ -279,6 +281,8 @@ impl MongoQuery {
                         mongosql_translation.target_db,
                         mongosql_translation.target_collection,
                         mongosql_translation.result_set_schema,
+                        serde_json::to_string(&schema)
+                            .unwrap_or_else(|e| format!("Unable to serialize schema: {e}")),
                     )
                 }
                 MongoClusterType::Community | MongoClusterType::UnknownTarget => {
@@ -290,15 +294,24 @@ impl MongoQuery {
         let metadata =
             result_set_schema.process_result_metadata(working_db, type_mode, max_string_length)?;
 
-        Ok(Self {
-            resultset_cursor: None,
-            resultset_metadata: metadata,
-            current: None,
-            current_db: Some(current_db),
-            current_collection,
-            pipeline,
-            query_timeout,
-        })
+        log::debug!(
+            "Prepared query with metadata - pipeline: {pipeline:?}, json_schema: {json_schema:?}",
+        );
+
+        let diagnostics = Diagnostics::new(query.to_string(), json_schema, format!("{pipeline:?}"));
+
+        Ok((
+            Self {
+                resultset_cursor: None,
+                resultset_metadata: metadata,
+                current: None,
+                current_db: Some(current_db),
+                current_collection,
+                pipeline,
+                query_timeout,
+            },
+            diagnostics,
+        ))
     }
 }
 

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -3369,7 +3369,6 @@ mod unit_tests {
             errors: RwLock::new(vec![]),
             type_mode: RwLock::new(TypeMode::Simple),
             max_string_length: RwLock::new(Some(6)),
-            diagnostics: RwLock::new(None),
         })));
 
         // use simple type mode to test string columns for complex types

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -3369,6 +3369,7 @@ mod unit_tests {
             errors: RwLock::new(vec![]),
             type_mode: RwLock::new(TypeMode::Simple),
             max_string_length: RwLock::new(Some(6)),
+            diagnostics: RwLock::new(None),
         })));
 
         // use simple type mode to test string columns for complex types

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -26,9 +26,9 @@ use function_name::named;
 use log::{debug, error, info};
 use logger::Logger;
 use mongo_odbc_core::{
-    odbc_uri::ODBCUri, Diagnostics, Error, MongoColMetadata, MongoCollections, MongoConnection,
-    MongoDatabases, MongoFields, MongoForeignKeys, MongoPrimaryKeys, MongoQuery, MongoStatement,
-    MongoTableTypes, MongoTypesInfo, TypeMode,
+    odbc_uri::ODBCUri, Error, MongoColMetadata, MongoCollections, MongoConnection, MongoDatabases,
+    MongoFields, MongoForeignKeys, MongoPrimaryKeys, MongoQuery, MongoStatement, MongoTableTypes,
+    MongoTypesInfo, QueryDiagnostics, TypeMode,
 };
 use num_traits::FromPrimitive;
 use std::ptr::null_mut;
@@ -3361,7 +3361,7 @@ fn sql_prepare(
     statement_text: *const WideChar,
     text_length: Integer,
     connection: &Connection,
-) -> Result<(MongoQuery, Diagnostics)> {
+) -> Result<(MongoQuery, QueryDiagnostics)> {
     let mut query = unsafe {
         input_text_to_string_w(
             statement_text,

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -3369,7 +3369,7 @@ fn sql_prepare(
         )
     };
     query = query.strip_suffix(';').unwrap_or(&query).to_string();
-    if let Ok((mongo_statement, diagnostics)) = {
+    let mongo_statement_result = {
         let type_mode = *connection.type_mode.read().unwrap();
         let max_string_length = *connection.max_string_length.read().unwrap();
         let attributes = connection.attributes.read().unwrap();
@@ -3388,11 +3388,13 @@ fn sql_prepare(
         } else {
             Err(ODBCError::InvalidCursorState)
         }
-    } {
-        *connection.diagnostics.write().unwrap() = Some(diagnostics);
-        Ok(mongo_statement)
-    } else {
-        Err(ODBCError::InvalidCursorState)
+    };
+    match mongo_statement_result {
+        Ok((mongo_statement, diagnostics)) => {
+            *connection.diagnostics.write().unwrap() = Some(diagnostics);
+            Ok(mongo_statement)
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -6,7 +6,7 @@ use definitions::{
     CursorScrollable, CursorSensitivity, CursorType, HDbc, HDesc, HEnv, HStmt, Handle, Len, NoScan,
     Pointer, RetrieveData, SimulateCursor, SmallInt, SqlBool, ULen, USmallInt, UseBookmarks,
 };
-use mongo_odbc_core::{Diagnostics, TypeMode};
+use mongo_odbc_core::{QueryDiagnostics, TypeMode};
 use mongodb::bson::{Bson, Uuid};
 use std::{
     borrow::BorrowMut,
@@ -379,7 +379,7 @@ pub struct Statement {
     // pub cursor: RwLock<Option<Box<Peekable<Cursor>>>>,
     pub errors: RwLock<Vec<ODBCError>>,
     // query diagnostics for logging in errors
-    pub diagnostics: RwLock<Option<Diagnostics>>,
+    pub diagnostics: RwLock<Option<QueryDiagnostics>>,
     pub bound_cols: RwLock<Option<HashMap<USmallInt, BoundColInfo>>>,
 }
 

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -78,7 +78,7 @@ impl MongoHandle {
                 // otherwise this entire chain will cause unhappiness and chaos
                 if !s.connection.is_null() {
                     if let Some(diagnostics) = s.diagnostics.read().unwrap().as_ref() {
-                        log::error!("Diagnostics: {:?}", diagnostics);
+                        log::error!("Query diagnostics: {:?}", diagnostics);
                     }
                 }
                 s.errors.write().unwrap().push(error);

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -77,19 +77,23 @@ impl MongoHandle {
                 c.errors.write().unwrap().push(error);
             }
             MongoHandle::Statement(s) => {
-                unsafe {
-                    if let Some(ref diagnostics) = s
-                        .connection
-                        .as_ref()
-                        .unwrap()
-                        .as_connection()
-                        .unwrap()
-                        .diagnostics
-                        .read()
-                        .unwrap()
-                        .as_ref()
-                    {
-                        log::error!("Diagnostics: {:?}", diagnostics);
+                // SAFETY: we must ensure the connection is not null,
+                // otherwise this entire chain will cause unhappiness and chaos
+                if !s.connection.is_null() {
+                    unsafe {
+                        if let Some(ref diagnostics) = s
+                            .connection
+                            .as_ref()
+                            .unwrap()
+                            .as_connection()
+                            .unwrap()
+                            .diagnostics
+                            .read()
+                            .unwrap()
+                            .as_ref()
+                        {
+                            log::error!("Diagnostics: {:?}", diagnostics);
+                        }
                     }
                 }
                 s.errors.write().unwrap().push(error);


### PR DESCRIPTION
I ended up reworking this to put the diagnostic info on the connection, where it was more easily accessible in the odbc layer.

If the error occurs on a connection or statement, the diagnostics are read from the corresponding MongoConnection and logged at error level.

There is also a  debug level logging event in prepare. I ended up going with debug because trace is very noise, and we'd probably ask for debug logs first.