### PR TITLE
SQL-3435: Remove macos buildvariant from evergreen config

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -2238,18 +2238,6 @@ buildvariants:
       - name: asan-unit-tests
       - name: sign
 
-  - name: macos-arm
-    display_name: "macOS arm64"
-    run_on: [macos-13-arm64]
-    modules:
-      - sql-engines-common-test-infra
-    tasks:
-      - name: compile
-      - name: unit-test
-      # SQL-1841: Investigate iodbc hanging with odbc 2 integration tests
-      # - name: integration-test
-      - name: result-set-test
-
   - name: release
     display_name: "Release"
     run_on: [ubuntu2204-medium]

--- a/odbc/src/api/data_tests.rs
+++ b/odbc/src/api/data_tests.rs
@@ -3365,7 +3365,7 @@ mod unit_tests {
         unsafe {
             assert_eq!(SqlReturn::ERROR, SQLFetch(stmt_handle as *mut _,));
             assert_eq!(
-                format!("[MongoDB][API] No ResultSet"),
+                "[MongoDB][API] No ResultSet".to_string(),
                 format!(
                     "{}",
                     (*stmt_handle)


### PR DESCRIPTION
This PR removes the `macos-13-arm54` buildvariant from the evergreen config since the macos 13 fleet has been decommissioned by DevProd and we have not had any requests to support Mac since EA went GA.

This PR also drive-by fixes the clippy failure on the waterfall since it cannot merge without that. I'll close #397 in favor of this since that PR is blocked by the macos-13-arm64 hosts not existing.