### PR TITLE
SQL-2803: check for correct branch when releasing from main

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1832,6 +1832,7 @@ functions:
           # Make sure to only allow releases from the trunk of the project. If the name changes,
           # this will need be updated.
           if [[ $(git branch --show-current) != 'main' ]]; then
+             echo "Updating the download center feed should only run on the main branch. Current branch: $(git branch --show-current). Exiting."
              exit 0
           fi
           # Update the template to generate the feed for this release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1831,7 +1831,7 @@ functions:
           ${prepare_shell}
           # Make sure to only allow releases from the trunk of the project. If the name changes,
           # this will need be updated.
-          if [[ $(git branch --show-current) != 'master' ]]; then
+          if [[ $(git branch --show-current) != 'main' ]]; then
              exit 0
           fi
           # Update the template to generate the feed for this release


### PR DESCRIPTION
The most recent attempted [release](https://spruce.mongodb.com/version/mongosql_odbc_driver_v1.4.5_68758d41eca6120007a2437b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) fails at uploading the download center feed. 

I compared the logs from this run with the last successful release, and noticed the old one printed out the updated .json file:
- [old log](https://evergreen.mongodb.com/task_log_raw/mongosql_odbc_driver_release_download_center_update__v1.4.4_25_04_29_00_44_38/0?type=T&text=true)
- [new log](https://evergreen.mongodb.com/task_log_raw/mongosql_odbc_driver_release_download_center_update__v1.4.5_25_07_14_23_05_37/1?type=T&text=true)

This is the first release of the primary odbc driver (ie not the eap driver) from `main` rather than master, so I was also keeping my eyes peeled for that as well. This task exiting successfully and nothing happening seems to confirm these two suspicions about what was going wrong. 