### PR TITLE
[SQL-3209][SQL-3194][SQL-3210] Upgrade rand, actix http bump, rustls-webpki and mongosql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3952,7 +3952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3963,9 +3963,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5237,7 +5237,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "agg-ast"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#f29d45a80f0283ab5bd580af40c85ceb862aa408"
+source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "bson",
  "linked-hash-map",
@@ -838,7 +838,7 @@ dependencies = [
  "indexmap 2.13.0",
  "js-sys",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1563,26 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,7 +1931,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1973,7 +1953,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2672,7 +2652,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde-value",
  "serde_json",
@@ -2852,7 +2832,7 @@ dependencies = [
  "once_cell",
  "open",
  "openidconnect",
- "rand 0.9.2",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "rfc8252_http_server",
@@ -2940,7 +2920,7 @@ dependencies = [
  "mongodb-internal-macros",
  "pbkdf2",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
  "rustversion",
@@ -2978,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "mongosql"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#f29d45a80f0283ab5bd580af40c85ceb862aa408"
+source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "agg-ast",
  "base64 0.22.1",
@@ -2987,14 +2967,14 @@ dependencies = [
  "derive-new",
  "edit-distance",
  "enum-iterator",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
  "linked-hash-map",
  "mongosql-datastructures",
  "quickcheck",
- "rand 0.8.5",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -3010,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "mongosql-datastructures"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#f29d45a80f0283ab5bd580af40c85ceb862aa408"
+source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "linked-hash-map",
  "thiserror 2.0.18",
@@ -3080,7 +3060,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3142,7 +3122,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3198,7 +3178,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde-value",
@@ -3510,8 +3490,6 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
- "env_logger",
- "log",
  "rand 0.10.1",
 ]
 
@@ -3545,7 +3523,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3600,9 +3578,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3611,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4955,7 +4933,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 [[package]]
 name = "usererrordisplay-impl"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#f29d45a80f0283ab5bd580af40c85ceb862aa408"
+source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4999,7 +4977,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "visitgen"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#f29d45a80f0283ab5bd580af40c85ceb862aa408"
+source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "agg-ast"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#ebd5999826b2a694ec951d050006ff256501cc50"
 dependencies = [
  "bson",
  "linked-hash-map",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "mongosql"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#cb8bfd8a4d0fd3684b6bc4d84295938392b83082"
 dependencies = [
  "agg-ast",
  "base64 0.22.1",
@@ -2974,7 +2974,7 @@ dependencies = [
  "linked-hash-map",
  "mongosql-datastructures",
  "quickcheck",
- "rand 0.9.4",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "mongosql-datastructures"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#cb8bfd8a4d0fd3684b6bc4d84295938392b83082"
 dependencies = [
  "linked-hash-map",
  "thiserror 2.0.18",
@@ -4933,7 +4933,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 [[package]]
 name = "usererrordisplay-impl"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#cb8bfd8a4d0fd3684b6bc4d84295938392b83082"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4977,7 +4977,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "visitgen"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?rev=ebd5999826b2a694ec951d050006ff256501cc50#ebd5999826b2a694ec951d050006ff256501cc50"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#cb8bfd8a4d0fd3684b6bc4d84295938392b83082"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f860ee6746d0c5b682147b2f7f8ef036d4f92fe518251a3a35ffa3650eafdf0e"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -55,8 +55,8 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
- "sha1",
+ "rand 0.10.1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -793,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cstr"
 version = "0.0.0"
 dependencies = [
@@ -1170,7 +1194,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1243,7 +1267,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1326,10 +1350,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1360,7 +1395,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1413,7 +1448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1464,7 +1499,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1560,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1961,7 +1996,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2038,6 +2073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,7 +2137,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2722,7 +2766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2903,7 +2947,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "socket2 0.6.3",
  "stringprep",
@@ -2950,7 +2994,7 @@ dependencies = [
  "linked-hash-map",
  "mongosql-datastructures",
  "quickcheck",
- "rand 0.10.0",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -3094,7 +3138,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -3264,7 +3308,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3468,7 +3512,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3484,7 +3528,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3522,7 +3566,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3577,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3803,8 +3847,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3908,7 +3952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4200,7 +4244,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4211,7 +4266,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4245,7 +4300,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4290,7 +4345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5182,7 +5237,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-mongosql = { git = "https://github.com/mongodb/mongosql.git", branch = "main", package = "mongosql" }
-agg-ast = { git = "https://github.com/mongodb/mongosql.git", branch = "main", package = "agg-ast" }
+mongosql = { git = "https://github.com/mongodb/mongosql.git", rev = "ebd5999826b2a694ec951d050006ff256501cc50", package = "mongosql" }
+agg-ast = { git = "https://github.com/mongodb/mongosql.git", rev = "ebd5999826b2a694ec951d050006ff256501cc50", package = "agg-ast" }
 definitions = { path = "../definitions" }
 bson = { workspace = true }
 thiserror = { workspace = true }
@@ -44,7 +44,7 @@ reqwest = { version = "0", features = ["blocking", "rustls"] }
 rfc8252_http_server = { path = "../rfc8252_http_server" }
 once_cell = { workspace = true }
 serde_json = { workspace = true }
-rand = "0.9.2"
+rand = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0", features = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-mongosql = { git = "https://github.com/mongodb/mongosql.git", rev = "ebd5999826b2a694ec951d050006ff256501cc50", package = "mongosql" }
-agg-ast = { git = "https://github.com/mongodb/mongosql.git", rev = "ebd5999826b2a694ec951d050006ff256501cc50", package = "agg-ast" }
+mongosql = { git = "https://github.com/mongodb/mongosql.git", branch = "main", package = "mongosql" }
+agg-ast = { git = "https://github.com/mongodb/mongosql.git", branch = "main", package = "agg-ast" }
 definitions = { path = "../definitions" }
 bson = { workspace = true }
 thiserror = { workspace = true }

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -5,7 +5,7 @@ use constants::SQL_ALL_TABLE_TYPES;
 use fancy_regex::Regex as FancyRegex;
 use lazy_static::lazy_static;
 use mongodb::{bson::Document, error::ErrorKind, results::CollectionType, Database};
-use rand::RngExt;
+use rand::RngExt as _;
 use regex::{Regex, RegexSet, RegexSetBuilder};
 use std::collections::HashSet;
 

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -5,7 +5,7 @@ use constants::SQL_ALL_TABLE_TYPES;
 use fancy_regex::Regex as FancyRegex;
 use lazy_static::lazy_static;
 use mongodb::{bson::Document, error::ErrorKind, results::CollectionType, Database};
-use rand::Rng;
+use rand::RngExt;
 use regex::{Regex, RegexSet, RegexSetBuilder};
 use std::collections::HashSet;
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1751,7 +1751,7 @@ tasks:
       - name: compile
     commands:
       - func: "build odbc documentation"
-        run_on: ubuntu2004-large
+        run_on: ubuntu2204-large
       - func: "upload odbc docs"
 
   - name: sbom
@@ -2093,7 +2093,7 @@ task_groups:
 buildvariants:
   - name: static-analysis
     display_name: "* Static Analysis"
-    run_on: [ubuntu2004-test]
+    run_on: [ubuntu2204-small]
     modules:
       - sql-engines-common-test-infra
     tasks:
@@ -2154,7 +2154,7 @@ buildvariants:
 
   - name: release
     display_name: "Release"
-    run_on: [ubuntu2004-medium]
+    run_on: [ubuntu2204-medium]
     modules:
       - sql-engines-common-test-infra
     tasks:


### PR DESCRIPTION
 Bumps several dependencies:
    • actix-http 3.12.0 → 3.12.1
    • rustls-webpki 0.103.10 → 0.103.13
    • rand 0.8.5 → 0.8.6, 0.9.2 → 0.9.4, and the direct dep in core 0.9 → 0.10
    • mongosql updated to latest from main
    
    
 Also did a drive by change on the Evergreen script, replacing EOL Ubuntu 20.04 by 22.04 ones.