### PR TITLE
[SQL-3186][SQL-3198] Quality Of Life - ODBC Connection String Improvements

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -20,7 +20,7 @@ You may need to set the following environment variables in order to run and test
 
 For macos, we use [iodbc](https://www.iodbc.org/dataspace/doc/iodbc/wiki/iodbcWiki/WelcomeVisitors) as the driver manager. To set up iODBC, first download and install it using the following commands:
 ```
-export $INSTALLED_ODBC_PATH=$PWD/installed_odbc/install"
+export INSTALLED_ODBC_PATH="$PWD/installed_odbc/install"
 mkdir -p "$INSTALLED_ODBC_PATH"
 cd installed_odbc
 echo "downloading iODBC"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -20,7 +20,7 @@ You may need to set the following environment variables in order to run and test
 
 For macos, we use [iodbc](https://www.iodbc.org/dataspace/doc/iodbc/wiki/iodbcWiki/WelcomeVisitors) as the driver manager. To set up iODBC, first download and install it using the following commands:
 ```
-export INSTALLED_ODBC_PATH="$PWD/installed_odbc/install"
+export $INSTALLED_ODBC_PATH=$PWD/installed_odbc/install"
 mkdir -p "$INSTALLED_ODBC_PATH"
 cd installed_odbc
 echo "downloading iODBC"

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1039,10 +1039,7 @@ mod unit {
 
     #[cfg(test)]
     mod try_into_client_options {
-        use crate::odbc_uri::{DATABASE, PWD, UID, URI};
         use mongodb::options::ClientOptions;
-        use num_traits::One;
-        use openidconnect::http::Uri;
 
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -427,8 +427,8 @@ impl ODBCUri {
         // X509 and Kerberos (GSSAPI) do not require username and password as part of client options.
         // X509 does not specify username/pass in the URI because auth is done with a client cert
         // GSSAPI specifies username/pass in the uri, so it doesn't need to be specified in attributes.
-        if (auth_mechanism == &AuthMechanism::MongoDbX509
-            || auth_mechanism == &AuthMechanism::Gssapi)
+        if auth_mechanism == &AuthMechanism::MongoDbX509
+            || auth_mechanism == &AuthMechanism::Gssapi
         {
             return Ok(());
         }
@@ -619,15 +619,15 @@ impl ODBCUri {
                 self.remove(&[APPNAME]),
                 app_name,
             ]
-                .into_iter()
-                .flatten()
-                .fold(String::new(), |acc, x| {
-                    if acc.is_empty() {
-                        x
-                    } else {
-                        format!("{acc}|{x}")
-                    }
-                }),
+            .into_iter()
+            .flatten()
+            .fold(String::new(), |acc, x| {
+                if acc.is_empty() {
+                    x
+                } else {
+                    format!("{acc}|{x}")
+                }
+            }),
         )
     }
 }
@@ -1203,11 +1203,11 @@ mod unit {
             let opts = ODBCUri::new(
                 "USER=foo2;PWD=bar2;URI=mongodb://foo:bar@127.0.0.1:27017".to_string(),
             )
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .unwrap()
-                .client_options;
+            .unwrap()
+            .try_into_client_options()
+            .await
+            .unwrap()
+            .client_options;
             let cred = opts.credential.unwrap();
             assert_eq!(expected_cred.username, cred.username);
             assert_eq!(expected_cred.password, cred.password);
@@ -1329,11 +1329,11 @@ mod unit {
             let opts = ODBCUri::new(
                 "SERVER=127.0.0.2:27017;URI=mongodb://foo:bar@127.0.0.1:27017".to_string(),
             )
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .unwrap()
-                .client_options;
+            .unwrap()
+            .try_into_client_options()
+            .await
+            .unwrap()
+            .client_options;
             assert_eq!(expected_opts.hosts[0], opts.hosts[0]);
         }
 
@@ -1344,8 +1344,8 @@ mod unit {
             let expected_opts = ClientOptions::parse(
                 "mongodb://foo:bar@www.atlas.net:27017/?authSource=authDB&ssl=true",
             )
-                .await
-                .unwrap();
+            .await
+            .unwrap();
             let expected_cred = expected_opts.credential.unwrap();
             let opts = ODBCUri::new("UID=foo;PWD=bar;SERVER=www.atlas.net:27017;User=foo2;Password=bar2;uri=mongodb://localhost:29000/?authSource=authDB&ssl=true".to_string())
                 .unwrap()
@@ -1379,10 +1379,10 @@ mod unit {
                 "USER=foo;PWD=bar;SERVER=localhost:27017;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .unwrap();
+            .unwrap()
+            .try_into_client_options()
+            .await
+            .unwrap();
             assert_eq!(
                 format!("{}|powerbi-connector+1.0.0", *DEFAULT_APP_NAME),
                 uri_opts.client_options.app_name.unwrap()
@@ -1409,10 +1409,10 @@ mod unit {
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .unwrap();
+            .unwrap()
+            .try_into_client_options()
+            .await
+            .unwrap();
 
             assert_eq!(
                 format!("{}|powerbi-connector+1.0.0", *DEFAULT_APP_NAME),
@@ -1464,10 +1464,10 @@ mod unit {
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;".to_string(),
             )
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .unwrap();
+            .unwrap()
+            .try_into_client_options()
+            .await
+            .unwrap();
 
             assert_eq!(
                 DRIVER_SHORT_NAME,

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -414,6 +414,25 @@ impl ODBCUri {
     }
 
     fn check_client_opts_credentials(client_options: &ClientOptions) -> Result<()> {
+        // Kerberos (GSSAPI) Doesn't require user + pass as USER; PASS; if specified in the URI
+        // X509 should not require user or pass either
+        let auth_mechanism = client_options
+            .credential
+            .as_ref()
+            .unwrap()
+            .mechanism
+            .as_ref()
+            .unwrap();
+
+        // X509 and Kerberos (GSSAPI) do not require username and password as part of client options.
+        // X509 does not specify username/pass in the URI because auth is done with a client cert
+        // GSSAPI specifies username/pass in the uri, so it doesn't need to be specified in attributes.
+        if (auth_mechanism == &AuthMechanism::MongoDbX509
+            || auth_mechanism == &AuthMechanism::Gssapi)
+        {
+            return Ok(());
+        }
+
         if client_options
             .credential
             .as_ref()
@@ -600,15 +619,15 @@ impl ODBCUri {
                 self.remove(&[APPNAME]),
                 app_name,
             ]
-            .into_iter()
-            .flatten()
-            .fold(String::new(), |acc, x| {
-                if acc.is_empty() {
-                    x
-                } else {
-                    format!("{acc}|{x}")
-                }
-            }),
+                .into_iter()
+                .flatten()
+                .fold(String::new(), |acc, x| {
+                    if acc.is_empty() {
+                        x
+                    } else {
+                        format!("{acc}|{x}")
+                    }
+                }),
         )
     }
 }
@@ -628,6 +647,18 @@ mod unit {
             ));
             assert!(!ODBCUri::contains_username_and_or_password(
                 "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-1"
+            ));
+        }
+
+        #[test]
+        fn test_gssapi_username_password_detection() {
+            use crate::odbc_uri::ODBCUri;
+            // GSSAPI URIs can have an '@' in the username, so we should not treat that as a separator for username and password
+            // GSSAPI has this format when specifying username + pass in the uri:
+            // mongodb://{user@domain}:{password}@host:port/?authMechanism=GSSAPI&authSource=$external
+            // We need to introduce a regex to account for that, otherwise we'll have to continue to specify username and pass in URL + attributes, which is not ideal.
+            assert!(!ODBCUri::contains_username_and_or_password(
+                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external"
             ));
         }
     }
@@ -693,6 +724,15 @@ mod unit {
             let uri =
                 "mongodb://localhost:27017/abc?authSource=$external&authMechanism=MONGODB-AWS";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
+            assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
+        }
+
+        #[test]
+        fn test_gssapi_does_not_modify_uri() {
+            use crate::odbc_uri::ODBCUri;
+            let uri =
+                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external";
+            let mut odbc_uri = ODBCUri::new(format!("URI={uri}")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
         }
     }
@@ -1018,16 +1058,40 @@ mod unit {
         async fn missing_pwd_is_err() {
             use crate::odbc_uri::ODBCUri;
             assert_eq!(
-            "Invalid Uri: One of [\"password\", \"pwd\"] is required for a valid Mongo ODBC Uri",
-            format!(
-                "{}",
-                ODBCUri::new("USER=foo;SERVER=127.0.0.1:27017".to_string())
-                    .unwrap()
-                    .try_into_client_options().await
-                    .unwrap_err()
-            )
-        );
+                "Invalid Uri: One of [\"password\", \"pwd\"] is required for a valid Mongo ODBC Uri",
+                format!(
+                    "{}",
+                    ODBCUri::new("USER=foo;SERVER=127.0.0.1:27017".to_string())
+                        .unwrap()
+                        .try_into_client_options().await
+                        .unwrap_err()
+                )
+            );
         }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn gssapi_parses_password_from_uri() {
+            use crate::odbc_uri::ODBCUri;
+            // Arrange: Sample URL where authmechanism is GSSAPI, and specified in the url, but not in options
+            assert_eq!(
+                ClientOptions::parse("mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external")
+                    .await
+                    .unwrap()
+                    .credential
+                    .unwrap()
+                    .password,
+                ODBCUri::new("URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;".to_string())
+                    .unwrap()
+                    .try_into_client_options()
+                    .await
+                    .unwrap()
+                    .client_options
+                    .credential
+                    .unwrap()
+                    .password
+            );
+        }
+
         #[tokio::test(flavor = "current_thread")]
         async fn missing_user_is_err() {
             use crate::odbc_uri::ODBCUri;
@@ -1139,11 +1203,11 @@ mod unit {
             let opts = ODBCUri::new(
                 "USER=foo2;PWD=bar2;URI=mongodb://foo:bar@127.0.0.1:27017".to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap()
-            .client_options;
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap()
+                .client_options;
             let cred = opts.credential.unwrap();
             assert_eq!(expected_cred.username, cred.username);
             assert_eq!(expected_cred.password, cred.password);
@@ -1251,8 +1315,8 @@ mod unit {
                 (Some("jfhbgvhj".to_string()), "URI=mongodb://localhost/?ssl=true&appName='myauthSource=aut:hD@B'&authSource=jfhbgvhj;UID=f;PWD=b" ),
             ] {
                 let actual = ODBCUri::new(uri.to_string()).unwrap().try_into_client_options().await.unwrap().client_options.credential.unwrap().source;
-            assert_eq!(
-                expected, actual, "expected {expected:?}, got {actual:?}" );
+                assert_eq!(
+                    expected, actual, "expected {expected:?}, got {actual:?}" );
             }
         }
 
@@ -1265,11 +1329,11 @@ mod unit {
             let opts = ODBCUri::new(
                 "SERVER=127.0.0.2:27017;URI=mongodb://foo:bar@127.0.0.1:27017".to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap()
-            .client_options;
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap()
+                .client_options;
             assert_eq!(expected_opts.hosts[0], opts.hosts[0]);
         }
 
@@ -1280,8 +1344,8 @@ mod unit {
             let expected_opts = ClientOptions::parse(
                 "mongodb://foo:bar@www.atlas.net:27017/?authSource=authDB&ssl=true",
             )
-            .await
-            .unwrap();
+                .await
+                .unwrap();
             let expected_cred = expected_opts.credential.unwrap();
             let opts = ODBCUri::new("UID=foo;PWD=bar;SERVER=www.atlas.net:27017;User=foo2;Password=bar2;uri=mongodb://localhost:29000/?authSource=authDB&ssl=true".to_string())
                 .unwrap()
@@ -1315,10 +1379,10 @@ mod unit {
                 "USER=foo;PWD=bar;SERVER=localhost:27017;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap();
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap();
             assert_eq!(
                 format!("{}|powerbi-connector+1.0.0", *DEFAULT_APP_NAME),
                 uri_opts.client_options.app_name.unwrap()
@@ -1345,10 +1409,10 @@ mod unit {
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap();
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap();
 
             assert_eq!(
                 format!("{}|powerbi-connector+1.0.0", *DEFAULT_APP_NAME),
@@ -1363,10 +1427,10 @@ mod unit {
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap();
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap();
 
             assert_eq!(
                 format!("{}|powerbi-connector+1.0.0|foo", *DEFAULT_APP_NAME),
@@ -1382,10 +1446,10 @@ mod unit {
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;APPNAME=powerbi-connector+1.0.0"
                     .to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap();
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap();
 
             assert_eq!(
                 format!("{DRIVER_SHORT_NAME}|powerbi-connector",),
@@ -1400,10 +1464,10 @@ mod unit {
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;".to_string(),
             )
-            .unwrap()
-            .try_into_client_options()
-            .await
-            .unwrap();
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .unwrap();
 
             assert_eq!(
                 DRIVER_SHORT_NAME,

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -432,18 +432,18 @@ impl ODBCUri {
             return Ok(());
         }
 
-        let is_oidc_and_azure_environment = auth_mechanism == &AuthMechanism::MongoDbOidc
-            && client_credentials
-                .mechanism_properties
-                .as_ref()
-                .and_then(|props| props.get("ENVIRONMENT"))
-                .is_some_and(|v| v == &Bson::String("azure".to_string()));
-
         if client_credentials.username.is_none() {
             // OIDC only requires username when Azure is the environment.
+            let is_oidc_and_azure_environment = auth_mechanism == &AuthMechanism::MongoDbOidc
+                && client_credentials
+                    .mechanism_properties
+                    .as_ref()
+                    .and_then(|props| props.get("ENVIRONMENT"))
+                    .is_some_and(|v| v == &Bson::String("azure".to_string()));
+
             if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(
-                    "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri"
+                    "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri when using an Azure managed identity. Set this to the client ID of the managed identity or the application ID of the service principal."
                 )));
             }
         }
@@ -451,7 +451,7 @@ impl ODBCUri {
             // OIDC doesn't require password either.
             if auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(
-                    "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri"
+                    "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri when the authication mechanism is {:?}", auth_mechanism
                 )));
             }
         }

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -631,11 +631,12 @@ impl ODBCUri {
 }
 
 mod unit {
-
+    #[cfg(test)]
     mod test_username_password_detection {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn test_username_password_detection() {
-            use crate::odbc_uri::ODBCUri;
             assert!(ODBCUri::contains_username_and_or_password(
                 "foo:bar@localhost"
             ));
@@ -649,10 +650,12 @@ mod unit {
         }
     }
 
+    #[cfg(test)]
     mod test_uri_construction {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn test_no_auth_mechanism_specified_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://localhost:27017";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -660,7 +663,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha1_specified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-1";
             let expected = "mongodb://dummy_username:dummy_password@localhost:27017/abc?authMechanism=SCRAM-SHA-1";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
@@ -669,7 +671,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha1_specified_with_username_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:@localhost:27017/abc?authMechanism=SCRAM-SHA-1";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -677,7 +678,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha1_specified_with_username_and_password_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:bar@localhost:27017/abc?authMechanism=SCRAM-SHA-1";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -685,7 +685,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha_256_specified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-256";
             let expected = "mongodb://dummy_username:dummy_password@localhost:27017/abc?authMechanism=SCRAM-SHA-256";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar;")).unwrap();
@@ -694,7 +693,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha_256_specified_with_username_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:@localhost:27017/abc?authMechanism=SCRAM-SHA-256";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -702,7 +700,6 @@ mod unit {
 
         #[test]
         fn test_scram_sha_256_specified_with_username_and_password_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:bar@localhost:27017/abc?authMechanism=SCRAM-SHA-256";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -710,7 +707,6 @@ mod unit {
 
         #[test]
         fn test_plain_specified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://localhost:27017/abc?authSource=$external&authMechanism=PLAIN";
             let expected =
                 "mongodb://dummy_username:dummy_password@localhost:27017/abc?authSource=$external&authMechanism=PLAIN";
@@ -720,7 +716,6 @@ mod unit {
 
         #[test]
         fn test_plain_specified_with_username_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:@localhost:27017/abc?authMechanism=PLAIN";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -728,7 +723,6 @@ mod unit {
 
         #[test]
         fn test_plain_specified_with_username_and_password_in_uri_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://foo:bar@localhost:27017/abc?authMechanism=PLAIN";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
@@ -736,7 +730,6 @@ mod unit {
 
         #[test]
         fn test_mechanism_not_recognized_is_unmodified() {
-            use crate::odbc_uri::ODBCUri;
             let uri = "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-512";
             let expected = "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-512";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
@@ -745,7 +738,6 @@ mod unit {
 
         #[test]
         fn test_x509_does_not_modify_uri() {
-            use crate::odbc_uri::ODBCUri;
             let uri =
                 "mongodb://localhost:27017/abc?authSource=$external&authMechanism=MONGODB-X509";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
@@ -754,7 +746,6 @@ mod unit {
 
         #[test]
         fn test_aws_does_not_modify_uri() {
-            use crate::odbc_uri::ODBCUri;
             let uri =
                 "mongodb://localhost:27017/abc?authSource=$external&authMechanism=MONGODB-AWS";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
@@ -763,7 +754,6 @@ mod unit {
 
         #[test]
         fn test_gssapi_does_not_modify_uri() {
-            use crate::odbc_uri::ODBCUri;
             let uri =
                 "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri}")).unwrap();
@@ -771,10 +761,12 @@ mod unit {
         }
     }
 
+    #[cfg(test)]
     mod get_next_attribute {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn get_unbraced() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("driver".to_string(), "foo".to_string(), None),
                 ODBCUri::get_next_attribute("DRIVER=foo".to_string())
@@ -785,7 +777,6 @@ mod unit {
 
         #[test]
         fn get_braced() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("driver".to_string(), "fo[]=o".to_string(), None),
                 ODBCUri::get_next_attribute("DRIVER={fo[]=o}".to_string())
@@ -796,7 +787,6 @@ mod unit {
 
         #[test]
         fn get_unbraced_with_rest() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 (
                     "driver".to_string(),
@@ -811,7 +801,6 @@ mod unit {
 
         #[test]
         fn get_braced_with_rest() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 (
                     "driver".to_string(),
@@ -826,7 +815,6 @@ mod unit {
 
         #[test]
         fn get_with_non_keyword_in_keyword_position_is_error() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Invalid Uri: 'stuff' is not a valid URI keyword",
                 format!(
@@ -837,10 +825,12 @@ mod unit {
         }
     }
 
+    #[cfg(test)]
     mod handle_braced_value {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn no_closing_brace_is_error() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Invalid Uri: attribute value beginning with '{' must end with '}'",
                 format!(
@@ -852,7 +842,6 @@ mod unit {
 
         #[test]
         fn ends_with_brace() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), None),
                 ODBCUri::handle_braced_value("stuff}").unwrap()
@@ -861,7 +850,6 @@ mod unit {
 
         #[test]
         fn ends_with_semi() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), None),
                 ODBCUri::handle_braced_value("stuff};").unwrap()
@@ -870,7 +858,6 @@ mod unit {
 
         #[test]
         fn has_rest() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), Some("DRIVER=foo".to_string())),
                 ODBCUri::handle_braced_value("stuff};DRIVER=foo").unwrap()
@@ -879,7 +866,6 @@ mod unit {
 
         #[test]
         fn ends_with_brace_special_chars() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stu%=[]}ff".to_string(), None),
                 ODBCUri::handle_braced_value("stu%=[]}ff}").unwrap()
@@ -888,7 +874,6 @@ mod unit {
 
         #[test]
         fn ends_with_semi_special_chars() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stu%=[]}ff".to_string(), None),
                 ODBCUri::handle_braced_value("stu%=[]}ff};").unwrap()
@@ -897,7 +882,6 @@ mod unit {
 
         #[test]
         fn has_rest_special_chars() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stu%=[]}ff".to_string(), Some("DRIVER=foo".to_string())),
                 ODBCUri::handle_braced_value("stu%=[]}ff};DRIVER=foo").unwrap()
@@ -905,10 +889,12 @@ mod unit {
         }
     }
 
+    #[cfg(test)]
     mod handle_unbraced_value {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn ends_with_empty() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), None),
                 ODBCUri::handle_unbraced_value("stuff").unwrap()
@@ -917,7 +903,6 @@ mod unit {
 
         #[test]
         fn ends_with_semi() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), None),
                 ODBCUri::handle_unbraced_value("stuff;").unwrap()
@@ -926,7 +911,6 @@ mod unit {
 
         #[test]
         fn has_rest() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ("stuff".to_string(), Some("DRIVER=foo".to_string())),
                 ODBCUri::handle_unbraced_value("stuff;DRIVER=foo").unwrap()
@@ -934,29 +918,28 @@ mod unit {
         }
     }
 
+    #[cfg(test)]
     mod new {
+        use crate::odbc_uri::ODBCUri;
+
         #[test]
         fn empty_uri_is_err() {
-            use crate::odbc_uri::ODBCUri;
-            assert!(ODBCUri::new("".to_string()).is_err());
+            assert!(ODBCUri::new(String::new()).is_err());
         }
 
         #[test]
         fn string_foo_is_err() {
-            use crate::odbc_uri::ODBCUri;
             assert!(ODBCUri::new("Foo".to_string()).is_err());
         }
 
         #[test]
         fn missing_equals_is_err() {
-            use crate::odbc_uri::ODBCUri;
             assert!(ODBCUri::new("driver=Foo;Bar".to_string()).is_err());
         }
 
         #[test]
         fn one_attribute_works() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(map! {"driver".to_string() => "Foo".to_string()});
             assert_eq!(expected, ODBCUri::new("Driver=Foo".to_string()).unwrap());
         }
@@ -964,7 +947,6 @@ mod unit {
         #[test]
         fn two_attributes_works() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "server".to_string() => "bAr".to_string()},
             );
@@ -977,7 +959,6 @@ mod unit {
         #[test]
         fn standard_types_test() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "simple_types_only".to_string() => "0".to_string()},
             );
@@ -990,7 +971,6 @@ mod unit {
         #[test]
         fn enable_max_string_length_test() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "enable_max_string_length".to_string() => "1".to_string()},
             );
@@ -1003,7 +983,6 @@ mod unit {
         #[test]
         fn repeated_attribute_selects_first() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "server".to_string() => "bAr".to_string()},
             );
@@ -1016,7 +995,6 @@ mod unit {
         #[test]
         fn two_attributes_with_trailing_semi_works() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "server".to_string() => "bAr".to_string()},
             );
@@ -1029,7 +1007,6 @@ mod unit {
         #[test]
         fn two_attributes_with_triple_trailing_semis_works() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "Foo".to_string(), "server".to_string() => "bAr".to_string()},
             );
@@ -1042,7 +1019,6 @@ mod unit {
         #[test]
         fn log_level() {
             use crate::map;
-            use crate::odbc_uri::ODBCUri;
             let expected = ODBCUri(
                 map! {"driver".to_string() => "foo".to_string(), "server".to_string() => "bAr".to_string(), "loglevel".to_string() => "debug".to_string()},
             );
@@ -1055,7 +1031,6 @@ mod unit {
         // Verifies that get_attribute returns the DSN value after parsing.
         #[test]
         fn dsn_keyword_is_accessible_via_get_attribute() {
-            use crate::odbc_uri::ODBCUri;
             let dsn = "DSN_Test";
             let odbc_uri = ODBCUri::process_uri(format!("DSN={dsn};UID=user")).unwrap();
             assert_eq!(odbc_uri.get_attribute(&["dsn"]), Some(&dsn.to_string()));
@@ -1063,7 +1038,6 @@ mod unit {
 
         #[test]
         fn driver_keyword_yields_no_dsn() {
-            use crate::odbc_uri::ODBCUri;
             let odbc_uri = ODBCUri::new("DRIVER=Foo;UID=user".to_string()).unwrap();
             assert_eq!(odbc_uri.get_attribute(&["dsn"]), None);
         }
@@ -1071,14 +1045,39 @@ mod unit {
 
     #[cfg(test)]
     mod try_into_client_options {
+        use crate::odbc_uri::ODBCUri;
         use mongodb::options::ClientOptions;
+
+        macro_rules! validate_odbc_uri_parsing {
+            ($uri:expr, ok) => {
+                assert!(
+                    ODBCUri::new($uri.to_string())
+                        .unwrap()
+                        .try_into_client_options()
+                        .await
+                        .is_ok(),
+                    "Expected URI to parse successfully: {}",
+                    $uri
+                );
+            };
+            ($uri:expr, err) => {
+                assert!(
+                    ODBCUri::new($uri.to_string())
+                        .unwrap()
+                        .try_into_client_options()
+                        .await
+                        .is_err(),
+                    "Expected URI parsing to fail: {}",
+                    $uri
+                );
+            };
+        }
 
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {
-            use crate::odbc_uri::ODBCUri;
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;DATABASE=mydb;LOGLEVEL=DEBUG;";
             assert_eq!(
-                "Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri",
+                "Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri when using an Azure managed identity. Set this to the client ID of the managed identity or the application ID of the service principal.",
                 format!(
                     "{}",
                     ODBCUri::new(odbc_uri.to_string())
@@ -1091,103 +1090,84 @@ mod unit {
         }
         #[tokio::test(flavor = "current_thread")]
         async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
-  Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509&tls=true&tlsCertificateKeyFile=/path/to/client.pem;DATABASE=mydb;LOGLEVEL=DEBUG;";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509\
+                 &tls=true&tlsCertificateKeyFile=/path/to/client.pem;\
+                 DATABASE=mydb;LOGLEVEL=DEBUG;",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn gssapi_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
-  Driver};URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;DATABASE=mydb;LOGLEVEL=DEBUG;";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/\
+                 ?authMechanism=GSSAPI&authSource=$external;\
+                 DATABASE=mydb;LOGLEVEL=DEBUG;",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_without_mechanism_properties_does_not_require_username() {
             // OIDC without authMechanismProperties means no ENVIRONMENT key exists,
             // so no username should be required.
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-                URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
-                DATABASE=mydb;";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
+                 DATABASE=mydb;",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_non_azure_environment_does_not_require_username() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-                URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
-                &authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:my_audience&tls=true;\
-                DATABASE=mydb;";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
+                 &authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:my_audience&tls=true;\
+                 DATABASE=mydb;",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_succeeds() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-         URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
-         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-         DATABASE=mydb;UID=myUser";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
+                 &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+                 DATABASE=mydb;UID=myUser",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_in_uri_succeeds() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-         URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
-         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-         DATABASE=mydb;";
-            let parsed_odbc_uri = ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await;
-
-            assert!(parsed_odbc_uri.is_ok());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
+                 &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+                 DATABASE=mydb;",
+                ok
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_without_username_fails() {
-            use crate::odbc_uri::ODBCUri;
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-         URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
-         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-         DATABASE=mydb;";
-            assert!(ODBCUri::new(odbc_uri.to_string())
-                .unwrap()
-                .try_into_client_options()
-                .await
-                .is_err());
+            validate_odbc_uri_parsing!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
+                 &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+                 DATABASE=mydb;",
+                err
+            );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn missing_server_is_err() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Invalid Uri: server is required for a valid Mongo ODBC Uri",
                 format!(
@@ -1202,7 +1182,6 @@ mod unit {
         }
         #[tokio::test(flavor = "current_thread")]
         async fn missing_pwd_is_err() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Invalid Uri: One of [\"password\", \"pwd\"] is required for a valid Mongo ODBC Uri",
                 format!(
@@ -1217,7 +1196,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn missing_user_is_err() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri",
                 format!(
@@ -1233,7 +1211,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn use_pwd_server_works() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                     .await
@@ -1255,7 +1232,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uid_instead_of_user_works() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                     .await
@@ -1277,7 +1253,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn password_instead_of_pwd_works() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                     .await
@@ -1299,7 +1274,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uri_with_embedded_user_and_password_works() {
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                 .await
                 .unwrap();
@@ -1318,7 +1292,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uri_seperate_user_and_password_replace_embedded() {
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse("mongodb://foo2:bar2@127.0.0.1:27017")
                 .await
                 .unwrap();
@@ -1339,7 +1312,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uri_with_separate_user_and_password_works() {
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                 .await
                 .unwrap();
@@ -1358,7 +1330,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uri_with_separate_password_works() {
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse("mongodb://foo:bar@127.0.0.1:27017")
                 .await
                 .unwrap();
@@ -1377,7 +1348,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn credless_uri_without_user_and_password_is_error() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
                 "Err(InvalidUriFormat(\"One of [\\\"uid\\\", \\\"user\\\"] is required for a valid Mongo ODBC Uri\"))".to_string(),
                 format!(
@@ -1392,9 +1362,8 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn credless_uri_with_user_and_no_password_is_error() {
-            use crate::odbc_uri::ODBCUri;
             assert_eq!(
-                "Err(InvalidUriFormat(\"One of [\\\"password\\\", \\\"pwd\\\"] is required for a valid Mongo ODBC Uri\"))".to_string(),
+                "Err(InvalidUriFormat(\"One of [\\\"password\\\", \\\"pwd\\\"] is required for a valid Mongo ODBC Uri when the authication mechanism is ScramSha256\"))".to_string(),
                 format!(
                     "{:?}",
                     ODBCUri::new("URI=mongodb://foo@127.0.0.1:27017".to_string())
@@ -1407,7 +1376,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn ldap_correctness() {
-            use crate::odbc_uri::ODBCUri;
             let odbc_str = "URI=mongodb://localhost/abc?authSource=$external&authMechanism=PLAIN;UID=foo;PWD=bar";
             let actual = ODBCUri::new(odbc_str.to_string())
                 .unwrap()
@@ -1427,7 +1395,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn auth_source_correctness() {
-            use crate::odbc_uri::ODBCUri;
             for (expected, uri) in [
                 (Some("authDB".to_string()), "URI=mongodb://localhost/?authSource=authDB;UID=foo;PWD=bar"),
                 (None, "URI=mongodb://localhost/;UID=foo;PWD=bar"),
@@ -1445,7 +1412,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn uri_seperate_server_replaces_embedded() {
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse("mongodb://foo2:bar2@127.0.0.2:27017")
                 .await
                 .unwrap();
@@ -1463,7 +1429,6 @@ mod unit {
         #[tokio::test(flavor = "current_thread")]
         async fn supplied_args_override_dsn_args() {
             // we leave dsn out of the uri so that it doesn't try to query the registry in the test
-            use crate::odbc_uri::ODBCUri;
             let expected_opts = ClientOptions::parse(
                 "mongodb://foo:bar@www.atlas.net:27017/?authSource=authDB&ssl=true",
             )
@@ -1483,7 +1448,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn no_app_name_in_odbc_uri_or_mongodb_uri_still_shows_odbc_driver_version() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
             let uri_opts =
                 ODBCUri::new("USER=foo;PWD=bar;URI=mongodb://localhost:27017/".to_string())
@@ -1496,7 +1460,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn app_name_in_odbc_uri_and_no_mongodb_uri() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;SERVER=localhost:27017;APPNAME=powerbi-connector+1.0.0"
@@ -1514,7 +1477,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn no_app_name_in_odbc_uri_and_no_mongodb_uri() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
             let uri_opts = ODBCUri::new("USER=foo;PWD=bar;SERVER=localhost:27017;".to_string())
                 .unwrap()
@@ -1526,7 +1488,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn app_name_in_odbc_uri_shows_with_odbc_driver_version_added() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/;APPNAME=powerbi-connector+1.0.0"
@@ -1544,7 +1505,6 @@ mod unit {
         }
         #[tokio::test(flavor = "current_thread")]
         async fn app_name_in_odbc_uri_and_mongodb_uri_chains_and_adds_odbc_driver_version() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DEFAULT_APP_NAME;
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;APPNAME=powerbi-connector+1.0.0"
@@ -1563,7 +1523,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn driver_info_with_powerbi_provided() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DRIVER_SHORT_NAME;
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;APPNAME=powerbi-connector+1.0.0"
@@ -1582,7 +1541,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn driver_info_with_no_powerbi_provided() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DRIVER_SHORT_NAME;
             let uri_opts = ODBCUri::new(
                 "USER=foo;PWD=bar;URI=mongodb://localhost:27017/?appName=foo;".to_string(),
@@ -1600,7 +1558,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn driver_info_with_no_mongodb_uri_and_no_odbc_uri_appname() {
-            use crate::odbc_uri::ODBCUri;
             use constants::DRIVER_SHORT_NAME;
             let uri_opts = ODBCUri::new("USER=foo;PWD=bar;SERVER=localhost:27017".to_string())
                 .unwrap()

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -414,6 +414,25 @@ impl ODBCUri {
     }
 
     fn check_client_opts_credentials(client_options: &ClientOptions) -> Result<()> {
+        // Kerberos (GSSAPI) Doesn't require user + pass as USER; PASS; if specified in the URI
+        // X509 should not require user or pass either
+        let auth_mechanism = client_options
+            .credential
+            .as_ref()
+            .unwrap()
+            .mechanism
+            .as_ref()
+            .unwrap();
+
+        // X509 and Kerberos (GSSAPI) do not require username and password as part of client options.
+        // X509 does not specify username/pass in the URI because auth is done with a client cert
+        // GSSAPI specifies username/pass in the uri, so it doesn't need to be specified in attributes.
+        if (auth_mechanism == &AuthMechanism::MongoDbX509
+            || auth_mechanism == &AuthMechanism::Gssapi)
+        {
+            return Ok(());
+        }
+
         if client_options
             .credential
             .as_ref()
@@ -630,6 +649,18 @@ mod unit {
                 "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-1"
             ));
         }
+
+        #[test]
+        fn test_gssapi_username_password_detection() {
+            use crate::odbc_uri::ODBCUri;
+            // GSSAPI URIs can have an '@' in the username, so we should not treat that as a separator for username and password
+            // GSSAPI has this format when specifying username + pass in the uri:
+            // mongodb://{user@domain}:{password}@host:port/?authMechanism=GSSAPI&authSource=$external
+            // We need to introduce a regex to account for that, otherwise we'll have to continue to specify username and pass in URL + attributes, which is not ideal.
+            assert!(!ODBCUri::contains_username_and_or_password(
+                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external"
+            ));
+        }
     }
 
     mod test_uri_construction {
@@ -693,6 +724,15 @@ mod unit {
             let uri =
                 "mongodb://localhost:27017/abc?authSource=$external&authMechanism=MONGODB-AWS";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
+            assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
+        }
+
+        #[test]
+        fn test_gssapi_does_not_modify_uri() {
+            use crate::odbc_uri::ODBCUri;
+            let uri =
+                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external";
+            let mut odbc_uri = ODBCUri::new(format!("URI={uri}")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
         }
     }
@@ -1028,6 +1068,30 @@ mod unit {
             )
         );
         }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn gssapi_parses_password_from_uri() {
+            use crate::odbc_uri::ODBCUri;
+            // Arrange: Sample URL where authmechanism is GSSAPI, and specified in the url, but not in options
+            assert_eq!(
+                ClientOptions::parse("mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external")
+                    .await
+                    .unwrap()
+                    .credential
+                    .unwrap()
+                    .password,
+                ODBCUri::new("URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;".to_string())
+                    .unwrap()
+                    .try_into_client_options()
+                    .await
+                    .unwrap()
+                    .client_options
+                    .credential
+                    .unwrap()
+                    .password
+            );
+        }
+
         #[tokio::test(flavor = "current_thread")]
         async fn missing_user_is_err() {
             use crate::odbc_uri::ODBCUri;

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1026,7 +1026,6 @@ mod unit {
     #[cfg(test)]
     mod try_into_client_options {
         use mongodb::options::ClientOptions;
-        use serde_json::to_string;
 
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -415,10 +415,11 @@ impl ODBCUri {
     }
 
     fn check_client_opts_credentials(client_options: &ClientOptions) -> Result<()> {
-        let auth_mechanism = client_options
+        let client_credentials = client_options
             .credential
             .as_ref()
-            .unwrap()
+            .expect("credential must be set before validation");
+        let auth_mechanism = client_credentials
             .mechanism
             .as_ref()
             .unwrap_or(&AuthMechanism::ScramSha256);
@@ -432,22 +433,13 @@ impl ODBCUri {
         }
 
         let is_oidc_and_azure_environment = auth_mechanism == &AuthMechanism::MongoDbOidc
-            && client_options
-                .credential
-                .as_ref()
-                .unwrap()
+            && client_credentials
                 .mechanism_properties
                 .as_ref()
                 .and_then(|props| props.get("ENVIRONMENT"))
                 .is_some_and(|v| v == &Bson::String("azure".to_string()));
 
-        if client_options
-            .credential
-            .as_ref()
-            .unwrap()
-            .username
-            .is_none()
-        {
+        if client_credentials.username.is_none() {
             // OIDC only requires username when Azure is the environment.
             if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(
@@ -455,13 +447,7 @@ impl ODBCUri {
                 )));
             }
         }
-        if client_options
-            .credential
-            .as_ref()
-            .unwrap()
-            .password
-            .is_none()
-        {
+        if client_credentials.password.is_none() {
             // OIDC doesn't require password either.
             if auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -462,7 +462,7 @@ impl ODBCUri {
             .password
             .is_none()
         {
-            // All OIDC skips the password check (OIDC post-processing clears the password anyway).
+            // OIDC doesn't require password either.
             if auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(
                     "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri"

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1048,29 +1048,11 @@ mod unit {
         use crate::odbc_uri::ODBCUri;
         use mongodb::options::ClientOptions;
 
-        macro_rules! validate_odbc_uri_parsing {
-            ($uri:expr, ok) => {
-                assert!(
-                    ODBCUri::new($uri.to_string())
-                        .unwrap()
-                        .try_into_client_options()
-                        .await
-                        .is_ok(),
-                    "Expected URI to parse successfully: {}",
-                    $uri
-                );
-            };
-            ($uri:expr, err) => {
-                assert!(
-                    ODBCUri::new($uri.to_string())
-                        .unwrap()
-                        .try_into_client_options()
-                        .await
-                        .is_err(),
-                    "Expected URI parsing to fail: {}",
-                    $uri
-                );
-            };
+        async fn parse_uri(uri: &str) -> crate::err::Result<crate::odbc_uri::UserOptions> {
+            ODBCUri::new(uri.to_string())
+                .expect("test URI should be parseable by ODBCUri::new")
+                .try_into_client_options()
+                .await
         }
 
         #[tokio::test(flavor = "current_thread")]
@@ -1090,23 +1072,27 @@ mod unit {
         }
         #[tokio::test(flavor = "current_thread")]
         async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509\
                  &tls=true&tlsCertificateKeyFile=/path/to/client.pem;\
-                 DATABASE=mydb;LOGLEVEL=DEBUG;",
-                ok
+                 DATABASE=mydb;LOGLEVEL=DEBUG;";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn gssapi_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/\
                  ?authMechanism=GSSAPI&authSource=$external;\
-                 DATABASE=mydb;LOGLEVEL=DEBUG;",
-                ok
+                 DATABASE=mydb;LOGLEVEL=DEBUG;";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
@@ -1114,55 +1100,64 @@ mod unit {
         async fn oidc_without_mechanism_properties_does_not_require_username() {
             // OIDC without authMechanismProperties means no ENVIRONMENT key exists,
             // so no username should be required.
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
-                 DATABASE=mydb;",
-                ok
+                 DATABASE=mydb;";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_non_azure_environment_does_not_require_username() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;",
-                ok
+                 DATABASE=mydb;";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_succeeds() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;UID=myUser",
-                ok
+                 DATABASE=mydb;UID=myUser";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_in_uri_succeeds() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;",
-                ok
+                 DATABASE=mydb;";
+            let result = parse_uri(uri).await;
+            assert!(
+                result.is_ok(),
+                "Expected URI to parse successfully, got: {result:?}"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_without_username_fails() {
-            validate_odbc_uri_parsing!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;",
-                err
+                 DATABASE=mydb;";
+            assert!(
+                parse_uri(uri).await.is_err(),
+                "Expected URI parsing to fail: {uri}"
             );
         }
 

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1026,6 +1026,7 @@ mod unit {
     #[cfg(test)]
     mod try_into_client_options {
         use mongodb::options::ClientOptions;
+        use serde_json::to_string;
 
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {
@@ -1108,6 +1109,21 @@ mod unit {
                 .try_into_client_options()
                 .await
                 .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn oidc_with_azure_environment_and_username_in_uri_succeeds() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+         URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
+         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+         DATABASE=mydb;";
+            let parsed_odbc_uri = ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await;
+
+            assert!(parsed_odbc_uri.is_ok());
         }
 
         #[tokio::test(flavor = "current_thread")]

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -756,7 +756,7 @@ mod unit {
         fn test_gssapi_does_not_modify_uri() {
             let uri =
                 "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external";
-            let mut odbc_uri = ODBCUri::new(format!("URI={uri}")).unwrap();
+            let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar;")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
         }
     }

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1,7 +1,6 @@
 use crate::err::{Error, Result};
 use bson::Bson;
 use constants::{DEFAULT_APP_NAME, DRIVER_SHORT_NAME};
-use itertools::Itertools;
 use lazy_static::lazy_static;
 use mongodb::{
     bson::UuidRepresentation,
@@ -15,7 +14,6 @@ use once_cell::sync::OnceCell;
 use regex::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
 use shared_sql_utils::Dsn;
 use std::collections::HashMap;
-use std::ptr::eq;
 use std::str::FromStr;
 
 const EMPTY_URI_ERROR: &str = "URI must not be empty";
@@ -649,7 +647,6 @@ impl ODBCUri {
 }
 
 mod unit {
-    use mongodb::options::ClientOptions;
 
     mod test_username_password_detection {
         #[test]

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -448,7 +448,7 @@ impl ODBCUri {
             .username
             .is_none()
         {
-            // OIDC only requires username when Azure is the environment. For now do a nested if, but we can refactor later.
+            // OIDC only requires username when Azure is the environment.
             if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
                 return Err(Error::InvalidUriFormat(format!(
                     "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri"

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1060,7 +1060,6 @@ mod unit {
         #[tokio::test(flavor = "current_thread")]
         async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
             use crate::odbc_uri::ODBCUri;
-            // TODO: Is there any way to run this test with a +srv url and ignore the DNS Resolution path?
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
   Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509&tls=true&tlsCertificateKeyFile=/path/to/client.pem;DATABASE=mydb;LOGLEVEL=DEBUG;";
             assert!(ODBCUri::new(odbc_uri.to_string())
@@ -1072,9 +1071,8 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_without_mechanism_properties_does_not_require_username() {
-            // Regression test for mechanism_properties.as_ref().unwrap() panic.
             // OIDC without authMechanismProperties means no ENVIRONMENT key exists,
-            // so no username should be required. Previously this panicked.
+            // so no username should be required.
             use crate::odbc_uri::ODBCUri;
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
@@ -1088,10 +1086,6 @@ mod unit {
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_non_azure_environment_does_not_require_username() {
-            // Regression test for ptr::eq value-comparison bug.
-            // OIDC with ENVIRONMENT=gcp (or any non-azure value) must not require a username.
-            // Previously, std::ptr::eq compared pointer addresses rather than values,
-            // making the azure check always false and incorrectly rejecting valid connections.
             use crate::odbc_uri::ODBCUri;
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
@@ -1102,6 +1096,34 @@ mod unit {
                 .try_into_client_options()
                 .await
                 .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn oidc_with_azure_environment_and_username_succeeds() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+         URI=mongodb://myuser@cluster.example.net/?authMechanism=MONGODB-OIDC\
+         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+         DATABASE=mydb;UID=myUser";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn oidc_with_azure_environment_and_without_username_fails() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+         URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
+         &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
+         DATABASE=mydb;";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_err());
         }
 
         #[tokio::test(flavor = "current_thread")]

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -414,25 +414,6 @@ impl ODBCUri {
     }
 
     fn check_client_opts_credentials(client_options: &ClientOptions) -> Result<()> {
-        // Kerberos (GSSAPI) Doesn't require user + pass as USER; PASS; if specified in the URI
-        // X509 should not require user or pass either
-        let auth_mechanism = client_options
-            .credential
-            .as_ref()
-            .unwrap()
-            .mechanism
-            .as_ref()
-            .unwrap();
-
-        // X509 and Kerberos (GSSAPI) do not require username and password as part of client options.
-        // X509 does not specify username/pass in the URI because auth is done with a client cert
-        // GSSAPI specifies username/pass in the uri, so it doesn't need to be specified in attributes.
-        if (auth_mechanism == &AuthMechanism::MongoDbX509
-            || auth_mechanism == &AuthMechanism::Gssapi)
-        {
-            return Ok(());
-        }
-
         if client_options
             .credential
             .as_ref()
@@ -649,18 +630,6 @@ mod unit {
                 "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-1"
             ));
         }
-
-        #[test]
-        fn test_gssapi_username_password_detection() {
-            use crate::odbc_uri::ODBCUri;
-            // GSSAPI URIs can have an '@' in the username, so we should not treat that as a separator for username and password
-            // GSSAPI has this format when specifying username + pass in the uri:
-            // mongodb://{user@domain}:{password}@host:port/?authMechanism=GSSAPI&authSource=$external
-            // We need to introduce a regex to account for that, otherwise we'll have to continue to specify username and pass in URL + attributes, which is not ideal.
-            assert!(!ODBCUri::contains_username_and_or_password(
-                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external"
-            ));
-        }
     }
 
     mod test_uri_construction {
@@ -724,15 +693,6 @@ mod unit {
             let uri =
                 "mongodb://localhost:27017/abc?authSource=$external&authMechanism=MONGODB-AWS";
             let mut odbc_uri = ODBCUri::new(format!("URI={uri};User=foo;PWD=bar")).unwrap();
-            assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
-        }
-
-        #[test]
-        fn test_gssapi_does_not_modify_uri() {
-            use crate::odbc_uri::ODBCUri;
-            let uri =
-                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external";
-            let mut odbc_uri = ODBCUri::new(format!("URI={uri}")).unwrap();
             assert_eq!(odbc_uri.construct_uri_for_parsing(uri).unwrap(), uri);
         }
     }
@@ -1068,30 +1028,6 @@ mod unit {
             )
         );
         }
-
-        #[tokio::test(flavor = "current_thread")]
-        async fn gssapi_parses_password_from_uri() {
-            use crate::odbc_uri::ODBCUri;
-            // Arrange: Sample URL where authmechanism is GSSAPI, and specified in the url, but not in options
-            assert_eq!(
-                ClientOptions::parse("mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external")
-                    .await
-                    .unwrap()
-                    .credential
-                    .unwrap()
-                    .password,
-                ODBCUri::new("URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;".to_string())
-                    .unwrap()
-                    .try_into_client_options()
-                    .await
-                    .unwrap()
-                    .client_options
-                    .credential
-                    .unwrap()
-                    .password
-            );
-        }
-
         #[tokio::test(flavor = "current_thread")]
         async fn missing_user_is_err() {
             use crate::odbc_uri::ODBCUri;

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1039,7 +1039,10 @@ mod unit {
 
     #[cfg(test)]
     mod try_into_client_options {
+        use crate::odbc_uri::{DATABASE, PWD, UID, URI};
         use mongodb::options::ClientOptions;
+        use num_traits::One;
+        use openidconnect::http::Uri;
 
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {
@@ -1062,6 +1065,18 @@ mod unit {
             use crate::odbc_uri::ODBCUri;
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
   Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509&tls=true&tlsCertificateKeyFile=/path/to/client.pem;DATABASE=mydb;LOGLEVEL=DEBUG;";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn gssapi_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
+  Driver};URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;DATABASE=mydb;LOGLEVEL=DEBUG;";
             assert!(ODBCUri::new(odbc_uri.to_string())
                 .unwrap()
                 .try_into_client_options()
@@ -1153,24 +1168,6 @@ mod unit {
                         .try_into_client_options().await
                         .unwrap_err()
                 )
-            );
-        }
-
-        #[tokio::test(flavor = "current_thread")]
-        async fn gssapi_client_options_do_not_include_password() {
-            use crate::odbc_uri::ODBCUri;
-            // Arrange: Sample URL where auth mechanism is GSSAPI, and specified in the url, but not in options
-            assert_eq!(
-                ODBCUri::new("URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;".to_string())
-                    .unwrap()
-                    .try_into_client_options()
-                    .await
-                    .unwrap()
-                    .client_options
-                    .credential
-                    .unwrap()
-                    .password,
-                        None
             );
         }
 

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1,5 +1,7 @@
 use crate::err::{Error, Result};
+use bson::Bson;
 use constants::{DEFAULT_APP_NAME, DRIVER_SHORT_NAME};
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use mongodb::{
     bson::UuidRepresentation,
@@ -13,6 +15,7 @@ use once_cell::sync::OnceCell;
 use regex::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
 use shared_sql_utils::Dsn;
 use std::collections::HashMap;
+use std::ptr::eq;
 use std::str::FromStr;
 
 const EMPTY_URI_ERROR: &str = "URI must not be empty";
@@ -414,24 +417,31 @@ impl ODBCUri {
     }
 
     fn check_client_opts_credentials(client_options: &ClientOptions) -> Result<()> {
-        // Kerberos (GSSAPI) Doesn't require user + pass as USER; PASS; if specified in the URI
-        // X509 should not require user or pass either
         let auth_mechanism = client_options
             .credential
             .as_ref()
             .unwrap()
             .mechanism
             .as_ref()
-            .unwrap();
+            .unwrap_or(&AuthMechanism::ScramSha256);
 
         // X509 and Kerberos (GSSAPI) do not require username and password as part of client options.
         // X509 does not specify username/pass in the URI because auth is done with a client cert
         // GSSAPI specifies username/pass in the uri, so it doesn't need to be specified in attributes.
-        if auth_mechanism == &AuthMechanism::MongoDbX509
-            || auth_mechanism == &AuthMechanism::Gssapi
+        if auth_mechanism == &AuthMechanism::MongoDbX509 || auth_mechanism == &AuthMechanism::Gssapi
         {
             return Ok(());
         }
+
+        let is_oidc_and_azure_environment = auth_mechanism == &AuthMechanism::MongoDbOidc
+            && client_options
+                .credential
+                .as_ref()
+                .unwrap()
+                .mechanism_properties
+                .as_ref()
+                .and_then(|props| props.get("ENVIRONMENT"))
+                .is_some_and(|v| v == &Bson::String("azure".to_string()));
 
         if client_options
             .credential
@@ -440,9 +450,12 @@ impl ODBCUri {
             .username
             .is_none()
         {
-            return Err(Error::InvalidUriFormat(format!(
-                "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri"
-            )));
+            // OIDC only requires username when Azure is the environment. For now do a nested if, but we can refactor later.
+            if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
+                return Err(Error::InvalidUriFormat(format!(
+                    "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri"
+                )));
+            }
         }
         if client_options
             .credential
@@ -451,9 +464,12 @@ impl ODBCUri {
             .password
             .is_none()
         {
-            return Err(Error::InvalidUriFormat(format!(
-                "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri"
-            )));
+            // All OIDC skips the password check (OIDC post-processing clears the password anyway).
+            if auth_mechanism != &AuthMechanism::MongoDbOidc {
+                return Err(Error::InvalidUriFormat(format!(
+                    "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri"
+                )));
+            }
         }
         Ok(())
     }
@@ -633,6 +649,7 @@ impl ODBCUri {
 }
 
 mod unit {
+    use mongodb::options::ClientOptions;
 
     mod test_username_password_detection {
         #[test]
@@ -647,18 +664,6 @@ mod unit {
             ));
             assert!(!ODBCUri::contains_username_and_or_password(
                 "mongodb://localhost:27017/abc?authMechanism=SCRAM-SHA-1"
-            ));
-        }
-
-        #[test]
-        fn test_gssapi_username_password_detection() {
-            use crate::odbc_uri::ODBCUri;
-            // GSSAPI URIs can have an '@' in the username, so we should not treat that as a separator for username and password
-            // GSSAPI has this format when specifying username + pass in the uri:
-            // mongodb://{user@domain}:{password}@host:port/?authMechanism=GSSAPI&authSource=$external
-            // We need to introduce a regex to account for that, otherwise we'll have to continue to specify username and pass in URL + attributes, which is not ideal.
-            assert!(!ODBCUri::contains_username_and_or_password(
-                "mongodb://alice@CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external"
             ));
         }
     }
@@ -1040,6 +1045,69 @@ mod unit {
         use mongodb::options::ClientOptions;
 
         #[tokio::test(flavor = "current_thread")]
+        async fn username_required_when_auth_mechanism_environment_is_azure() {
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;DATABASE=mydb;LOGLEVEL=DEBUG;";
+            assert_eq!(
+                "Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri",
+                format!(
+                    "{}",
+                    ODBCUri::new(odbc_uri.to_string())
+                        .unwrap()
+                        .try_into_client_options()
+                        .await
+                        .unwrap_err()
+                )
+            );
+        }
+        #[tokio::test(flavor = "current_thread")]
+        async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
+            use crate::odbc_uri::ODBCUri;
+            // TODO: Is there any way to run this test with a +srv url and ignore the DNS Resolution path?
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC
+  Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509&tls=true&tlsCertificateKeyFile=/path/to/client.pem;DATABASE=mydb;LOGLEVEL=DEBUG;";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn oidc_without_mechanism_properties_does_not_require_username() {
+            // Regression test for mechanism_properties.as_ref().unwrap() panic.
+            // OIDC without authMechanismProperties means no ENVIRONMENT key exists,
+            // so no username should be required. Previously this panicked.
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
+                DATABASE=mydb;";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn oidc_with_non_azure_environment_does_not_require_username() {
+            // Regression test for ptr::eq value-comparison bug.
+            // OIDC with ENVIRONMENT=gcp (or any non-azure value) must not require a username.
+            // Previously, std::ptr::eq compared pointer addresses rather than values,
+            // making the azure check always false and incorrectly rejecting valid connections.
+            use crate::odbc_uri::ODBCUri;
+            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+                URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
+                &authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:my_audience&tls=true;\
+                DATABASE=mydb;";
+            assert!(ODBCUri::new(odbc_uri.to_string())
+                .unwrap()
+                .try_into_client_options()
+                .await
+                .is_ok());
+        }
+
+        #[tokio::test(flavor = "current_thread")]
         async fn missing_server_is_err() {
             use crate::odbc_uri::ODBCUri;
             assert_eq!(
@@ -1070,16 +1138,10 @@ mod unit {
         }
 
         #[tokio::test(flavor = "current_thread")]
-        async fn gssapi_parses_password_from_uri() {
+        async fn gssapi_client_options_do_not_include_password() {
             use crate::odbc_uri::ODBCUri;
-            // Arrange: Sample URL where authmechanism is GSSAPI, and specified in the url, but not in options
+            // Arrange: Sample URL where auth mechanism is GSSAPI, and specified in the url, but not in options
             assert_eq!(
-                ClientOptions::parse("mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external")
-                    .await
-                    .unwrap()
-                    .credential
-                    .unwrap()
-                    .password,
                 ODBCUri::new("URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/?authMechanism=GSSAPI&authSource=$external;".to_string())
                     .unwrap()
                     .try_into_client_options()
@@ -1088,7 +1150,8 @@ mod unit {
                     .client_options
                     .credential
                     .unwrap()
-                    .password
+                    .password,
+                        None
             );
         }
 

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1100,7 +1100,7 @@ mod unit {
         async fn oidc_with_azure_environment_and_username_succeeds() {
             use crate::odbc_uri::ODBCUri;
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-         URI=mongodb://myuser@cluster.example.net/?authMechanism=MONGODB-OIDC\
+         URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
          &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
          DATABASE=mydb;UID=myUser";
             assert!(ODBCUri::new(odbc_uri.to_string())

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -443,7 +443,7 @@ impl ODBCUri {
 
             if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
                 log::warn!(
-                    "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri when using an Azure managed identity. Set this to the client ID of the managed identity or the application ID of the service principal."
+                     "No {USER_KWS:?} provided with an Azure managed identity. If you are encountering connection issue, you might need to set it to the client ID of the managed identity or the application ID of the service principal."
                 );
             }
         }
@@ -1065,6 +1065,7 @@ mod unit {
             };
         }
 
+        #[allow(unused_macros)]
         macro_rules! assert_parse_err {
             ($uri:expr) => {
                 let uri = $uri;

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -442,18 +442,15 @@ impl ODBCUri {
                     .is_some_and(|v| v == &Bson::String("azure".to_string()));
 
             if is_oidc_and_azure_environment || auth_mechanism != &AuthMechanism::MongoDbOidc {
-                return Err(Error::InvalidUriFormat(format!(
+                log::warn!(
                     "One of {USER_KWS:?} is required for a valid Mongo ODBC Uri when using an Azure managed identity. Set this to the client ID of the managed identity or the application ID of the service principal."
-                )));
+                );
             }
         }
         if client_credentials.password.is_none() {
-            // OIDC doesn't require password either.
-            if auth_mechanism != &AuthMechanism::MongoDbOidc {
-                return Err(Error::InvalidUriFormat(format!(
+            return Err(Error::InvalidUriFormat(format!(
                     "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri when the authication mechanism is {:?}", auth_mechanism
                 )));
-            }
         }
         Ok(())
     }

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -1055,6 +1055,26 @@ mod unit {
                 .await
         }
 
+        macro_rules! assert_parse_ok {
+            ($uri:expr) => {
+                let result = parse_uri($uri).await;
+                assert!(
+                    result.is_ok(),
+                    "Expected URI to parse successfully, got: {result:?}"
+                );
+            };
+        }
+
+        macro_rules! assert_parse_err {
+            ($uri:expr) => {
+                let uri = $uri;
+                assert!(
+                    parse_uri(uri).await.is_err(),
+                    "Expected URI parsing to fail: {uri}"
+                );
+            };
+        }
+
         #[tokio::test(flavor = "current_thread")]
         async fn username_required_when_auth_mechanism_environment_is_azure() {
             let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;DATABASE=mydb;LOGLEVEL=DEBUG;";
@@ -1072,27 +1092,21 @@ mod unit {
         }
         #[tokio::test(flavor = "current_thread")]
         async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-X509\
                  &tls=true&tlsCertificateKeyFile=/path/to/client.pem;\
-                 DATABASE=mydb;LOGLEVEL=DEBUG;";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;LOGLEVEL=DEBUG;"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn gssapi_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://alice%40CORP.EXAMPLE.COM:s3cr3t@mongo.corp.example.com/\
                  ?authMechanism=GSSAPI&authSource=$external;\
-                 DATABASE=mydb;LOGLEVEL=DEBUG;";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;LOGLEVEL=DEBUG;"
             );
         }
 
@@ -1100,64 +1114,50 @@ mod unit {
         async fn oidc_without_mechanism_properties_does_not_require_username() {
             // OIDC without authMechanismProperties means no ENVIRONMENT key exists,
             // so no username should be required.
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&tls=true;\
-                 DATABASE=mydb;";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_non_azure_environment_does_not_require_username() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_succeeds() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;UID=myUser";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;UID=myUser"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_username_in_uri_succeeds() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_ok!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;";
-            let result = parse_uri(uri).await;
-            assert!(
-                result.is_ok(),
-                "Expected URI to parse successfully, got: {result:?}"
+                 DATABASE=mydb;"
             );
         }
 
         #[tokio::test(flavor = "current_thread")]
         async fn oidc_with_azure_environment_and_without_username_fails() {
-            let uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};\
+            assert_parse_err!(
+                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;";
-            assert!(
-                parse_uri(uri).await.is_err(),
-                "Expected URI parsing to fail: {uri}"
+                 DATABASE=mydb;"
             );
         }
 

--- a/core/src/odbc_uri.rs
+++ b/core/src/odbc_uri.rs
@@ -448,9 +448,12 @@ impl ODBCUri {
             }
         }
         if client_credentials.password.is_none() {
-            return Err(Error::InvalidUriFormat(format!(
+            // OIDC doesn't require password either.
+            if auth_mechanism != &AuthMechanism::MongoDbOidc {
+                return Err(Error::InvalidUriFormat(format!(
                     "One of {PWD_KWS:?} is required for a valid Mongo ODBC Uri when the authication mechanism is {:?}", auth_mechanism
                 )));
+            }
         }
         Ok(())
     }
@@ -1073,21 +1076,6 @@ mod unit {
         }
 
         #[tokio::test(flavor = "current_thread")]
-        async fn username_required_when_auth_mechanism_environment_is_azure() {
-            let odbc_uri = "DRIVER={MongoDB Atlas SQL ODBC Driver};URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;DATABASE=mydb;LOGLEVEL=DEBUG;";
-            assert_eq!(
-                "Invalid Uri: One of [\"uid\", \"user\"] is required for a valid Mongo ODBC Uri when using an Azure managed identity. Set this to the client ID of the managed identity or the application ID of the service principal.",
-                format!(
-                    "{}",
-                    ODBCUri::new(odbc_uri.to_string())
-                        .unwrap()
-                        .try_into_client_options()
-                        .await
-                        .unwrap_err()
-                )
-            );
-        }
-        #[tokio::test(flavor = "current_thread")]
         async fn x509_auth_does_not_throw_when_uid_pwd_not_specified_in_odbc_uri() {
             assert_parse_ok!(
                 "DRIVER={MongoDB Atlas SQL ODBC Driver};\
@@ -1143,16 +1131,6 @@ mod unit {
             assert_parse_ok!(
                 "DRIVER={MongoDB Atlas SQL ODBC Driver};\
                  URI=mongodb://test_user@cluster.example.net/?authMechanism=MONGODB-OIDC\
-                 &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
-                 DATABASE=mydb;"
-            );
-        }
-
-        #[tokio::test(flavor = "current_thread")]
-        async fn oidc_with_azure_environment_and_without_username_fails() {
-            assert_parse_err!(
-                "DRIVER={MongoDB Atlas SQL ODBC Driver};\
-                 URI=mongodb://cluster.example.net/?authMechanism=MONGODB-OIDC\
                  &authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:my_audience&tls=true;\
                  DATABASE=mydb;"
             );


### PR DESCRIPTION
## Summary

A collection of small fixes to make the ODBC Driver more ergonomic. When we introduced the odbc-connectivity-tester during the troubleshooting epic, we found that we had to include username and password in the generated ODBC URL even when the auth mechanism did not require it.

**Fix 1:**  UID and PWD should not be required as part of the URL if the auth mechaism does not require it.
This is the case for OIDC and X509

```
DRIVER={MongoDB Atlas SQL ODBC Driver};URI=<clusterUrl>?tlsCertificateKeyFile=../../client.pem&tls=true&authSource=%24external&authMechanism=MONGODB-X509;DATABASE=test;UID=;PWD=;
```

And this for OIDC:
```
DRIVER={MongoDB Atlas SQL ODBC Driver};URI=<clusterUrl>/?directConnection=true&connectTimeoutMS=60000&tls=true&authMechanism=MONGODB-OIDC;DATABASE=airbnb;UID=jonathan.powell@mongodb.com;PWD=;
```

We've updated the code to ignore uid + pwd checks when these auth mechanisms are used because they validate this info externally.

**Fix 2:** Do not require username + password be included when using Kerberos

Kerberos Auth already requires user to specify username + password in the URL so we shouldn't require it to be included again.

## Testing

- Unit Tests in the ODBC Driver

**Connectivity Tester**
- [ ] Manual testing of OIDC to confirm UID + PWD are not required
- [ ] Manual testing of X509 to confirm UID + PWD are not required
- [ ] Manual testing of Kerberos to confirm UID + PWD are not required