### PR TITLE
SQL-2846: fix windows signing for standard build

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2159,7 +2159,7 @@ tasks:
       #   variants: [ ubuntu2204 ]
 
   - name: sign
-    allowed_requesters: ["ad_hoc", "github_tag"]
+    allowed_requesters: ["ad_hoc", "github_tag", "patch"]
     depends_on:
       - name: compile
     commands:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2159,7 +2159,7 @@ tasks:
       #   variants: [ ubuntu2204 ]
 
   - name: sign
-    allowed_requesters: ["ad_hoc", "github_tag", "patch"]
+    allowed_requesters: ["ad_hoc", "github_tag", "github_merge_queue"]
     depends_on:
       - name: compile
     commands:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2159,7 +2159,7 @@ tasks:
       #   variants: [ ubuntu2204 ]
 
   - name: sign
-    allowed_requesters: ["ad_hoc", "github_tag", "github_merge_queue"]
+    allowed_requesters: ["github_tag", "github_merge_queue"]
     depends_on:
       - name: compile
     commands:

--- a/evergreen/eap.yml
+++ b/evergreen/eap.yml
@@ -295,7 +295,7 @@ tasks:
       #   variants: [ ubuntu2204 ]
 
   - name: sign-eap
-    allowed_requesters: ["ad_hoc", "github_tag", "github_merge_queue"]
+    allowed_requesters: ["github_tag", "github_merge_queue"]
     depends_on:
       - name: compile-eap
     commands:

--- a/evergreen/eap.yml
+++ b/evergreen/eap.yml
@@ -295,7 +295,7 @@ tasks:
       #   variants: [ ubuntu2204 ]
 
   - name: sign-eap
-    allowed_requesters: ["ad_hoc", "github_tag"]
+    allowed_requesters: ["ad_hoc", "github_tag", "github_merge_queue"]
     depends_on:
       - name: compile-eap
     commands:


### PR DESCRIPTION
The periodic builds succeed while the merge patches fail, because patch is not allowed to run the signing tasks