### PR TITLE
SQL-3392: update mongosql dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "agg-ast"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#46ac64e35fc62b052caddfd6400c9e777326353a"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#27baefa1f1eb4ba3462114313245552bc880df87"
 dependencies = [
  "bson",
  "linked-hash-map",
@@ -1443,7 +1443,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1580,22 +1580,22 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "0.7.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "0.7.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1611,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2439,15 +2439,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2747,7 +2738,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 name = "macos_postinstall"
 version = "0.0.0"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "lazy_static",
  "rust-ini",
 ]
@@ -2884,7 +2875,7 @@ dependencies = [
  "definitions",
  "fancy-regex",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "mongodb",
@@ -3019,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "mongosql"
 version = "0.0.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#46ac64e35fc62b052caddfd6400c9e777326353a"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#27baefa1f1eb4ba3462114313245552bc880df87"
 dependencies = [
  "agg-ast",
  "base64 0.22.1",
@@ -3028,14 +3019,12 @@ dependencies = [
  "derive-new",
  "edit-distance",
  "enum-iterator",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
  "linked-hash-map",
  "mongosql-datastructures",
- "quickcheck",
- "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -3051,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "mongosql-datastructures"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#46ac64e35fc62b052caddfd6400c9e777326353a"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#27baefa1f1eb4ba3462114313245552bc880df87"
 dependencies = [
  "linked-hash-map",
  "thiserror 2.0.18",
@@ -3563,15 +3552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
-dependencies = [
- "rand 0.10.1",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,7 +3998,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4428,7 +4408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4463,7 +4443,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5039,7 +5019,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 [[package]]
 name = "usererrordisplay-impl"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#46ac64e35fc62b052caddfd6400c9e777326353a"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#27baefa1f1eb4ba3462114313245552bc880df87"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5083,7 +5063,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "visitgen"
 version = "0.1.0"
-source = "git+https://github.com/mongodb/mongosql.git?branch=main#46ac64e35fc62b052caddfd6400c9e777326353a"
+source = "git+https://github.com/mongodb/mongosql.git?branch=main#27baefa1f1eb4ba3462114313245552bc880df87"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -5317,7 +5297,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates the mongosql dependency to use the latest released version