### PR TITLE
SQL-2846: Fix Windows signing for standard build

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2349,6 +2349,7 @@ buildvariants:
       - name: windows-test-integration-group
       - name: windows-test-result-set-group
       - name: sign
+        run_on: ubuntu2204-large
       - name: compile-eap
       - name: windows-windows-test-unit-group-eap
       - name: windows-test-integration-group-eap


### PR DESCRIPTION
Runs the windows signing task on the Ubuntu host instead of Windows. 

Working patch:
https://evergreen.mongodb.com/task/mongosql_odbc_driver_eap_windows_64_sign_patch_b6173da8984297d390eaea0eb790116767141bd8_683e726bfba74c000791fd6b_25_06_03_03_56_56