### PR TITLE
SQL-2868: update RELEASE_VERSION

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -341,9 +341,9 @@ functions:
           ${prepare_shell}
           echo "Author = $AUTHOR"
           echo "Author email = $AUTHOR_EMAIL"
-          echo "Version = $RELEASE_VERSION"
-          SBOM_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}.sbom.json"
-          SARIF_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongo-odbc-$RELEASE_VERSION.sast.sarif"
+          echo "Version = $release_version"
+          SBOM_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongosql-odbc-${release_version}.sbom.json"
+          SARIF_URL="https://translators-connectors-releases.s3.amazonaws.com/mongosql-odbc-driver/mongo-odbc-$release_version.sast.sarif"
           echo "Sbom url = $SBOM_URL"
           echo "Sarif Url = $SARIF_URL"
 
@@ -351,7 +351,7 @@ functions:
           cp resources/ssdlc/mongo-odbc-driver_compliance_report_template.md $COMPLIANCE_REPORT_NAME
 
           # Update the version
-          sed -i.bu "s,%VERSION%,$RELEASE_VERSION,g" $COMPLIANCE_REPORT_NAME
+          sed -i.bu "s,%VERSION%,$release_version,g" $COMPLIANCE_REPORT_NAME
           # Update the SBOM link
           sed -i.bu "s,%SBOM_URL%,$SBOM_URL,g" $COMPLIANCE_REPORT_NAME
           # Update the SARIF link
@@ -383,11 +383,11 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/${COMPLIANCE_REPORT_NAME}
-        remote_file: mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
+        remote_file: mongosql-odbc-driver/mongosql-odbc-${release_version}-compliance-report.md
         content_type: text/markdown
         bucket: translators-connectors-releases
         permissions: public-read
-        display_name: mongosql-odbc-${RELEASE_VERSION}-compliance-report.md
+        display_name: mongosql-odbc-${release_version}-compliance-report.md
 
   "augment SBOM":
     - command: ec2.assume_role
@@ -451,11 +451,11 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/mongo-odbc-driver.augmented.sbom.json
-        remote_file: mongosql-odbc-driver/mongosql-odbc-${RELEASE_VERSION}.sbom.json
+        remote_file: mongosql-odbc-driver/mongosql-odbc-${release_version}.sbom.json
         bucket: translators-connectors-releases
         content_type: application/json
         permissions: public-read
-        display_name: mongosql-odbc-${RELEASE_VERSION}.sbom.json
+        display_name: mongosql-odbc-${release_version}.sbom.json
 
   "use latest mongosql version":
     - command: shell.exec
