### PR TITLE
SQL-3077: Add support for SQL_DATA_SOURCE_NAME attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ dependencies = [
  "once_cell",
  "open",
  "openidconnect",
+ "rand 0.9.2",
  "regex",
  "reqwest",
  "rfc8252_http_server",

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -977,6 +977,22 @@ mod unit {
                 ODBCUri::new("Driver=foo;SERVER=bAr;LOGLEVEL=debug".to_string()).unwrap()
             );
         }
+
+        // Verifies that get_attribute returns the DSN value after parsing.
+        #[test]
+        fn dsn_keyword_is_accessible_via_get_attribute() {
+            use crate::odbc_uri::ODBCUri;
+            let dsn = "DSN_Test";
+            let odbc_uri = ODBCUri::process_uri(format!("DSN={dsn};UID=user")).unwrap();
+            assert_eq!(odbc_uri.get_attribute(&["dsn"]), Some(&dsn.to_string()));
+        }
+
+        #[test]
+        fn driver_keyword_yields_no_dsn() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = ODBCUri::new("DRIVER=Foo;UID=user".to_string()).unwrap();
+            assert_eq!(odbc_uri.get_attribute(&["dsn"]), None);
+        }
     }
 
     #[cfg(test)]

--- a/odbc/src/api/functions.rs
+++ b/odbc/src/api/functions.rs
@@ -1114,6 +1114,7 @@ fn sql_driver_connect(conn: &Connection, odbc_uri_string: &str) -> Result<MongoC
         .build()
         .unwrap();
     let client_options = runtime.block_on(async { odbc_uri.try_into_client_options().await })?;
+    let dsn = odbc_uri.get_attribute(&["dsn"]).cloned();
     odbc_uri
         .remove(&["driver", "dsn"])
         .ok_or(ODBCError::MissingDriverOrDSNProperty)?;
@@ -1137,6 +1138,7 @@ fn sql_driver_connect(conn: &Connection, odbc_uri_string: &str) -> Result<MongoC
     }
 
     let mut conn_attrs = conn.attributes.write().unwrap();
+    conn_attrs.dsn = dsn;
     let database = if conn_attrs.current_catalog.is_some() {
         conn_attrs.current_catalog.as_deref().map(|s| s.to_string())
     } else {
@@ -2905,7 +2907,18 @@ macro_rules! sql_get_info_helper {
                         string_length_ptr,
                     )
                 }
-                 InfoType::SQL_DATABASE_NAME => {
+                 InfoType::SQL_DATA_SOURCE_NAME => {
+                    let conn = must_be_valid!((*conn_handle).as_connection());
+                    let attributes = conn.attributes.read().unwrap();
+                    let dsn = attributes.dsn.as_deref().unwrap_or("");
+                    i16_len::set_output_wstring_as_bytes(
+                        dsn,
+                        info_value_ptr,
+                        buffer_length as usize,
+                        string_length_ptr,
+                    )
+                }
+                InfoType::SQL_DATABASE_NAME => {
                     let conn = must_be_valid!((*conn_handle).as_connection());
                     let attributes = conn.attributes.read().unwrap();
                     if let Some(catalog) = &attributes.current_catalog {

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -780,4 +780,50 @@ mod unit {
         expected_value = u16::MAX,
         actual_value_modifier = modify_u16_value,
     );
+
+    test_get_info!(
+        data_source_name_no_dsn,
+        info_type = InfoType::SQL_DATA_SOURCE_NAME as u16,
+        expected_sql_return = SqlReturn::SUCCESS,
+        buffer_length = size_of::<WideChar>() as i16,
+        expected_length = 0,
+        expected_value = "",
+        actual_value_modifier = modify_string_value,
+    );
+
+    #[test]
+    fn data_source_name_with_dsn() {
+        unsafe {
+            let dsn_value = "MY_DSN";
+            let mut conn =
+                Connection::with_state(std::ptr::null_mut(), ConnectionState::Connected);
+            conn.attributes.write().unwrap().dsn = Some(dsn_value.to_string());
+            let mongo_handle: *mut _ = &mut MongoHandle::Connection(conn);
+
+            let value_ptr: *mut std::ffi::c_void =
+                Box::into_raw(Box::new([0u8; 900])) as *mut _;
+            let out_length: *mut SmallInt = &mut 0;
+            let buffer_length: SmallInt =
+                (dsn_value.len() + 1) as i16 * size_of::<WideChar>() as i16;
+
+            assert_eq!(
+                SqlReturn::SUCCESS,
+                SQLGetInfoW(
+                    mongo_handle as *mut _,
+                    InfoType::SQL_DATA_SOURCE_NAME as u16,
+                    value_ptr as Pointer,
+                    buffer_length,
+                    out_length,
+                )
+            );
+
+            assert_eq!(
+                dsn_value.len() as i16 * size_of::<WideChar>() as i16,
+                *out_length
+            );
+            assert_eq!(dsn_value, modify_string_value(value_ptr, *out_length as usize));
+
+            let _ = Box::from_raw(value_ptr as *mut u8);
+        }
+    }
 }

--- a/odbc/src/api/get_info_tests.rs
+++ b/odbc/src/api/get_info_tests.rs
@@ -795,13 +795,11 @@ mod unit {
     fn data_source_name_with_dsn() {
         unsafe {
             let dsn_value = "MY_DSN";
-            let mut conn =
-                Connection::with_state(std::ptr::null_mut(), ConnectionState::Connected);
+            let conn = Connection::with_state(std::ptr::null_mut(), ConnectionState::Connected);
             conn.attributes.write().unwrap().dsn = Some(dsn_value.to_string());
             let mongo_handle: *mut _ = &mut MongoHandle::Connection(conn);
 
-            let value_ptr: *mut std::ffi::c_void =
-                Box::into_raw(Box::new([0u8; 900])) as *mut _;
+            let value_ptr: *mut std::ffi::c_void = Box::into_raw(Box::new([0u8; 900])) as *mut _;
             let out_length: *mut SmallInt = &mut 0;
             let buffer_length: SmallInt =
                 (dsn_value.len() + 1) as i16 * size_of::<WideChar>() as i16;
@@ -821,7 +819,10 @@ mod unit {
                 dsn_value.len() as i16 * size_of::<WideChar>() as i16,
                 *out_length
             );
-            assert_eq!(dsn_value, modify_string_value(value_ptr, *out_length as usize));
+            assert_eq!(
+                dsn_value,
+                modify_string_value(value_ptr, *out_length as usize)
+            );
 
             let _ = Box::from_raw(value_ptr as *mut u8);
         }

--- a/odbc/src/handles/definitions.rs
+++ b/odbc/src/handles/definitions.rs
@@ -323,6 +323,9 @@ pub struct ConnectionAttributes {
     // to wait for any operation on a connection to timeout (other than
     // initial login).
     pub connection_timeout: Option<u32>,
+    // SQL_DATA_SOURCE_NAME: the DSN used to connect, if any.
+    // Empty string if the connection was made with DRIVER= instead of DSN=.
+    pub dsn: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Adds SQL_DATA_SOURCE_NAME support to SQLGetInfo, returning the DSN name when connected via `DSN=` or an empty string when connected with `Driver=`.  

Stores the DSN value at connect time in ConnectionAttributes so it can be retrieved later.

Added unit test and tested manually with `pyodbc` on Windows to confirm it retrieves the data source name with `getinfo()`. 