### PR TITLE
SQL-3474: DISALLOW Atlas Dedicated DB + Collection Name

### DIFF
--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -17,7 +17,7 @@ pub(crate) const TIMESERIES: &str = "timeseries";
 pub(crate) const VIEW: &str = "view";
 pub(crate) static DISALLOWED_DB_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     let mut set = HashSet::new();
-    set.insert("_mdb_internal_sqlinterface");
+    set.insert("__mdb_internal_sqlinterface");
     set.insert("admin");
     set.insert("config");
     set.insert("local");
@@ -29,7 +29,7 @@ pub(crate) static DISALLOWED_COLLECTION_NAMES: LazyLock<HashSet<&'static str>> =
     LazyLock::new(|| {
         let mut set = HashSet::new();
         set.insert("__sql_schemas");
-        set.insert("_sql_status");
+        set.insert("__sql_status");
         set.insert("");
         set
     });

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -17,6 +17,7 @@ pub(crate) const TIMESERIES: &str = "timeseries";
 pub(crate) const VIEW: &str = "view";
 pub(crate) static DISALLOWED_DB_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     let mut set = HashSet::new();
+    set.insert("_mdb_internal_sqlinterface");
     set.insert("admin");
     set.insert("config");
     set.insert("local");
@@ -28,6 +29,7 @@ pub(crate) static DISALLOWED_COLLECTION_NAMES: LazyLock<HashSet<&'static str>> =
     LazyLock::new(|| {
         let mut set = HashSet::new();
         set.insert("__sql_schemas");
+        set.insert("_sql_status");
         set.insert("");
         set
     });


### PR DESCRIPTION
## Summary

Updates our collection of DISALLOWED_DB_NAMES and DISALLOWED_COLLECTION_NAMES to include the Atlas Dedicated internal dbs.