### PR TITLE
SQL-2848: Update common-test-infra references to use mongodb instead of 10gen

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -102,7 +102,7 @@ The first step on either macos or windows is to start a local mongod and Atlas D
 ./resources/run_adf.sh start
 ```
 
-To load the data,  use the [sql-engines-common-test-infra](https://github.com/10gen/sql-engines-common-test-infra)
+To load the data,  use the [sql-engines-common-test-infra](https://github.com/mongodb/sql-engines-common-test-infra)
 `data-loader` tool along with the data in the `resources/integration_test/testdata.tar.gz` archive. Decompress that
 data and use it with the `data-loader`. See `cargo run --bin data-loader -- --help` in that repo for more details.
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -5,12 +5,12 @@
 # when the task started failing
 stepback: true
 
-# Mark a failure as a system/bootstrap failure (purple box) rather then a task
+# Mark a failure as a system/bootstrap failure (purple box) rather than a task
 # failure by default.
 # Actual testing tasks are marked with `type: test`
 command_type: system
 
-# Protect ourself against rogue test case, or curl gone wild, that runs forever
+# Protect ourselves against rogue test case, or curl gone wild, that runs forever
 # 12 minutes is the longest we'll ever run
 exec_timeout_secs: 3600 # 12 minutes is the longest we'll ever run
 
@@ -23,7 +23,7 @@ timeout:
 
 modules:
   - name: sql-engines-common-test-infra
-    owner: 10gen
+    owner: mongodb
     repo: sql-engines-common-test-infra
     branch: main
     auto_update: true


### PR DESCRIPTION
This PR updates the references to `sql-engines-common-test-infra` to use the `mongodb` org instead of the `10gen` org since the repo has now been migrated.