@@ -713,12 +713,12 @@ functions:
           cp target/release/*.dll installer/msi
           cp ./THIRD_PARTY_LICENSES.txt ./README.md ./mongo-odbc-driver.augmented.sbom.json installer/msi
           cd installer/msi
-          if [[ "$RELEASE_VERSION" == "snapshot" || "$RELEASE_VERSION" == "snapshot-eap" ]]; then
+          if [[ "$release_version" == "snapshot" || "$release_version" == "snapshot-eap" ]]; then
               MINOR_VERSION="0.1"
               VERSION_LABEL="0.1.0"
           else
-              MINOR_VERSION=$(echo "$RELEASE_VERSION" | cut -d '.' -f 1-2)
-              VERSION_LABEL="$RELEASE_VERSION"
+              MINOR_VERSION=$(echo "$release_version" | cut -d '.' -f 1-2)
+              VERSION_LABEL="$release_version"
           fi
 
           # unfortunately, using a variable to hold the path to powershell
@@ -753,10 +753,10 @@ functions:
           cp target/release/*.dylib installer/dmg
           cp target/release/macos_postinstall installer/dmg
           cd installer/dmg
-          if [ "$RELEASE_VERSION" == "snapshot" ]; then
+          if [ "$release_version" == "snapshot" ]; then
               MINOR_VERSION="0.1"
           else
-              MINOR_VERSION=$(echo "$RELEASE_VERSION" | sed 's|\([0-9]\+[.][0-9]\+\)[.][0-9]\+|\1|')
+              MINOR_VERSION=$(echo "$release_version" | sed 's|\([0-9]\+[.][0-9]\+\)[.][0-9]\+|\1|')
           fi
           ./build-dmg.sh "$MINOR_VERSION"
 
@@ -947,7 +947,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsql.dll
-        remote_file: eap/mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsql.dll
+        remote_file: eap/mongosql-odbc-driver/windows/${release_version}/release/atsql.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -963,7 +963,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsqls.dll
-        remote_file: eap/mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsqls.dll
+        remote_file: eap/mongosql-odbc-driver/windows/${release_version}/release/atsqls.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -979,7 +979,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsql.pdb
-        remote_file: eap/mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsql.pdb
+        remote_file: eap/mongosql-odbc-driver/windows/${release_version}/release/atsql.pdb
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -1015,7 +1015,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/target/release/${UBUNTU_FILENAME}.sig
-        remote_file: eap/mongosql-odbc-driver/ubuntu2204/${RELEASE_VERSION}/release/${UBUNTU_FILENAME}.sig
+        remote_file: eap/mongosql-odbc-driver/ubuntu2204/${release_version}/release/${UBUNTU_FILENAME}.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -1033,7 +1033,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/target/release/libatsql.so
-        remote_file: eap/mongosql-odbc-driver/ubuntu2204/${RELEASE_VERSION}/release/libatsql.so
+        remote_file: eap/mongosql-odbc-driver/ubuntu2204/${release_version}/release/libatsql.so
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -1807,7 +1807,7 @@ functions:
         key_id: ${papertrail_id}
         secret_key: ${papertrail_key}
         product: mongo-odbc-driver
-        version: ${RELEASE_VERSION}
+        version: ${release_version}
         filenames:
           - papertrail/*
 
@@ -1835,7 +1835,7 @@ functions:
              exit 0
           fi
           # Update the template to generate the feed for this release
-          sed -i 's@{RELEASE_VERSION}@'${RELEASE_VERSION}'@' mongo-odbc-downloads_template.json
+          sed -i 's@{release_version}@'${release_version}'@' mongo-odbc-downloads_template.json
           sed -i 's@{WINDOWS_INSTALLER_PATH}@'${WINDOWS_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
           sed -i 's@{UBUNTU2204_INSTALLER_PATH}@'${UBUNTU2204_INSTALLER_PATH}'@' mongo-odbc-downloads_template.json
           echo "--------- New release object ----------------"
@@ -1925,11 +1925,11 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/${STATIC_CODE_ANALYSIS_NAME}
-        remote_file: mongosql-odbc-driver/mongo-odbc-${RELEASE_VERSION}.sast.sarif
+        remote_file: mongosql-odbc-driver/mongo-odbc-${release_version}.sast.sarif
         content_type: application/json
         bucket: translators-connectors-releases
         permissions: public-read
-        display_name: mongo-odbc-${RELEASE_VERSION}.sast.sarif
+        display_name: mongo-odbc-${release_version}.sast.sarif
 
 tasks:
   - name: make-odbc-docs

--- a/evergreen/create-expansions.sh
+++ b/evergreen/create-expansions.sh
@@ -31,7 +31,7 @@ export PATH_PREFIX=""
 echo "snapshot-eap: ${snapshot-eap}"
 
 if [[ "${triggered_by_git_tag}" != "" ]]; then
-    export RELEASE_VERSION=$(echo ${triggered_by_git_tag} | sed s/v//)
+    export release_version=$(echo ${triggered_by_git_tag} | sed s/v//)
 
     # Check if this is a beta tag or snapshot-eap is set to true
     if [[ "${triggered_by_git_tag}" == *"beta"* || "${snapshot-eap}" == "true" ]]; then
@@ -43,27 +43,27 @@ else
     # If not a tag, we are in a snapshot build. We need to see if we're in beta mode or not
     # and set the release version to either snapshot or snapshot-eap
     if [[ "${snapshot-eap}" == "true" ]]; then
-        export RELEASE_VERSION="snapshot-eap"
+        export release_version="snapshot-eap"
         export FEATURE_FLAGS="eap"
         export PRODUCT_NAME="mongoodbc-eap"
         echo "Building EAP version"
     else
-        export RELEASE_VERSION="snapshot"
+        export release_version="snapshot"
     fi
 fi
 
-export MSI_FILENAME="$PRODUCT_NAME-$RELEASE_VERSION.msi"
-export UBUNTU_FILENAME="$PRODUCT_NAME-$RELEASE_VERSION.tar.gz"
+export MSI_FILENAME="$PRODUCT_NAME-$release_version.msi"
+export UBUNTU_FILENAME="$PRODUCT_NAME-$release_version.tar.gz"
 
 cat <<EOT >expansions.yml
-RELEASE_VERSION: "$RELEASE_VERSION"
+release_version: "$release_version"
 FEATURE_FLAGS: "$FEATURE_FLAGS"
 PATH_PREFIX: "$PATH_PREFIX"
 PRODUCT_NAME: "$PRODUCT_NAME"
 MSI_FILENAME: "$MSI_FILENAME"
 UBUNTU_FILENAME: "$UBUNTU_FILENAME"
-WINDOWS_INSTALLER_PATH: "mongosql-odbc-driver/windows/$RELEASE_VERSION/release/$MSI_FILENAME"
-UBUNTU2204_INSTALLER_PATH: "mongosql-odbc-driver/ubuntu2204/$RELEASE_VERSION/release/$UBUNTU_FILENAME"
+WINDOWS_INSTALLER_PATH: "mongosql-odbc-driver/windows/$release_version/release/$MSI_FILENAME"
+UBUNTU2204_INSTALLER_PATH: "mongosql-odbc-driver/ubuntu2204/$release_version/release/$UBUNTU_FILENAME"
 COMPLIANCE_REPORT_NAME: "$COMPLIANCE_REPORT_NAME"
 STATIC_CODE_ANALYSIS_NAME: "$STATIC_CODE_ANALYSIS_NAME"
 PROJECT_DIRECTORY: "$(pwd)"
@@ -77,7 +77,7 @@ MONGO_ORCHESTRATION_HOME: "$DRIVERS_TOOLS/.evergreen/orchestration"
 MONGODB_BINARIES: "$MONGODB_BINARIES"
 prepare_shell: |
   set -o errexit
-  export RELEASE_VERSION="$RELEASE_VERSION"
+  export release_version="$release_version"
   export FEATURE_FLAGS="$FEATURE_FLAGS"
   export PATH_PREFIX="$PATH_PREFIX"
   export PRODUCT_NAME="$PRODUCT_NAME"

--- a/evergreen/eap.yml
+++ b/evergreen/eap.yml
@@ -63,7 +63,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsql.dll
-        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsql.dll
+        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${release_version}/release/atsql.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -79,7 +79,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsqls.dll
-        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsqls.dll
+        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${release_version}/release/atsqls.dll
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -95,7 +95,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/release/atsql.pdb
-        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${RELEASE_VERSION}/release/atsql.pdb
+        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/windows/${release_version}/release/atsql.pdb
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -131,7 +131,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/target/release/${UBUNTU_FILENAME}.sig
-        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/ubuntu2204/${RELEASE_VERSION}/release/${UBUNTU_FILENAME}.sig
+        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/ubuntu2204/${release_version}/release/${UBUNTU_FILENAME}.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
@@ -149,7 +149,7 @@ functions:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
         local_file: mongosql-odbc-driver/target/release/libatsql.so
-        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/ubuntu2204/${RELEASE_VERSION}/release/libatsql.so
+        remote_file: ${PATH_PREFIX}mongosql-odbc-driver/ubuntu2204/${release_version}/release/libatsql.so
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream

--- a/resources/download-center/mongo-odbc-downloads_template.json
+++ b/resources/download-center/mongo-odbc-downloads_template.json
@@ -1,5 +1,5 @@
     {
-      "version": "{RELEASE_VERSION}",
+      "version": "{release_version}",
       "platform": [
         {
           "name": "Windows",


### PR DESCRIPTION
The sbom release [task](https://spruce.mongodb.com/task/mongosql_odbc_driver_eap_code_quality_security_sbom__v2.0.0_beta_4_libv1.0.0_beta_5_25_06_17_23_10_15/logs?execution=0) failed. The implication of the error message (generated [here](https://github.com/mongodb/sql-engines-common-test-infra/blob/db60f9fbdcf8e1a9154ac647b94cdb81ecf1c431/evergreen/scripts/set_and_check_packages_version.sh#L23)) is that the `$release_version` variable is empty, and that it was successfully picked up as triggered by git tag. So I think this is just a result of variable case sensitivity, but let me know if there is a better idea. 

I didn't see obvious implications for other variables in a brief scan. I believe this is coming up because it is the first time releasing ODBC since switching over to the shared test infra, which defines the `set and check packages version` task.